### PR TITLE
Implement deterministic excavator crawl

### DIFF
--- a/plugins/excavator/README.md
+++ b/plugins/excavator/README.md
@@ -25,12 +25,10 @@ Excavator is the Playwright-powered crawler foundation for Glyph. It provides a 
 Excavator keeps crawls predictable and safe:
 
 - `TARGET_URL` / `--target` — seed URL to crawl (defaults to `https://example.com`).
-- `DEPTH` / `--depth` (default `1`) — maximum link depth to follow from the seed URL.
-- `MAX_PAGES` / `--max-pages` (default `25`) — hard cap on visited pages.
-- `HOST_LIMIT` / `--host-limit` — optional maximum number of hostnames (including the seed host) that the crawler may visit.
-- `ALLOWED_HOSTS` / repeated `--allowed-host` / `--allowed-hosts` — additional hostnames permitted during the crawl. The seed host is always included.
-- `TIMEOUT` / `--timeout` (milliseconds, default `45000`) — navigation timeout override.
+- `DEPTH` / `--depth` (default `1`) — maximum same-origin link depth to follow from the seed URL.
+- `HOST_LIMIT` / `--host-limit` (default `1`) — cap on the number of unique hostnames the crawler may visit (including the seed host).
+- `TIMEOUT_MS` / `--timeout-ms` (milliseconds, default `45000`) — navigation timeout override.
 
-The previous `EXCAVATOR_*` variables remain supported for backwards compatibility.
+The previous `EXCAVATOR_*` environment variables remain supported for backwards compatibility.
 
-All URLs are normalised, deduplicated, and constrained to the allowed host list. Each run emits a stable JSON object containing the seed `target`, unique `links`, discovered `scripts`, and crawl `meta` (see `sample_output.json`). Golden coverage for the crawler lives in `tests/crawl.test.js`.
+All URLs are normalised, deduplicated, and constrained to the host limit. Each run emits a stable JSON object containing the seed `target`, unique `links`, discovered `scripts`, and crawl `meta` (see `sample_output.json`). Golden coverage for the crawler lives in `tests/crawl.test.js`. For Playwright usage details see the [Page API documentation](https://playwright.dev/docs/api/class-page).

--- a/plugins/excavator/package-lock.json
+++ b/plugins/excavator/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "excavator",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "excavator",
+      "version": "0.1.0",
+      "dependencies": {
+        "playwright": "^1.40.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/plugins/excavator/sample_output.json
+++ b/plugins/excavator/sample_output.json
@@ -1,15 +1,9 @@
 {
   "target": "https://example.com",
   "links": [
-    "https://example.com",
-    "https://www.iana.org/domains/example"
+    "https://example.com"
   ],
-  "scripts": [
-    {
-      "src": "https://example.com/script.js",
-      "snippet": "console.log('hello from excavator');"
-    }
-  ],
+  "scripts": [],
   "meta": {
     "crawled_at": "2024-01-01T00:00:10Z",
     "depth": 1

--- a/plugins/excavator/tests/crawl.test.js
+++ b/plugins/excavator/tests/crawl.test.js
@@ -64,9 +64,8 @@ test('crawlSite normalises URLs, respects depth limits, and returns canonical sc
 
   const result = await crawlSite({
     seed: 'https://example.com',
-    maxDepth: 1,
-    maxPages: 5,
-    allowedHosts: ['example.com', 'cdn.example.com'],
+    depth: 1,
+    hostLimit: 1,
     fetchPage,
     now: nowStub(['2024-01-01T00:00:00Z', '2024-01-01T00:00:05Z']),
   });
@@ -81,6 +80,7 @@ test('crawlSite normalises URLs, respects depth limits, and returns canonical sc
     'https://example.com/contact?a=1&b=2',
     'https://example.com/team',
   ]);
+  assert.ok(!result.links.includes('https://external.test/path'));
 
   assert.ok(Array.isArray(result.scripts));
   assert.deepStrictEqual(result.scripts, [


### PR DESCRIPTION
## Summary
- rework the Playwright crawler to follow same-origin depth/host limits and emit canonical JSON
- replace networkidle navigation with a load-based wait, update docs, and refresh the golden sample
- check in the npm lockfile and expand the Node test to cover the new behaviour

## Testing
- npm --prefix plugins/excavator test

------
https://chatgpt.com/codex/tasks/task_e_68d13105edf0832a8df163d2000cc673