### PR TITLE
Update report markdown layout

### DIFF
--- a/cmd/glyphctl/report_test.go
+++ b/cmd/glyphctl/report_test.go
@@ -43,7 +43,7 @@ func TestRunReportSuccess(t *testing.T) {
 		t.Fatalf("read report: %v", err)
 	}
 	content := string(data)
-	if !strings.Contains(content, "## Severity Breakdown") {
+	if !strings.Contains(content, "## Totals by Severity") {
 		t.Fatalf("report missing severity section: %s", content)
 	}
 	if !strings.Contains(content, "## Last 20 Findings") {

--- a/cmd/glyphctl/testdata/report.golden
+++ b/cmd/glyphctl/testdata/report.golden
@@ -2,7 +2,7 @@
 
 Total findings: 3
 
-## Severity Breakdown
+## Totals by Severity
 
 | Severity | Count |
 | --- | ---: |
@@ -12,7 +12,7 @@ Total findings: 3
 | Low | 1 |
 | Informational | 0 |
 
-## Top Targets
+## Top 10 Targets
 
 Showing top 3 targets by finding volume.
 
@@ -22,9 +22,9 @@ Showing top 3 targets by finding volume.
 
 ## Last 20 Findings
 
-| Detected At | Severity | Plugin | Target | Evidence |
-| --- | --- | --- | --- | --- |
-| 2024-02-01T10:00:00Z | High | seer | https://a.example | Access key: AKIA1234567890TEST |
-| 2024-02-01T09:00:00Z | Low | galdr | https://b.example/login | Banner: ExampleCo Service Version 1.2.3 |
-| 2024-02-01T08:30:00Z | Critical | raider | (not specified) | SQL injection |
+| Plugin | Target | Evidence | Detected At |
+| --- | --- | --- | --- |
+| seer | https://a.example | Access key: AKIA1234567890TEST | 2024-02-01T10:00:00Z |
+| galdr | https://b.example/login | Banner: ExampleCo Service Version 1.2.3 | 2024-02-01T09:00:00Z |
+| raider | (not specified) | SQL injection | 2024-02-01T08:30:00Z |
 

--- a/internal/reporter/testdata/report.golden
+++ b/internal/reporter/testdata/report.golden
@@ -2,7 +2,7 @@
 
 Total findings: 3
 
-## Severity Breakdown
+## Totals by Severity
 
 | Severity | Count |
 | --- | ---: |
@@ -12,7 +12,7 @@ Total findings: 3
 | Low | 1 |
 | Informational | 0 |
 
-## Top Targets
+## Top 10 Targets
 
 Showing top 2 targets by finding volume.
 
@@ -21,9 +21,9 @@ Showing top 2 targets by finding volume.
 
 ## Last 20 Findings
 
-| Detected At | Severity | Plugin | Target | Evidence |
-| --- | --- | --- | --- | --- |
-| 2024-01-01T02:00:00Z | High | p1 | https://a | high |
-| 2024-01-01T01:00:00Z | Medium | p1 | https://a | medium |
-| 2024-01-01T00:00:00Z | Low | p2 | https://b | low |
+| Plugin | Target | Evidence | Detected At |
+| --- | --- | --- | --- |
+| p1 | https://a | high | 2024-01-01T02:00:00Z |
+| p1 | https://a | medium | 2024-01-01T01:00:00Z |
+| p2 | https://b | low | 2024-01-01T00:00:00Z |
 


### PR DESCRIPTION
## Summary
- align the markdown report section headings with the "Totals by Severity"/"Top 10 Targets" specification
- present the recent findings table as plugin/target/evidence/detected-at entries and ensure timestamps are RFC3339 UTC
- refresh reporter and glyphctl golden fixtures to match the new layout

## Testing
- `go test ./internal/reporter ./cmd/glyphctl`


------
https://chatgpt.com/codex/tasks/task_e_68d1428727b8832a8d6bfec103c9f5c0