### PR TITLE
Add passive Amass wrapper and normalizer

### DIFF
--- a/plugins/osint-well/README.md
+++ b/plugins/osint-well/README.md
@@ -1,21 +1,75 @@
 # OSINT Well
 
-OSINT Well orchestrates Amass to enrich Glyph investigations with open-source intelligence such as subdomains and infrastructure relationships.
+OSINT Well wraps [OWASP Amass](https://github.com/owasp-amass/amass) to surface open-source intelligence such as subdomains and infrastructure relationships. The plugin intentionally defaults to passive reconnaissance so that it can be executed safely in shared or sensitive environments.
 
-## Capabilities
-- `CAP_EMIT_FINDINGS`
-- `CAP_STORAGE`
+## Installation
 
-## Getting started
-1. Ensure Amass is installed locally and available on your `PATH`.
-2. 2. Use `glyphctl` to run a passive enumeration and normalise the output:
+1. Install the Amass binary (v3.23.0 or newer is recommended) and ensure it is available on your `PATH`.
+2. Build `glyphctl` if you plan to orchestrate plugins locally:
    ```bash
    go build ./cmd/glyphctl
-   ./glyphctl osint-well --domain example.com --out ./out/assets.jsonl
    ```
-   - Override the Amass binary with `--binary`.
-   - Pass extra Amass flags via `--args "-config /path/to/config"`.
-   - Adjust the output path with `--out` (defaults to `${GLYPH_OUT:-/out}/assets.jsonl`).
-3. `run_amass.sh` wraps the command above for quick experiments.
+3. (Optional) Export `GLYPH_OUT` to control where normalized assets are written. The default is `/out`.
 
-The normaliser aggregates duplicate hosts, deduplicates addresses/sources, and tags each entry with `amass-passive`. `tests` contain fixtures for the JSONL shape.
+## Passive vs. active enumeration
+
+`amass enum` supports both passive and active techniques. Passive mode only queries third-party data sources (e.g. certificate transparency, passive DNS) and does not touch the target's infrastructure. Active mode may probe DNS records, perform brute-force name discovery, and send network traffic to discovered hosts.
+
+This plugin's wrapper keeps executions passive by default to minimize risk:
+
+- `run_amass.sh` enforces `amass enum --passive`.
+- Extra flags forwarded to Amass should preserve passive behaviour. Avoid enabling brute force (`-brute`), active port scanning, or other intrusive features unless you have explicit authorization.
+- If you need active enumeration, run Amass manually and then feed the results into `normalize.js` for post-processing.
+
+## Usage
+
+### Quick wrapper
+
+```
+./plugins/osint-well/run_amass.sh -d example.com
+```
+
+Arguments:
+
+- `-d / --domain` – target domain (required).
+- `-o / --out` – destination JSONL file. Defaults to `${GLYPH_OUT:-/out}/assets.jsonl`.
+- `-b / --binary` – override the Amass binary path.
+- `--` – pass through additional passive-safe flags to Amass.
+
+The script writes Amass JSON to a temporary file, invokes the normalizer, and reports where the JSONL landed.
+
+### Normalizing previously captured output
+
+If you already have Amass NDJSON (from `amass enum ... -json results.json`), convert it with:
+
+```
+node plugins/osint-well/normalize.js path/to/amass.json existing-assets.jsonl
+```
+
+Each line of the output will look like:
+
+```
+{"type":"subdomain","value":"foo.example.com","source":"amass","ts":"2024-05-01T00:00:00Z"}
+```
+
+The normalizer deduplicates subdomains, keeps the earliest timestamp when duplicates are encountered, and guarantees deterministic sorting for stable diffs.
+
+### Working with `glyphctl`
+
+You can also drive the plugin through `glyphctl` once it is compiled:
+
+```
+./glyphctl osint-well --domain example.com --out ./out/assets.jsonl
+```
+
+To stay passive, avoid adding active enumeration flags via `--args`. When in doubt, consult the [Amass user guide](https://github.com/owasp-amass/amass/blob/master/doc/user_guide.md) for the distinction between passive and active options.
+
+## Testing the normalizer
+
+A canned Amass sample lives in `plugins/osint-well/tests/amass_passive.json`. Run the following to verify normalisation without hitting the network:
+
+```
+go test ./plugins/osint-well
+```
+
+The test harness executes `normalize.js` against the fixture and asserts that a valid `assets.jsonl` is produced.

--- a/plugins/osint-well/normalize.js
+++ b/plugins/osint-well/normalize.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+function usage() {
+  console.error('Usage: normalize.js <amass-json> [out.jsonl]');
+}
+
+function safeTimestamp(value) {
+  if (!value) {
+    return new Date().toISOString();
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return new Date().toISOString();
+  }
+  return parsed.toISOString();
+}
+
+function main() {
+  const [, , inputArg, outputArg] = process.argv;
+
+  if (!inputArg) {
+    usage();
+    process.exit(1);
+  }
+
+  const defaultOut = path.join(process.env.GLYPH_OUT || '/out', 'assets.jsonl');
+  const outputPath = outputArg ? path.resolve(outputArg) : defaultOut;
+
+  const inputPath = inputArg === '-' ? 0 : path.resolve(inputArg);
+  let raw = '';
+
+  try {
+    raw = inputArg === '-' ? fs.readFileSync(process.stdin.fd, 'utf8') : fs.readFileSync(inputPath, 'utf8');
+  } catch (err) {
+    console.error(`Failed to read input: ${err.message}`);
+    process.exit(1);
+  }
+
+  const seen = new Map();
+  raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .forEach((line, idx) => {
+      let payload;
+      try {
+        payload = JSON.parse(line);
+      } catch (err) {
+        console.warn(`Skipping line ${idx + 1}: ${err.message}`);
+        return;
+      }
+
+      const name = typeof payload.name === 'string' ? payload.name.trim() : '';
+      if (!name) {
+        return;
+      }
+
+      const ts = safeTimestamp(payload.timestamp || payload.timestr || payload.last_seen);
+      const existing = seen.get(name);
+      if (!existing || existing.ts > ts) {
+        seen.set(name, {
+          type: 'subdomain',
+          value: name,
+          source: 'amass',
+          ts,
+        });
+      }
+    });
+
+  const records = Array.from(seen.values()).sort((a, b) => a.value.localeCompare(b.value));
+
+  try {
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    const body = records.map((record) => JSON.stringify(record)).join('\n');
+    const output = body.length > 0 ? `${body}\n` : '';
+    fs.writeFileSync(outputPath, output);
+  } catch (err) {
+    console.error(`Failed to write output: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/plugins/osint-well/normalize_test.go
+++ b/plugins/osint-well/normalize_test.go
@@ -1,0 +1,43 @@
+package osintwell
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeProducesJSONL(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+
+	fixture := filepath.Join(repoRoot, "tests", "amass_passive.json")
+	outDir := t.TempDir()
+	outputPath := filepath.Join(outDir, "assets.jsonl")
+
+	normalize := filepath.Join(repoRoot, "normalize.js")
+	cmd := exec.Command("node", normalize, fixture, outputPath)
+	cmd.Env = append(os.Environ(), "GLYPH_OUT="+outDir)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("normalize.js failed: %v\n%s", err, stderr.String())
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read normalized output: %v", err)
+	}
+
+	expected := "{\"type\":\"subdomain\",\"value\":\"blog.example.com\",\"source\":\"amass\",\"ts\":\"2024-05-02T10:00:00.000Z\"}\n" +
+		"{\"type\":\"subdomain\",\"value\":\"www.example.com\",\"source\":\"amass\",\"ts\":\"2024-05-01T00:00:00.000Z\"}\n"
+
+	if string(data) != expected {
+		t.Fatalf("unexpected normalization output\nexpected:\n%s\ngot:\n%s", expected, string(data))
+	}
+}

--- a/plugins/osint-well/run_amass.sh
+++ b/plugins/osint-well/run_amass.sh
@@ -1,19 +1,112 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -lt 1 ]; then
-  echo "usage: $0 <target-domain> [additional amass args...]" >&2
+usage() {
+  cat <<USAGE >&2
+Usage: $0 [-o <assets.jsonl>] [-b <amass-binary>] -d <domain> [-- <extra passive amass args>]
+
+Runs "amass enum --passive" for the requested domain and normalizes the
+results to Glyph's assets.jsonl format.
+
+Options:
+  -d <domain>          Domain to enumerate (required)
+  -o <path>            Output path for normalized JSONL (defaults to
+                       "${GLYPH_OUT:-/out}/assets.jsonl")
+  -b <binary>          Path to the amass binary (defaults to the first amass
+                       on $PATH)
+  -- <args>            Additional arguments forwarded to amass. Keep these
+                       passive-only to avoid active probing.
+USAGE
+}
+
+DOMAIN=""
+OUTPUT_PATH="${GLYPH_OUT:-/out}/assets.jsonl"
+AMASS_BIN="${AMASS_BIN:-amass}"
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -d|--domain)
+      if [[ $# -lt 2 ]]; then
+        echo "error: -d|--domain requires a value" >&2
+        usage
+        exit 1
+      fi
+      DOMAIN="$2"
+      shift 2
+      ;;
+    -o|--out)
+      if [[ $# -lt 2 ]]; then
+        echo "error: -o|--out requires a value" >&2
+        usage
+        exit 1
+      fi
+      OUTPUT_PATH="$2"
+      shift 2
+      ;;
+    -b|--binary)
+      if [[ $# -lt 2 ]]; then
+        echo "error: -b|--binary requires a value" >&2
+        usage
+        exit 1
+      fi
+      AMASS_BIN="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      EXTRA_ARGS+=("$@")
+      break
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -z "$DOMAIN" ]]; then
+        DOMAIN="$1"
+      else
+        EXTRA_ARGS+=("$1")
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$DOMAIN" ]]; then
+  echo "error: domain is required" >&2
+  usage
   exit 1
 fi
 
-TARGET_DOMAIN="$1"
-shift
-
-if ! command -v glyphctl >/dev/null 2>&1; then
-  echo "glyphctl binary not found in PATH" >&2
+if ! command -v "$AMASS_BIN" >/dev/null 2>&1; then
+  echo "error: amass binary '$AMASS_BIN' not found" >&2
   exit 1
 fi
 
-mkdir -p out
-glyphctl osint-well --domain "$TARGET_DOMAIN" --out ./out/assets.jsonl --args "$*"
-echo "Normalized assets written to ./out/assets.jsonl"
+if ! command -v node >/dev/null 2>&1; then
+  echo "error: node is required to run the normalizer" >&2
+  exit 1
+fi
+
+NORMALIZER="$(dirname "$0")/normalize.js"
+if [[ ! -x "$NORMALIZER" && ! -f "$NORMALIZER" ]]; then
+  echo "error: normalizer script not found at $NORMALIZER" >&2
+  exit 1
+fi
+
+TMPDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+AMASS_JSON="$TMPDIR/amass.json"
+
+# Always enforce passive enumeration.
+"$AMASS_BIN" enum --passive -d "$DOMAIN" -json "$AMASS_JSON" "${EXTRA_ARGS[@]}"
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+node "$NORMALIZER" "$AMASS_JSON" "$OUTPUT_PATH"
+
+echo "Normalized assets written to $OUTPUT_PATH"

--- a/plugins/osint-well/tests/amass_passive.json
+++ b/plugins/osint-well/tests/amass_passive.json
@@ -1,0 +1,3 @@
+{"timestamp":"2024-05-01T00:00:00Z","name":"www.example.com","domain":"example.com","addresses":[{"ip":"93.184.216.34"}],"sources":["ExampleSource"]}
+{"timestamp":"2024-05-02T10:00:00Z","name":"blog.example.com","domain":"example.com","sources":["ExampleSource","Another"]}
+{"timestamp":"2024-05-03T09:30:00Z","name":"www.example.com","domain":"example.com","sources":["ExampleSource"]}

--- a/plugins/osint-well/tests/sample_fixture.json
+++ b/plugins/osint-well/tests/sample_fixture.json
@@ -1,3 +1,0 @@
-{
-  "notes": "Capture representative Amass outputs and normalized records here."
-}


### PR DESCRIPTION
## Summary
- add a Node-based normalizer that converts Amass NDJSON into Glyph assets JSONL
- provide a passive `run_amass.sh` wrapper that enforces `amass enum --passive` and feeds the normalizer
- document installation, passive usage guidance, and ship a canned fixture plus Go test for offline verification

## Testing
- go test ./plugins/osint-well

------
https://chatgpt.com/codex/tasks/task_e_68d1508103a0832a80b6da5dda931efc