### PR TITLE
Improve seer heuristics and redaction controls

### DIFF
--- a/internal/seer/detector_test.go
+++ b/internal/seer/detector_test.go
@@ -1,6 +1,7 @@
 package seer
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -49,12 +50,12 @@ Email: alerts@example.com`
 		}
 	}
 
-	check(0, "seer.aws_access_key", findings.SeverityHigh, "****************MNOP")
-        check(1, "seer.generic_api_key", findings.SeverityMedium, "********************g7H8")
+	check(0, "seer.aws_access_key", findings.SeverityHigh, "AKIA…MNOP")
+	check(1, "seer.generic_api_key", findings.SeverityMedium, "sk_l…g7H8")
 	if entropy := results[1].Metadata["entropy"]; entropy == "" {
 		t.Fatalf("generic finding missing entropy")
 	}
-        check(2, "seer.slack_token", findings.SeverityHigh, "******************************mnop")
+	check(2, "seer.slack_token", findings.SeverityHigh, "xoxb…mnop")
 }
 
 func TestScanDeduplicatesAndRedactsEmails(t *testing.T) {
@@ -69,7 +70,63 @@ func TestScanDeduplicatesAndRedactsEmails(t *testing.T) {
 	if f.Type != "seer.email_address" {
 		t.Fatalf("email finding type = %q", f.Type)
 	}
-	if f.Evidence != "s******y@example.com" {
+	if f.Evidence != "secu…@….com" {
 		t.Fatalf("email evidence = %q", f.Evidence)
+	}
+	if got := f.Metadata["domain"]; got != "example.com" {
+		t.Fatalf("email metadata domain = %q", got)
+	}
+}
+
+func TestAllowlistControls(t *testing.T) {
+	target := "https://example.com/settings"
+	content := `AWS: AKIAABCDEFGHIJKLMNOP
+Email: alerts@corp.example.com
+Slack: xoxb-123456789012-abcdefghijklmnop`
+
+	results := Scan(target, content, Config{
+		Allowlist: []string{"pattern:seer.aws_access_key", "@example.com"},
+	})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 finding after allowlists, got %d", len(results))
+	}
+	if results[0].Type != "seer.slack_token" {
+		t.Fatalf("remaining finding type = %q", results[0].Type)
+	}
+
+	cfg := Config{Allowlist: []string{"pattern:seer.aws_access_key", "@example.com", "path:/settings"}}
+	if res := Scan(target, content, cfg); len(res) != 0 {
+		t.Fatalf("path allowlist should suppress all findings, got %d", len(res))
+	}
+
+	cfg.Allowlist = []string{"url:https://example.com/settings"}
+	if res := Scan(target, content, cfg); len(res) != 0 {
+		t.Fatalf("url allowlist should suppress all findings, got %d", len(res))
+	}
+}
+
+func TestScanSkipsBinaryContent(t *testing.T) {
+	blob := string([]byte{0x00, 0x01, 0x02, 'A', 'K', 'I', 'A'})
+	if res := Scan("https://example.com", blob, Config{}); len(res) != 0 {
+		t.Fatalf("expected binary content to be skipped, got %d findings", len(res))
+	}
+}
+
+func TestScanHonoursMaxBytes(t *testing.T) {
+	key := "AKIAABCDEFGHIJKLMNOP"
+	content := strings.Repeat("A", 200) + "\n" + key
+
+	truncated := Scan("https://example.com", content, Config{MaxScanBytes: 128})
+	if len(truncated) != 0 {
+		t.Fatalf("expected no findings with strict max bytes, got %d", len(truncated))
+	}
+
+	allowed := Scan("https://example.com", content, Config{MaxScanBytes: 256})
+	if len(allowed) != 1 {
+		t.Fatalf("expected aws key to be detected with higher cap, got %d", len(allowed))
+	}
+	if allowed[0].Evidence != "AKIA…MNOP" {
+		t.Fatalf("unexpected redaction: %q", allowed[0].Evidence)
 	}
 }

--- a/plugins/seer/tests/fixtures/allowlist.json
+++ b/plugins/seer/tests/fixtures/allowlist.json
@@ -3,8 +3,9 @@
   "target": "https://example.com/settings",
   "allowlist": [
     "AKIAABCDEFGHIJKLMNOP",
-    "xoxb-111111111111-placeholder",
-    "security@example.com"
+    "pattern:seer.slack_token",
+    "@example.com",
+    "url:https://example.com/settings"
   ],
   "content": "AWS key: AKIAABCDEFGHIJKLMNOP\nSlack token: xoxb-111111111111-placeholder\nEmail: security@example.com\nGeneric key: api_key = test-token-123",
   "expect": []

--- a/plugins/seer/tests/fixtures/secrets.json
+++ b/plugins/seer/tests/fixtures/secrets.json
@@ -7,23 +7,23 @@
     {
       "type": "seer.aws_access_key",
       "severity": "high",
-      "evidence": "****************MNOP"
+      "evidence": "AKIA…MNOP"
     },
     {
       "type": "seer.email_address",
       "severity": "low",
-      "evidence": "i***************e@example.com"
+      "evidence": "inci…@….com"
     },
     {
       "type": "seer.generic_api_key",
       "severity": "med",
-      "evidence": "********************g7H8",
+      "evidence": "sk_l…g7H8",
       "min_entropy": 3.5
     },
     {
       "type": "seer.slack_token",
       "severity": "high",
-      "evidence": "******************************mnop"
+      "evidence": "xoxb…mnop"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- tighten the seer detector by capping scan size, skipping binary blobs, adding configurable redaction, and refining email/API-key matching
- expand allowlist handling with per-pattern, domain, URL, and path suppression while updating fixtures for the new redaction output
- add unit tests for the new controls, including binary avoidance, max-byte limits, and domain/path/url allowlists

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d291416530832ab3b16b452a2f06f6