### PR TITLE
Improve grapher schema discovery resilience

### DIFF
--- a/plugins/grapher/README.md
+++ b/plugins/grapher/README.md
@@ -6,9 +6,15 @@ Grapher performs unauthenticated discovery of API schemas so downstream Glyph wo
 
 - Probes common OpenAPI locations (`/.well-known/openapi.json`, `/openapi.json`, `/swagger.json`, `/swagger/v1/swagger.json`).
 - Checks likely GraphQL handlers (`/.well-known/graphql`, `/graphql`, `/api/graphql`) with safe `HEAD`/`GET` metadata requests.
-- Normalizes any hits to JSON Lines at `${GLYPH_OUT:-/out}/schemas.jsonl` for later enrichment.
+- Follows same-host 301/302 redirects, retries transient 429/503 responses with backoff, and caps response bodies at 1 MiB per request.
+- Normalizes any hits to JSON Lines at `${GLYPH_OUT:-/out}/schemas.jsonl` for later enrichment, deduped by schema type + URL.
 
-The scanner intentionally uses **no authentication** and performs **no active GraphQL introspection** queries. It only records whether a schema endpoint is reachable and the HTTP status returned.
+The scanner intentionally uses **no authentication** and performs **no active GraphQL introspection** queries. Many production GraphQL deployments disable introspection for security-hardening, so Grapher only records whether a schema endpoint is reachable and the HTTP status returned.
+
+## Security notes
+
+- Review the [OpenAPI Specification security considerations](https://spec.openapis.org/oas/latest.html#security-considerations) when deciding how to expose schema documents publicly.
+- GraphQL administrators frequently lock down introspection in production; see the [GraphQL best practices on security](https://graphql.org/learn/best-practices/#security) for background.
 
 ## Examples
 

--- a/plugins/grapher/main.go
+++ b/plugins/grapher/main.go
@@ -114,10 +114,11 @@ func runDiscovery(ctx context.Context, client *http.Client, targets []string) ([
 			return nil, fmt.Errorf("discover %s: %w", target, err)
 		}
 		for _, res := range results {
-			if _, ok := seen[res.URL]; ok {
+			key := string(res.Type) + "|" + res.URL
+			if _, ok := seen[key]; ok {
 				continue
 			}
-			seen[res.URL] = struct{}{}
+			seen[key] = struct{}{}
 			all = append(all, res)
 		}
 	}


### PR DESCRIPTION
## Summary
- harden schema discovery by handling safe redirects, retrying 429/503 responses with backoff, capping response sizes, and recording the resolved endpoint URL
- dedupe aggregated results by schema type and URL so repeated hits across targets only emit once
- expand documentation and tests to cover redirect/unauthorized/retry scenarios and verify the byte-cap behaviour

## Testing
- go test ./plugins/grapher -count=1

------
https://chatgpt.com/codex/tasks/task_e_68d299fab98c832a843a14e8a35d145e