### PR TITLE
Build + minimal CI harness.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,13 @@ glyphd
 *.so
 *.dll
 
+# Track the Go command sources even though the glyphd binary is ignored.
+!cmd/
+!cmd/glyphd/
+!cmd/glyphd/**
+!cmd/glyphctl/
+!cmd/glyphctl/**
+
 # Python artifacts
 __pycache__/
 *.pyc

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,22 @@ PYTHON_PLUGIN_RUNTIME_DIR := examples/glyph-passive-headers/glyph_plugin_runtime
 # Output directory for Go stubs.
 GO_STUBS_DIR := proto/gen/go
 
+# Development defaults for running the Go services.
+GLYPH_ADDR ?= :50051
+GLYPH_AUTH_TOKEN ?= dev-token
+
+.PHONY: test
+test:
+	go test ./...
+
+.PHONY: lint
+lint:
+	go vet ./...
+
+.PHONY: run
+run:
+	go run ./cmd/glyphd --addr $(GLYPH_ADDR) --token $(GLYPH_AUTH_TOKEN)
+
 # Default target.
 .PHONY: all
 all: proto

--- a/cmd/glyphctl/main.go
+++ b/cmd/glyphctl/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/example/glyph/internal/plugins"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("glyphctl", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	manifestPath := fs.String("manifest", "", "Path to a plugin manifest to validate")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if *manifestPath == "" {
+		fmt.Fprintln(stderr, "--manifest flag is required")
+		return 2
+	}
+
+	if err := plugins.ValidateManifest(*manifestPath); err != nil {
+		fmt.Fprintf(stderr, "invalid manifest: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "manifest %s is valid\n", *manifestPath)
+	return 0
+}

--- a/cmd/glyphctl/main_test.go
+++ b/cmd/glyphctl/main_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunInvalidManifestReturnsNonZero(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "manifest.json")
+	if err := os.WriteFile(manifestPath, []byte(`{"name":"demo","version":"1.0.0","entry":"/bin/demo"}`), 0o644); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	var stdout, stderr strings.Builder
+	code := run([]string{"--manifest", manifestPath}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit code, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "capability") {
+		t.Fatalf("expected error mentioning capabilities, got %q", stderr.String())
+	}
+}

--- a/cmd/glyphd/main.go
+++ b/cmd/glyphd/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/example/glyph/internal/bus"
+	pb "github.com/example/glyph/proto/gen/go/proto/glyph"
+	"google.golang.org/grpc"
+)
+
+type config struct {
+	addr  string
+	token string
+}
+
+func main() {
+	addr := flag.String("addr", ":50051", "address for the gRPC server to listen on")
+	token := flag.String("token", "", "authentication token required for plugins")
+	flag.Parse()
+
+	if *token == "" {
+		fmt.Fprintln(os.Stderr, "--token must be provided")
+		os.Exit(2)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx, config{addr: *addr, token: *token}); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, cfg config) error {
+	lis, err := net.Listen("tcp", cfg.addr)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", cfg.addr, err)
+	}
+	defer lis.Close()
+
+	return serve(ctx, lis, cfg.token)
+}
+
+func serve(ctx context.Context, lis net.Listener, token string) error {
+	if token == "" {
+		return errors.New("auth token must be provided")
+	}
+
+	srv := grpc.NewServer()
+	busServer := bus.NewServer(token)
+	pb.RegisterPluginBusServer(srv, busServer)
+
+	// Create a background context used by the event generator. It is cancelled
+	// once the gRPC server begins shutting down.
+	generatorCtx, cancelGenerator := context.WithCancel(context.Background())
+	defer cancelGenerator()
+	go busServer.StartEventGenerator(generatorCtx)
+
+	// Stop the gRPC server once the provided context is cancelled.
+	go func() {
+		<-ctx.Done()
+		cancelGenerator()
+
+		done := make(chan struct{})
+		go func() {
+			srv.GracefulStop()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			srv.Stop()
+		}
+	}()
+
+	if err := srv.Serve(lis); err != nil {
+		if errors.Is(err, grpc.ErrServerStopped) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/cmd/glyphd/main_test.go
+++ b/cmd/glyphd/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func TestServeBootsAndShutsDown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- serve(ctx, lis, "test-token")
+	}()
+
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer dialCancel()
+	conn, err := grpc.DialContext(dialCtx, lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	if err != nil {
+		t.Fatalf("failed to dial server: %v", err)
+	}
+	conn.Close()
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("serve returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not shut down after context cancellation")
+	}
+}

--- a/internal/plugins/manifest.go
+++ b/internal/plugins/manifest.go
@@ -1,0 +1,81 @@
+package plugins
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+var allowedCapabilities = []string{
+	"CAP_EMIT_FINDINGS",
+	"CAP_HTTP_ACTIVE",
+	"CAP_HTTP_PASSIVE",
+	"CAP_WS",
+	"CAP_SPIDER",
+	"CAP_REPORT",
+	"CAP_STORAGE",
+}
+
+// Manifest represents the expected contents of a plugin manifest.
+type Manifest struct {
+	Name         string                 `json:"name"`
+	Version      string                 `json:"version"`
+	Entry        string                 `json:"entry"`
+	Capabilities []string               `json:"capabilities"`
+	Config       map[string]interface{} `json:"config,omitempty"`
+}
+
+// LoadManifest reads a manifest from disk and validates its contents.
+func LoadManifest(path string) (*Manifest, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest: %w", err)
+	}
+
+	var manifest Manifest
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&manifest); err != nil {
+		return nil, fmt.Errorf("decode manifest: %w", err)
+	}
+
+	if manifest.Name == "" {
+		return nil, fmt.Errorf("manifest is missing name")
+	}
+	if manifest.Version == "" {
+		return nil, fmt.Errorf("manifest is missing version")
+	}
+	if manifest.Entry == "" {
+		return nil, fmt.Errorf("manifest is missing entry")
+	}
+	if len(manifest.Capabilities) == 0 {
+		return nil, fmt.Errorf("manifest must declare at least one capability")
+	}
+
+	allowed := make(map[string]struct{}, len(allowedCapabilities))
+	for _, c := range allowedCapabilities {
+		allowed[c] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(manifest.Capabilities))
+	for _, capability := range manifest.Capabilities {
+		if capability == "" {
+			return nil, fmt.Errorf("manifest cannot contain empty capability values")
+		}
+		if _, ok := allowed[capability]; !ok {
+			return nil, fmt.Errorf("manifest contains unknown capability %q", capability)
+		}
+		if _, ok := seen[capability]; ok {
+			return nil, fmt.Errorf("manifest contains duplicate capability %q", capability)
+		}
+		seen[capability] = struct{}{}
+	}
+
+	return &manifest, nil
+}
+
+// ValidateManifest ensures the manifest at the provided path is well-formed.
+func ValidateManifest(path string) error {
+	_, err := LoadManifest(path)
+	return err
+}

--- a/internal/plugins/manifest_test.go
+++ b/internal/plugins/manifest_test.go
@@ -1,0 +1,19 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadManifestRequiresCapabilities(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "manifest.json")
+	if err := os.WriteFile(manifestPath, []byte(`{"name":"demo","version":"1.0.0","entry":"/bin/demo"}`), 0o644); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	if _, err := LoadManifest(manifestPath); err == nil {
+		t.Fatalf("expected error when capabilities are missing")
+	}
+}


### PR DESCRIPTION
## Summary
- add Go targets to the Makefile so CI can run linting, testing, and the server entrypoint
- implement a glyphd command that starts the gRPC bus server and a smoke test that ensures it boots and shuts down cleanly
- add a plugin manifest loader, expose a glyphctl validation CLI, and cover invalid manifests with unit tests

## Testing
- make test
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68c940e730c8832a8b5a1e522248e59d