### PR TITLE
Implement Excavator canonical crawl output and Scribe report fixtures

### DIFF
--- a/internal/reporter/md.go
+++ b/internal/reporter/md.go
@@ -16,7 +16,8 @@ const (
 	findingsFilename = "findings.jsonl"
 	reportFilename   = "report.md"
 	// DefaultTopTargets controls how many targets appear in summary tables.
-	DefaultTopTargets = 5
+	DefaultTopTargets     = 10
+	defaultRecentFindings = 10
 )
 
 var (
@@ -144,7 +145,8 @@ func RenderMarkdown(list []findings.Finding, topN int) string {
 		b.WriteString("\n")
 	}
 
-	b.WriteString("## Last 10 Findings\n\n")
+	recentCap := defaultRecentFindings
+	fmt.Fprintf(&b, "## Last %d Findings\n\n", recentCap)
 	if len(list) == 0 {
 		b.WriteString("No findings recorded.\n")
 		return b.String()
@@ -160,8 +162,8 @@ func RenderMarkdown(list []findings.Finding, topN int) string {
 		}
 		return ti.After(tj)
 	})
-	if len(recent) > 10 {
-		recent = recent[:10]
+	if len(recent) > recentCap {
+		recent = recent[:recentCap]
 	}
 
 	b.WriteString("| Detected At | Severity | Plugin | Target | Message |\n")

--- a/plugins/excavator/README.md
+++ b/plugins/excavator/README.md
@@ -13,20 +13,24 @@ Excavator is the Playwright-powered crawler foundation for Glyph. It provides a 
    npm --prefix plugins/excavator install
    npm --prefix plugins/excavator run install-playwright-browsers
    ```
-2. Run the sample crawl (TARGET_URL may be an environment variable or CLI argument):
+2. Run the sample crawl (all configuration values may be provided via environment variables or CLI flags):
    ```bash
-   TARGET_URL=https://example.com npm --prefix plugins/excavator run crawl
+   TARGET_URL=https://example.com DEPTH=1 npm --prefix plugins/excavator run crawl
    # or
-   npm --prefix plugins/excavator run crawl -- https://example.com
+   npm --prefix plugins/excavator run crawl -- --target=https://example.com --depth=1
    ```
 
 ### Runtime configuration
 
 Excavator keeps crawls predictable and safe:
 
-- `EXCAVATOR_MAX_DEPTH` (default `1`) — maximum link depth to follow from the seed URL.
-- `EXCAVATOR_MAX_PAGES` (default `25`) — hard cap on visited pages.
-- `EXCAVATOR_ALLOWED_HOSTS` — comma-separated list of additional hostnames permitted during the crawl. The seed host is always included.
-- `EXCAVATOR_TIMEOUT_MS` — optional navigation timeout override (defaults to 45s).
+- `TARGET_URL` / `--target` — seed URL to crawl (defaults to `https://example.com`).
+- `DEPTH` / `--depth` (default `1`) — maximum link depth to follow from the seed URL.
+- `MAX_PAGES` / `--max-pages` (default `25`) — hard cap on visited pages.
+- `HOST_LIMIT` / `--host-limit` — optional maximum number of hostnames (including the seed host) that the crawler may visit.
+- `ALLOWED_HOSTS` / repeated `--allowed-host` / `--allowed-hosts` — additional hostnames permitted during the crawl. The seed host is always included.
+- `TIMEOUT` / `--timeout` (milliseconds, default `45000`) — navigation timeout override.
 
-All URLs are normalised, deduplicated, and constrained to the allowed host list. Each run emits a stable JSON object containing metadata, discovered links, and script excerpts (see `sample_output.json`). Golden coverage for the crawler lives in `tests/crawl.test.js`.
+The previous `EXCAVATOR_*` variables remain supported for backwards compatibility.
+
+All URLs are normalised, deduplicated, and constrained to the allowed host list. Each run emits a stable JSON object containing the seed `target`, unique `links`, discovered `scripts`, and crawl `meta` (see `sample_output.json`). Golden coverage for the crawler lives in `tests/crawl.test.js`.

--- a/plugins/excavator/sample_output.json
+++ b/plugins/excavator/sample_output.json
@@ -1,30 +1,19 @@
 {
-  "seed": "https://example.com/",
-  "started_at": "2024-01-01T00:00:00Z",
-  "finished_at": "2024-01-01T00:00:10Z",
-  "config": {
-    "max_depth": 1,
-    "max_pages": 25,
+  "target": "https://example.com/",
+  "links": [
+    "https://example.com/",
+    "https://www.iana.org/domains/example"
+  ],
+  "scripts": [],
+  "meta": {
+    "crawled_at": "2024-01-01T00:00:10Z",
+    "depth": 1,
+    "pages_visited": 1,
+    "host_limit": 1,
     "allowed_hosts": [
       "example.com"
-    ]
-  },
-  "stats": {
-    "pages_visited": 1,
-    "links_discovered": 1
-  },
-  "pages": [
-    {
-      "url": "https://example.com/",
-      "resolved_url": "https://example.com/",
-      "depth": 0,
-      "status": 200,
-      "title": "Example Domain",
-      "error": null,
-      "links": [
-        "https://www.iana.org/domains/example"
-      ],
-      "scripts": []
-    }
-  ]
+    ],
+    "started_at": "2024-01-01T00:00:00Z",
+    "max_pages": 25
+  }
 }

--- a/plugins/excavator/tests/crawl.golden.json
+++ b/plugins/excavator/tests/crawl.golden.json
@@ -1,66 +1,31 @@
 {
-  "seed": "https://example.com/",
-  "started_at": "2024-01-01T00:00:00.000Z",
-  "finished_at": "2024-01-01T00:00:05.000Z",
-  "config": {
-    "max_depth": 1,
-    "max_pages": 5,
+  "target": "https://example.com/",
+  "links": [
+    "https://example.com/",
+    "https://example.com/about",
+    "https://example.com/contact?a=1&b=2",
+    "https://example.com/team"
+  ],
+  "scripts": [
+    {
+      "src": null,
+      "snippet": "console.log(\"hi\");"
+    },
+    {
+      "src": "https://example.com/static/app.js",
+      "snippet": ""
+    }
+  ],
+  "meta": {
+    "crawled_at": "2024-01-01T00:00:05.000Z",
+    "depth": 1,
+    "pages_visited": 3,
+    "host_limit": null,
     "allowed_hosts": [
       "cdn.example.com",
       "example.com"
-    ]
-  },
-  "stats": {
-    "pages_visited": 3,
-    "links_discovered": 4
-  },
-  "pages": [
-    {
-      "url": "https://example.com/",
-      "resolved_url": "https://example.com/",
-      "depth": 0,
-      "status": 200,
-      "title": "Example Home",
-      "error": null,
-      "links": [
-        "https://example.com/",
-        "https://example.com/about",
-        "https://example.com/contact?a=1&b=2"
-      ],
-      "scripts": [
-        {
-          "src": null,
-          "content_excerpt": "console.log(\"hi\");",
-          "size_bytes": 18
-        },
-        {
-          "src": "https://example.com/static/app.js",
-          "content_excerpt": null,
-          "size_bytes": null
-        }
-      ]
-    },
-    {
-      "url": "https://example.com/about",
-      "resolved_url": "https://example.com/about",
-      "depth": 1,
-      "status": 200,
-      "title": "About",
-      "error": null,
-      "links": [
-        "https://example.com/team"
-      ],
-      "scripts": []
-    },
-    {
-      "url": "https://example.com/contact?a=1&b=2",
-      "resolved_url": "https://example.com/contact?a=1&b=2",
-      "depth": 1,
-      "status": 200,
-      "title": "Contact",
-      "error": null,
-      "links": [],
-      "scripts": []
-    }
-  ]
+    ],
+    "started_at": "2024-01-01T00:00:00.000Z",
+    "max_pages": 5
+  }
 }

--- a/plugins/samples/findings.jsonl
+++ b/plugins/samples/findings.jsonl
@@ -1,0 +1,12 @@
+{"id":"01HZXK4QAZ3ZKAB1Y7P5Z9Q4C4","plugin":"seer","type":"secret","message":"Exposed AWS access key","target":"https://a.example/app","severity":"high","detected_at":"2024-01-01T11:00:00Z"}
+{"id":"01HZXK4QAZ3ZKAB1Y7P5Z9Q4C5","plugin":"grapher","type":"misconfig","message":"Verbose directory listing enabled","target":"https://b.example/login","severity":"med","detected_at":"2024-01-01T10:30:00Z"}
+{"id":"01HZXK4QAZ3ZKAB1Y7P5Z9Q4C6","plugin":"raider","type":"vuln","message":"Remote code execution via template injection","target":"https://a.example/app","severity":"crit","detected_at":"2024-01-01T10:00:00Z"}
+{"id":"01HZXK4QAZ3ZKAB1Y7P5Z9Q4C7","plugin":"seer","type":"misconfig","message":"Missing security headers","target":"https://c.example/docs","severity":"low","detected_at":"2024-01-01T09:00:00Z"}
+{"id":"01HZXK4QAZ3ZKAB1Y7P5Z9Q4C8","plugin":"seer","type":"info","message":"Stack trace revealed version","target":"https://b.example/login","severity":"info","detected_at":"2024-01-01T08:30:00Z"}
+{"id":"01HZXK4QAZ3ZKAB1Y7P5Z9Q4C9","plugin":"seer","type":"secret","message":"Slack token exposed in page","target":"https://a.example/app","severity":"high","detected_at":"2024-01-01T08:00:00Z"}
+{"id":"01HZXK4QAZ3ZKAB1Y7P5Z9Q4CA","plugin":"seer","type":"bug","message":"Verbose error responses include stack traces","target":"https://b.example/api","severity":"med","detected_at":"2024-01-01T07:45:00Z"}
+{"id":"01HZXK4QAZ3ZKAB1Y7P5Z9Q4CB","plugin":"ranker","type":"observation","message":"Cookie missing SameSite flag","target":"https://a.example/app","severity":"low","detected_at":"2024-01-01T07:30:00Z"}
+{"id":"01HZXK4QAZ3ZKAB1Y7P5Z9Q4CC","plugin":"raider","type":"vuln","message":"Default credentials accepted","target":"https://d.example/admin","severity":"crit","detected_at":"2024-01-01T07:00:00Z"}
+{"id":"01HZXK4QAZ3ZKAB1Y7P5Z9Q4CD","plugin":"seer","type":"bug","message":"Outdated JavaScript library","target":"https://c.example/docs","severity":"med","detected_at":"2024-01-01T06:30:00Z"}
+{"id":"01HZXK4QAZ3ZKAB1Y7P5Z9Q4CE","plugin":"seer","type":"info","message":"Service banner exposes environment","target":"https://d.example/admin","severity":"info","detected_at":"2024-01-01T06:00:00Z"}
+{"id":"01HZXK4QAZ3ZKAB1Y7P5Z9Q4CF","plugin":"seer","type":"secret","message":"S3 bucket readable without auth","target":"https://e.example","severity":"high","detected_at":"2024-01-01T05:30:00Z"}

--- a/plugins/samples/report.golden.md
+++ b/plugins/samples/report.golden.md
@@ -1,0 +1,40 @@
+# Findings Report
+
+Total findings: 12
+
+## Severity Breakdown
+
+| Severity | Count |
+| --- | ---: |
+| Critical | 2 |
+| High | 3 |
+| Medium | 3 |
+| Low | 2 |
+| Informational | 2 |
+
+## Top Targets
+
+Showing top 6 targets by finding volume.
+
+1. **https://a.example/app** — 4 findings
+2. **https://b.example/login** — 2 findings
+3. **https://c.example/docs** — 2 findings
+4. **https://d.example/admin** — 2 findings
+5. **https://b.example/api** — 1 findings
+6. **https://e.example** — 1 findings
+
+## Last 10 Findings
+
+| Detected At | Severity | Plugin | Target | Message |
+| --- | --- | --- | --- | --- |
+| 2024-01-01T11:00:00Z | High | seer | https://a.example/app | Exposed AWS access key |
+| 2024-01-01T10:30:00Z | Medium | grapher | https://b.example/login | Verbose directory listing enabled |
+| 2024-01-01T10:00:00Z | Critical | raider | https://a.example/app | Remote code execution via template injection |
+| 2024-01-01T09:00:00Z | Low | seer | https://c.example/docs | Missing security headers |
+| 2024-01-01T08:30:00Z | Informational | seer | https://b.example/login | Stack trace revealed version |
+| 2024-01-01T08:00:00Z | High | seer | https://a.example/app | Slack token exposed in page |
+| 2024-01-01T07:45:00Z | Medium | seer | https://b.example/api | Verbose error responses include stack traces |
+| 2024-01-01T07:30:00Z | Low | ranker | https://a.example/app | Cookie missing SameSite flag |
+| 2024-01-01T07:00:00Z | Critical | raider | https://d.example/admin | Default credentials accepted |
+| 2024-01-01T06:30:00Z | Medium | seer | https://c.example/docs | Outdated JavaScript library |
+

--- a/plugins/scribe/README.md
+++ b/plugins/scribe/README.md
@@ -6,4 +6,14 @@ Scribe renders investigation output into human-friendly reports, summarizing fin
 - `CAP_REPORT`
 
 ## Getting started
-Scribe will eventually interface with `glyphctl report` to transform `out/findings.jsonl` into Markdown deliverables. Populate `plugin.js` with rendering logic and expand `tests/sample_fixture.json` with representative findings documents to validate formatting.
+
+`glyphctl report` converts persisted findings into a Markdown summary that includes severity totals, the busiest targets, and the latest findings table.
+
+1. Generate or copy a JSONL file of findings. A representative fixture lives at `plugins/samples/findings.jsonl`.
+2. Render the report:
+   ```bash
+   go run ./cmd/glyphctl -- report --input ./plugins/samples/findings.jsonl --out ./out/report.md
+   ```
+3. Compare the output with `plugins/samples/report.golden.md` or wire it into downstream automation.
+
+The `internal/reporter` package powers the CLI and exposes helpers for other components that need Markdown summaries.


### PR DESCRIPTION
## Summary
- harden the Excavator crawl script to honour depth, host, and timeout options from env/CLI and emit canonical target/links/scripts/meta JSON
- refresh crawler docs, sample output, and golden coverage to match the new schema and dedupe behaviour
- add Scribe sample findings/report assets, update the Markdown renderer defaults, and document the glyphctl report workflow

## Testing
- npm --prefix plugins/excavator test
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cdab995008832a8bc847c80ae09f67