### PR TITLE
chore/module-path-and-ci-hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,46 @@ name: CI
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ main ]
 jobs:
-  test:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.x'
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Cache Go
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+      - name: Build
+        run: go build ./...
+      - name: Test
+        run: go test ./... -v
+
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
-        with: { go-version: '1.22' }
-      - uses: actions/setup-node@v4
-        with: { node-version: '20' }
-      - run: make test  # let Codex add missing tests; failing tests block merge
+        with:
+          go-version: '1.22.x'
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.61
+      - name: Lint
+        run: golangci-lint run ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+run:
+  timeout: 5m
+linters:
+  enable:
+    - govet
+    - staticcheck
+    - gofmt
+    - goimports
+    - ineffassign
+    - gosimple
+    - misspell
+    - errcheck
+issues:
+  exclude-use-default: false

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ proto-go:
 	@go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 	@mkdir -p $(GO_STUBS_DIR)
 	@protoc -I proto \
-	  --go_out=$(GO_STUBS_DIR) --go_opt=module=github.com/example/glyph \
-	  --go-grpc_out=$(GO_STUBS_DIR) --go-grpc_opt=module=github.com/example/glyph \
+       --go_out=$(GO_STUBS_DIR) --go_opt=module=github.com/RowanDark/Glyph \
+       --go-grpc_out=$(GO_STUBS_DIR) --go-grpc_opt=module=github.com/RowanDark/Glyph \
 	  $(PROTO_FILES)
 	@echo "Go stubs generated in $(GO_STUBS_DIR)"
 

--- a/cmd/glyphctl/main.go
+++ b/cmd/glyphctl/main.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/example/glyph/internal/plugins"
+	"github.com/RowanDark/Glyph/internal/plugins"
 )
 
 func main() {

--- a/cmd/glyphd/main.go
+++ b/cmd/glyphd/main.go
@@ -11,8 +11,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/example/glyph/internal/bus"
-	pb "github.com/example/glyph/proto/gen/go/proto/glyph"
+	"github.com/RowanDark/Glyph/internal/bus"
+	pb "github.com/RowanDark/Glyph/proto/gen/go/proto/glyph"
 	"google.golang.org/grpc"
 )
 

--- a/examples/glyph-passive-headers/glyph_plugin_runtime/glyph/common_pb2.py
+++ b/examples/glyph-passive-headers/glyph_plugin_runtime/glyph/common_pb2.py
@@ -24,14 +24,14 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12glyph/common.proto\x12\x0cglyph.common\"\xba\x01\n\x07\x46inding\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x0f\n\x07message\x18\x02 \x01(\t\x12(\n\x08severity\x18\x03 \x01(\x0e\x32\x16.glyph.common.Severity\x12\x35\n\x08metadata\x18\x04 \x03(\x0b\x32#.glyph.common.Finding.MetadataEntry\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x8e\x01\n\tFlowEvent\x12*\n\x04type\x18\x01 \x01(\x0e\x32\x1c.glyph.common.FlowEvent.Type\x12\x0c\n\x04\x64\x61ta\x18\x02 \x01(\x0c\"G\n\x04Type\x12\x1a\n\x16\x46LOW_EVENT_UNSPECIFIED\x10\x00\x12\x10\n\x0c\x46LOW_REQUEST\x10\x01\x12\x11\n\rFLOW_RESPONSE\x10\x02*[\n\x08Severity\x12\x18\n\x14SEVERITY_UNSPECIFIED\x10\x00\x12\x08\n\x04INFO\x10\x01\x12\x07\n\x03LOW\x10\x02\x12\n\n\x06MEDIUM\x10\x03\x12\x08\n\x04HIGH\x10\x04\x12\x0c\n\x08\x43RITICAL\x10\x05\x42,Z*github.com/example/glyph/proto/glyph;glyphb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12glyph/common.proto\x12\x0cglyph.common\"\xba\x01\n\x07\x46inding\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x0f\n\x07message\x18\x02 \x01(\t\x12(\n\x08severity\x18\x03 \x01(\x0e\x32\x16.glyph.common.Severity\x12\x35\n\x08metadata\x18\x04 \x03(\x0b\x32#.glyph.common.Finding.MetadataEntry\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x8e\x01\n\tFlowEvent\x12*\n\x04type\x18\x01 \x01(\x0e\x32\x1c.glyph.common.FlowEvent.Type\x12\x0c\n\x04\x64\x61ta\x18\x02 \x01(\x0c\"G\n\x04Type\x12\x1a\n\x16\x46LOW_EVENT_UNSPECIFIED\x10\x00\x12\x10\n\x0c\x46LOW_REQUEST\x10\x01\x12\x11\n\rFLOW_RESPONSE\x10\x02*[\n\x08Severity\x12\x18\n\x14SEVERITY_UNSPECIFIED\x10\x00\x12\x08\n\x04INFO\x10\x01\x12\x07\n\x03LOW\x10\x02\x12\n\n\x06MEDIUM\x10\x03\x12\x08\n\x04HIGH\x10\x04\x12\x0c\n\x08\x43RITICAL\x10\x05\x42.Z,github.com/RowanDark/Glyph/proto/glyph;glyphb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'glyph.common_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
-  _globals['DESCRIPTOR']._serialized_options = b'Z*github.com/example/glyph/proto/glyph;glyph'
+  _globals['DESCRIPTOR']._serialized_options = b'Z,github.com/RowanDark/Glyph/proto/glyph;glyph'
   _globals['_FINDING_METADATAENTRY']._loaded_options = None
   _globals['_FINDING_METADATAENTRY']._serialized_options = b'8\001'
   _globals['_SEVERITY']._serialized_start=370

--- a/examples/glyph-passive-headers/glyph_plugin_runtime/glyph/plugin_bus_pb2.py
+++ b/examples/glyph-passive-headers/glyph_plugin_runtime/glyph/plugin_bus_pb2.py
@@ -25,14 +25,14 @@ _sym_db = _symbol_database.Default()
 from . import common_pb2 as glyph_dot_common__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16glyph/plugin_bus.proto\x12\x10glyph.plugin_bus\x1a\x12glyph/common.proto\"p\n\x0bPluginEvent\x12.\n\x05hello\x18\x01 \x01(\x0b\x32\x1d.glyph.plugin_bus.PluginHelloH\x00\x12(\n\x07\x66inding\x18\x02 \x01(\x0b\x32\x15.glyph.common.FindingH\x00\x42\x07\n\x05\x65vent\"p\n\x0bPluginHello\x12\x12\n\nauth_token\x18\x01 \x01(\t\x12\x13\n\x0bplugin_name\x18\x02 \x01(\t\x12\x0b\n\x03pid\x18\x03 \x01(\x05\x12\x15\n\rsubscriptions\x18\x04 \x03(\t\x12\x14\n\x0c\x63\x61pabilities\x18\x05 \x03(\t\"Y\n\tHostEvent\x12\x14\n\x0c\x63ore_version\x18\x01 \x01(\t\x12-\n\nflow_event\x18\x02 \x01(\x0b\x32\x17.glyph.common.FlowEventH\x00\x42\x07\n\x05\x65vent2Z\n\tPluginBus\x12M\n\x0b\x45ventStream\x12\x1d.glyph.plugin_bus.PluginEvent\x1a\x1b.glyph.plugin_bus.HostEvent(\x01\x30\x01\x42,Z*github.com/example/glyph/proto/glyph;glyphb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16glyph/plugin_bus.proto\x12\x10glyph.plugin_bus\x1a\x12glyph/common.proto\"p\n\x0bPluginEvent\x12.\n\x05hello\x18\x01 \x01(\x0b\x32\x1d.glyph.plugin_bus.PluginHelloH\x00\x12(\n\x07\x66inding\x18\x02 \x01(\x0b\x32\x15.glyph.common.FindingH\x00\x42\x07\n\x05\x65vent\"p\n\x0bPluginHello\x12\x12\n\nauth_token\x18\x01 \x01(\t\x12\x13\n\x0bplugin_name\x18\x02 \x01(\t\x12\x0b\n\x03pid\x18\x03 \x01(\x05\x12\x15\n\rsubscriptions\x18\x04 \x03(\t\x12\x14\n\x0c\x63\x61pabilities\x18\x05 \x03(\t\"Y\n\tHostEvent\x12\x14\n\x0c\x63ore_version\x18\x01 \x01(\t\x12-\n\nflow_event\x18\x02 \x01(\x0b\x32\x17.glyph.common.FlowEventH\x00\x42\x07\n\x05\x65vent2Z\n\tPluginBus\x12M\n\x0b\x45ventStream\x12\x1d.glyph.plugin_bus.PluginEvent\x1a\x1b.glyph.plugin_bus.HostEvent(\x01\x30\x01\x42.Z,github.com/RowanDark/Glyph/proto/glyph;glyphb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'glyph.plugin_bus_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
-  _globals['DESCRIPTOR']._serialized_options = b'Z*github.com/example/glyph/proto/glyph;glyph'
+  _globals['DESCRIPTOR']._serialized_options = b'Z,github.com/RowanDark/Glyph/proto/glyph;glyph'
   _globals['_PLUGINEVENT']._serialized_start=64
   _globals['_PLUGINEVENT']._serialized_end=176
   _globals['_PLUGINHELLO']._serialized_start=178

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/example/glyph
+module github.com/RowanDark/Glyph
 
 go 1.24.3
 

--- a/internal/bus/server.go
+++ b/internal/bus/server.go
@@ -9,14 +9,14 @@ import (
 	"sync"
 	"time"
 
-	pb "github.com/example/glyph/proto/gen/go/proto/glyph"
+	pb "github.com/RowanDark/Glyph/proto/gen/go/proto/glyph"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 const (
-	coreVersion         = "v0.1.0"
-	CapEmitFindings     = "CAP_EMIT_FINDINGS"
+	coreVersion     = "v0.1.0"
+	CapEmitFindings = "CAP_EMIT_FINDINGS"
 )
 
 // plugin holds the information about a connected plugin.

--- a/internal/bus/server_test.go
+++ b/internal/bus/server_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	pb "github.com/example/glyph/proto/gen/go/proto/glyph"
+	pb "github.com/RowanDark/Glyph/proto/gen/go/proto/glyph"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -54,9 +54,9 @@ func TestEventStream_ValidAuth(t *testing.T) {
 		mockStream.RecvChan <- &pb.PluginEvent{
 			Event: &pb.PluginEvent_Hello{
 				Hello: &pb.PluginHello{
-					AuthToken:   "test-token",
-					PluginName:  "test-plugin",
-					Pid:         123,
+					AuthToken:     "test-token",
+					PluginName:    "test-plugin",
+					Pid:           123,
 					Subscriptions: []string{"FLOW_RESPONSE"},
 				},
 			},
@@ -93,9 +93,9 @@ func TestEventStream_InvalidAuth(t *testing.T) {
 		mockStream.RecvChan <- &pb.PluginEvent{
 			Event: &pb.PluginEvent_Hello{
 				Hello: &pb.PluginHello{
-					AuthToken:   "wrong-token",
-					PluginName:  "test-plugin",
-					Pid:         123,
+					AuthToken:  "wrong-token",
+					PluginName: "test-plugin",
+					Pid:        123,
 				},
 			},
 		}

--- a/proto/gen/go/proto/glyph/common.pb.go
+++ b/proto/gen/go/proto/glyph/common.pb.go
@@ -283,7 +283,7 @@ const file_glyph_common_proto_rawDesc = "" +
 	"\n" +
 	"\x06MEDIUM\x10\x03\x12\b\n" +
 	"\x04HIGH\x10\x04\x12\f\n" +
-	"\bCRITICAL\x10\x05B,Z*github.com/example/glyph/proto/glyph;glyphb\x06proto3"
+	"\bCRITICAL\x10\x05B.Z,github.com/RowanDark/Glyph/proto/glyph;glyphb\x06proto3"
 
 var (
 	file_glyph_common_proto_rawDescOnce sync.Once

--- a/proto/gen/go/proto/glyph/plugin_bus.pb.go
+++ b/proto/gen/go/proto/glyph/plugin_bus.pb.go
@@ -292,7 +292,7 @@ const file_glyph_plugin_bus_proto_rawDesc = "" +
 	"flow_event\x18\x02 \x01(\v2\x17.glyph.common.FlowEventH\x00R\tflowEventB\a\n" +
 	"\x05event2Z\n" +
 	"\tPluginBus\x12M\n" +
-	"\vEventStream\x12\x1d.glyph.plugin_bus.PluginEvent\x1a\x1b.glyph.plugin_bus.HostEvent(\x010\x01B,Z*github.com/example/glyph/proto/glyph;glyphb\x06proto3"
+	"\vEventStream\x12\x1d.glyph.plugin_bus.PluginEvent\x1a\x1b.glyph.plugin_bus.HostEvent(\x010\x01B.Z,github.com/RowanDark/Glyph/proto/glyph;glyphb\x06proto3"
 
 var (
 	file_glyph_plugin_bus_proto_rawDescOnce sync.Once

--- a/proto/glyph/common.proto
+++ b/proto/glyph/common.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package glyph.common;
 
-option go_package = "github.com/example/glyph/proto/glyph;glyph";
+option go_package = "github.com/RowanDark/Glyph/proto/glyph;glyph";
 
 // A Finding is a report from a plugin about something it has observed.
 message Finding {

--- a/proto/glyph/plugin_bus.proto
+++ b/proto/glyph/plugin_bus.proto
@@ -4,7 +4,7 @@ package glyph.plugin_bus;
 
 import "glyph/common.proto";
 
-option go_package = "github.com/example/glyph/proto/glyph;glyph";
+option go_package = "github.com/RowanDark/Glyph/proto/glyph;glyph";
 
 // The PluginBus service provides a bi-directional stream for plugins to
 // receive events from the host and send findings back.


### PR DESCRIPTION
## What changed?
- update the Go module path and generated artifacts to github.com/RowanDark/Glyph.
- add CI jobs for go build/test and golangci-lint with shared configuration.

## Security impact (auth, crypto, injection, secrets)
- None; tooling-only changes.

## Tests added/updated
- go test ./...

## Rollback plan
- Revert this PR.


------
https://chatgpt.com/codex/tasks/task_e_68c94702e7cc832a84a7ed7132d6a1e6