### PR TITLE
Add HTML report renderer and CLI format flag

### DIFF
--- a/cmd/glyphctl/report.go
+++ b/cmd/glyphctl/report.go
@@ -18,7 +18,8 @@ func runReportAt(args []string, now time.Time) int {
 	fs := flag.NewFlagSet("report", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	input := fs.String("input", reporter.DefaultFindingsPath, "path to findings JSONL input")
-	output := fs.String("out", reporter.DefaultReportPath, "path to write the markdown report")
+	output := fs.String("out", reporter.DefaultReportPath, "path to write the report")
+	formatRaw := fs.String("format", string(reporter.FormatMarkdown), "report format (md or html)")
 	sinceRaw := fs.String("since", "", "only include findings detected on or after this RFC-3339 timestamp or duration (e.g. 24h)")
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -39,7 +40,16 @@ func runReportAt(args []string, now time.Time) int {
 		opts.Since = &since
 	}
 
-	if err := reporter.RenderReport(*input, *output, opts); err != nil {
+	format := reporter.ReportFormat(strings.ToLower(strings.TrimSpace(*formatRaw)))
+	if format == "" {
+		format = reporter.FormatMarkdown
+	}
+	if format != reporter.FormatMarkdown && format != reporter.FormatHTML {
+		fmt.Fprintf(os.Stderr, "invalid --format value %q (expected md or html)\n", *formatRaw)
+		return 2
+	}
+
+	if err := reporter.RenderReport(*input, *output, format, opts); err != nil {
 		fmt.Fprintf(os.Stderr, "generate report: %v\n", err)
 		return 1
 	}

--- a/internal/reporter/html.go
+++ b/internal/reporter/html.go
@@ -1,0 +1,140 @@
+package reporter
+
+import (
+	"fmt"
+	"html"
+	"strings"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+var severityClass = map[findings.Severity]string{
+	findings.SeverityCritical: "severity-critical",
+	findings.SeverityHigh:     "severity-high",
+	findings.SeverityMedium:   "severity-medium",
+	findings.SeverityLow:      "severity-low",
+	findings.SeverityInfo:     "severity-info",
+}
+
+const htmlStyles = `body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 32px; color: #1f2933; background-color: #ffffff; }
+h1 { margin-bottom: 0.25rem; }
+.meta { color: #52606d; margin: 0.25rem 0; }
+.section { margin-top: 2rem; }
+table { border-collapse: collapse; width: 100%; margin-top: 0.75rem; }
+th, td { border: 1px solid #d2d6dc; padding: 0.5rem; text-align: left; vertical-align: top; }
+th.numeric, td.numeric { text-align: right; }
+ol { margin-top: 0.75rem; padding-left: 1.5rem; }
+.severity-band { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 9999px; font-weight: 600; }
+.severity-critical { background-color: #b71c1c; color: #ffffff; }
+.severity-high { background-color: #e65100; color: #ffffff; }
+.severity-medium { background-color: #f9a825; color: #1f2933; }
+.severity-low { background-color: #1e88e5; color: #ffffff; }
+.severity-info { background-color: #546e7a; color: #ffffff; }
+`
+
+// RenderHTML converts a slice of findings into an HTML report.
+func RenderHTML(list []findings.Finding, opts ReportOptions) string {
+	summary := buildSummary(list, opts)
+
+	var b strings.Builder
+	b.WriteString("<!DOCTYPE html>\n")
+	b.WriteString("<html lang=\"en\">\n")
+	b.WriteString("<head>\n")
+	b.WriteString("  <meta charset=\"utf-8\">\n")
+	b.WriteString("  <title>Glyph Findings Report</title>\n")
+	fmt.Fprintf(&b, "  <style>%s</style>\n", htmlStyles)
+	b.WriteString("</head>\n")
+	b.WriteString("<body>\n")
+	b.WriteString("  <h1>Findings Report</h1>\n")
+	fmt.Fprintf(&b, "  <p class=\"meta\">Generated at %s (UTC)</p>\n", summary.GeneratedAt.Format(time.RFC3339))
+	if summary.WindowStart != nil {
+		fmt.Fprintf(&b, "  <p class=\"meta\">Reporting window: %s — %s (UTC)</p>\n", summary.WindowStart.Format(time.RFC3339), summary.WindowEnd.Format(time.RFC3339))
+	} else {
+		fmt.Fprintf(&b, "  <p class=\"meta\">Reporting window: All findings through %s (UTC)</p>\n", summary.WindowEnd.Format(time.RFC3339))
+	}
+	fmt.Fprintf(&b, "  <p class=\"meta\">Total findings: %d</p>\n", summary.Total)
+
+	b.WriteString("  <section class=\"section\">\n")
+	b.WriteString("    <h2>Totals by Severity</h2>\n")
+	b.WriteString("    <table>\n")
+	b.WriteString("      <thead>\n")
+	b.WriteString("        <tr><th scope=\"col\">Severity</th><th scope=\"col\" class=\"numeric\">Count</th></tr>\n")
+	b.WriteString("      </thead>\n")
+	b.WriteString("      <tbody>\n")
+	for _, entry := range severityOrder {
+		class := severityClass[entry.key]
+		if class == "" {
+			class = severityClass[findings.SeverityInfo]
+		}
+		fmt.Fprintf(&b, "        <tr><td><span class=\"severity-band %s\">%s</span></td><td class=\"numeric\">%d</td></tr>\n", class, entry.label, summary.SeverityCount[entry.key])
+	}
+	b.WriteString("      </tbody>\n")
+	b.WriteString("    </table>\n")
+	b.WriteString("  </section>\n")
+
+	b.WriteString("  <section class=\"section\">\n")
+	b.WriteString("    <h2>Findings by Plugin (top 5)</h2>\n")
+	if len(summary.Plugins) == 0 {
+		b.WriteString("    <p>No plugins reported.</p>\n")
+	} else {
+		fmt.Fprintf(&b, "    <p>Showing top %d plugins by finding volume.</p>\n", len(summary.Plugins))
+		b.WriteString("    <table>\n")
+		b.WriteString("      <thead>\n")
+		b.WriteString("        <tr><th scope=\"col\">Plugin</th><th scope=\"col\" class=\"numeric\">Findings</th></tr>\n")
+		b.WriteString("      </thead>\n")
+		b.WriteString("      <tbody>\n")
+		for _, entry := range summary.Plugins {
+			fmt.Fprintf(&b, "        <tr><td>%s</td><td class=\"numeric\">%d</td></tr>\n", html.EscapeString(entry.Plugin), entry.Count)
+		}
+		b.WriteString("      </tbody>\n")
+		b.WriteString("    </table>\n")
+	}
+	b.WriteString("  </section>\n")
+
+	b.WriteString("  <section class=\"section\">\n")
+	b.WriteString("    <h2>Top 10 Targets</h2>\n")
+	if len(summary.Targets) == 0 {
+		b.WriteString("    <p>No targets reported.</p>\n")
+	} else {
+		fmt.Fprintf(&b, "    <p>Showing top %d targets by finding volume.</p>\n", len(summary.Targets))
+		b.WriteString("    <ol>\n")
+		for _, entry := range summary.Targets {
+			fmt.Fprintf(&b, "      <li><strong>%s</strong> — %d findings</li>\n", html.EscapeString(entry.Target), entry.Count)
+		}
+		b.WriteString("    </ol>\n")
+	}
+	b.WriteString("  </section>\n")
+
+	b.WriteString("  <section class=\"section\">\n")
+	fmt.Fprintf(&b, "    <h2>Last %d Findings</h2>\n", defaultRecentFindings)
+	if summary.Total == 0 {
+		b.WriteString("    <p>No findings recorded.</p>\n")
+	} else {
+		b.WriteString("    <table>\n")
+		b.WriteString("      <thead>\n")
+		b.WriteString("        <tr><th scope=\"col\">Plugin</th><th scope=\"col\">Target</th><th scope=\"col\">Evidence</th><th scope=\"col\">Detected At</th></tr>\n")
+		b.WriteString("      </thead>\n")
+		b.WriteString("      <tbody>\n")
+		for _, f := range summary.Recent {
+			plugin := strings.TrimSpace(f.Plugin)
+			if plugin == "" {
+				plugin = "(not specified)"
+			}
+			target := strings.TrimSpace(f.Target)
+			if target == "" {
+				target = "(not specified)"
+			}
+			evidence := findingExcerpt(f)
+			ts := f.DetectedAt.Time().UTC().Format(time.RFC3339)
+			fmt.Fprintf(&b, "        <tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>\n", html.EscapeString(plugin), html.EscapeString(target), html.EscapeString(evidence), html.EscapeString(ts))
+		}
+		b.WriteString("      </tbody>\n")
+		b.WriteString("    </table>\n")
+	}
+	b.WriteString("  </section>\n")
+
+	b.WriteString("</body>\n")
+	b.WriteString("</html>\n")
+	return b.String()
+}

--- a/internal/reporter/html_test.go
+++ b/internal/reporter/html_test.go
@@ -1,0 +1,34 @@
+package reporter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+func TestRenderHTMLGolden(t *testing.T) {
+	base := time.Date(2024, 2, 10, 12, 0, 0, 0, time.UTC)
+	since24h := base.Add(-24 * time.Hour)
+
+	sample := []findings.Finding{
+		{ID: "01HZXK4QAZ3ZKAB1Y7P5Z9Q4C4", Plugin: "alpha", Type: "t", Message: "alpha high", Target: "https://a", Severity: findings.SeverityHigh, DetectedAt: findings.NewTimestamp(base.Add(-2 * time.Hour))},
+		{ID: "01HZXK4QAZ3ZKAB1Y7P5Z9Q4C5", Plugin: "beta", Type: "t", Message: "beta medium", Target: "https://b", Severity: findings.SeverityMedium, DetectedAt: findings.NewTimestamp(base.Add(-6 * time.Hour))},
+		{ID: "01HZXK4QAZ3ZKAB1Y7P5Z9Q4C6", Plugin: "alpha", Type: "t", Message: "alpha critical", Target: "https://a", Severity: findings.SeverityCritical, DetectedAt: findings.NewTimestamp(base.Add(-25 * time.Hour))},
+		{ID: "01HZXK4QAZ3ZKAB1Y7P5Z9Q4C7", Plugin: "gamma", Type: "t", Message: "gamma low", Target: "", Severity: findings.SeverityLow, DetectedAt: findings.NewTimestamp(base.Add(-26 * time.Hour))},
+	}
+
+	got := RenderHTML(sample, ReportOptions{Now: base, Since: &since24h})
+	goldenPath := filepath.Join("testdata", "report_since_24h.html.golden")
+	wantBytes, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	want := string(wantBytes)
+	if strings.TrimSpace(got) != strings.TrimSpace(want) {
+		t.Fatalf("html mismatch\nwant:\n%s\n\ngot:\n%s", want, got)
+	}
+}

--- a/internal/reporter/md_test.go
+++ b/internal/reporter/md_test.go
@@ -95,7 +95,7 @@ func TestRenderReportWritesFile(t *testing.T) {
 		t.Fatalf("write finding: %v", err)
 	}
 
-	if err := RenderReport(input, output, ReportOptions{}); err != nil {
+	if err := RenderReport(input, output, FormatMarkdown, ReportOptions{}); err != nil {
 		t.Fatalf("render report: %v", err)
 	}
 

--- a/internal/reporter/summary.go
+++ b/internal/reporter/summary.go
@@ -1,0 +1,205 @@
+package reporter
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+// ReportFormat identifies the type of report to generate.
+type ReportFormat string
+
+const (
+	// FormatMarkdown renders a Markdown report.
+	FormatMarkdown ReportFormat = "md"
+	// FormatHTML renders an HTML report.
+	FormatHTML ReportFormat = "html"
+)
+
+type targetCount struct {
+	Target string
+	Count  int
+}
+
+type pluginCount struct {
+	Plugin string
+	Count  int
+}
+
+type reportSummary struct {
+	WindowStart   *time.Time
+	WindowEnd     time.Time
+	GeneratedAt   time.Time
+	Total         int
+	SeverityCount map[findings.Severity]int
+	Targets       []targetCount
+	Plugins       []pluginCount
+	Recent        []findings.Finding
+}
+
+func buildSummary(list []findings.Finding, opts ReportOptions) reportSummary {
+	since, now, filtered := opts.reportingWindow()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+
+	var windowStart *time.Time
+	if filtered {
+		windowStart = &since
+	}
+
+	filteredList := list
+	if windowStart != nil {
+		trimmed := make([]findings.Finding, 0, len(list))
+		for _, f := range list {
+			ts := f.DetectedAt.Time().UTC()
+			if ts.Before(*windowStart) {
+				continue
+			}
+			if ts.After(now) {
+				continue
+			}
+			trimmed = append(trimmed, f)
+		}
+		filteredList = trimmed
+	}
+
+	counts := map[findings.Severity]int{
+		findings.SeverityCritical: 0,
+		findings.SeverityHigh:     0,
+		findings.SeverityMedium:   0,
+		findings.SeverityLow:      0,
+		findings.SeverityInfo:     0,
+	}
+	targets := map[string]int{}
+	plugins := map[string]int{}
+
+	for _, f := range filteredList {
+		sev := canonicalSeverity(f.Severity)
+		counts[sev]++
+
+		target := strings.TrimSpace(f.Target)
+		if target == "" {
+			target = "(not specified)"
+		}
+		targets[target]++
+
+		plugin := strings.TrimSpace(f.Plugin)
+		if plugin == "" {
+			plugin = "(not specified)"
+		}
+		plugins[plugin]++
+	}
+
+	rankedTargets := make([]targetCount, 0, len(targets))
+	for target, count := range targets {
+		if count == 0 {
+			continue
+		}
+		rankedTargets = append(rankedTargets, targetCount{Target: target, Count: count})
+	}
+
+	sort.Slice(rankedTargets, func(i, j int) bool {
+		if rankedTargets[i].Count == rankedTargets[j].Count {
+			return rankedTargets[i].Target < rankedTargets[j].Target
+		}
+		return rankedTargets[i].Count > rankedTargets[j].Count
+	})
+
+	targetLimit := len(rankedTargets)
+	if DefaultTopTargets > 0 && DefaultTopTargets < targetLimit {
+		targetLimit = DefaultTopTargets
+	}
+	rankedTargets = rankedTargets[:targetLimit]
+
+	rankedPlugins := make([]pluginCount, 0, len(plugins))
+	for plugin, count := range plugins {
+		if count == 0 {
+			continue
+		}
+		rankedPlugins = append(rankedPlugins, pluginCount{Plugin: plugin, Count: count})
+	}
+
+	sort.Slice(rankedPlugins, func(i, j int) bool {
+		if rankedPlugins[i].Count == rankedPlugins[j].Count {
+			return rankedPlugins[i].Plugin < rankedPlugins[j].Plugin
+		}
+		return rankedPlugins[i].Count > rankedPlugins[j].Count
+	})
+
+	pluginLimit := len(rankedPlugins)
+	if defaultTopPlugins > 0 && pluginLimit > defaultTopPlugins {
+		pluginLimit = defaultTopPlugins
+	}
+	rankedPlugins = rankedPlugins[:pluginLimit]
+
+	recent := make([]findings.Finding, len(filteredList))
+	copy(recent, filteredList)
+	sort.Slice(recent, func(i, j int) bool {
+		ti := recent[i].DetectedAt.Time()
+		tj := recent[j].DetectedAt.Time()
+		if ti.Equal(tj) {
+			return recent[i].ID > recent[j].ID
+		}
+		return ti.After(tj)
+	})
+	if len(recent) > defaultRecentFindings {
+		recent = recent[:defaultRecentFindings]
+	}
+
+	return reportSummary{
+		WindowStart:   windowStart,
+		WindowEnd:     now,
+		GeneratedAt:   now,
+		Total:         len(filteredList),
+		SeverityCount: counts,
+		Targets:       rankedTargets,
+		Plugins:       rankedPlugins,
+		Recent:        recent,
+	}
+}
+
+func canonicalSeverity(input findings.Severity) findings.Severity {
+	switch strings.ToLower(strings.TrimSpace(string(input))) {
+	case string(findings.SeverityCritical):
+		return findings.SeverityCritical
+	case string(findings.SeverityHigh):
+		return findings.SeverityHigh
+	case string(findings.SeverityMedium):
+		return findings.SeverityMedium
+	case string(findings.SeverityLow):
+		return findings.SeverityLow
+	case string(findings.SeverityInfo):
+		return findings.SeverityInfo
+	default:
+		return findings.SeverityInfo
+	}
+}
+
+func findingExcerpt(f findings.Finding) string {
+	raw := strings.TrimSpace(f.Evidence)
+	if raw == "" {
+		raw = strings.TrimSpace(f.Message)
+	}
+	if raw == "" {
+		return "(not provided)"
+	}
+	raw = strings.ReplaceAll(raw, "\r", " ")
+	raw = strings.ReplaceAll(raw, "\n", " ")
+	raw = strings.Join(strings.Fields(raw), " ")
+	if evidenceExcerptLimit > 0 {
+		runes := []rune(raw)
+		if len(runes) > evidenceExcerptLimit {
+			raw = strings.TrimSpace(string(runes[:evidenceExcerptLimit])) + "…"
+		}
+	}
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "(not provided)"
+	}
+	return trimmed
+}

--- a/internal/reporter/testdata/report_since_24h.html.golden
+++ b/internal/reporter/testdata/report_since_24h.html.golden
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Glyph Findings Report</title>
+  <style>body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 32px; color: #1f2933; background-color: #ffffff; }
+h1 { margin-bottom: 0.25rem; }
+.meta { color: #52606d; margin: 0.25rem 0; }
+.section { margin-top: 2rem; }
+table { border-collapse: collapse; width: 100%; margin-top: 0.75rem; }
+th, td { border: 1px solid #d2d6dc; padding: 0.5rem; text-align: left; vertical-align: top; }
+th.numeric, td.numeric { text-align: right; }
+ol { margin-top: 0.75rem; padding-left: 1.5rem; }
+.severity-band { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 9999px; font-weight: 600; }
+.severity-critical { background-color: #b71c1c; color: #ffffff; }
+.severity-high { background-color: #e65100; color: #ffffff; }
+.severity-medium { background-color: #f9a825; color: #1f2933; }
+.severity-low { background-color: #1e88e5; color: #ffffff; }
+.severity-info { background-color: #546e7a; color: #ffffff; }
+</style>
+</head>
+<body>
+  <h1>Findings Report</h1>
+  <p class="meta">Generated at 2024-02-10T12:00:00Z (UTC)</p>
+  <p class="meta">Reporting window: 2024-02-09T12:00:00Z — 2024-02-10T12:00:00Z (UTC)</p>
+  <p class="meta">Total findings: 2</p>
+  <section class="section">
+    <h2>Totals by Severity</h2>
+    <table>
+      <thead>
+        <tr><th scope="col">Severity</th><th scope="col" class="numeric">Count</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><span class="severity-band severity-critical">Critical</span></td><td class="numeric">0</td></tr>
+        <tr><td><span class="severity-band severity-high">High</span></td><td class="numeric">1</td></tr>
+        <tr><td><span class="severity-band severity-medium">Medium</span></td><td class="numeric">1</td></tr>
+        <tr><td><span class="severity-band severity-low">Low</span></td><td class="numeric">0</td></tr>
+        <tr><td><span class="severity-band severity-info">Informational</span></td><td class="numeric">0</td></tr>
+      </tbody>
+    </table>
+  </section>
+  <section class="section">
+    <h2>Findings by Plugin (top 5)</h2>
+    <p>Showing top 2 plugins by finding volume.</p>
+    <table>
+      <thead>
+        <tr><th scope="col">Plugin</th><th scope="col" class="numeric">Findings</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>alpha</td><td class="numeric">1</td></tr>
+        <tr><td>beta</td><td class="numeric">1</td></tr>
+      </tbody>
+    </table>
+  </section>
+  <section class="section">
+    <h2>Top 10 Targets</h2>
+    <p>Showing top 2 targets by finding volume.</p>
+    <ol>
+      <li><strong>https://a</strong> — 1 findings</li>
+      <li><strong>https://b</strong> — 1 findings</li>
+    </ol>
+  </section>
+  <section class="section">
+    <h2>Last 20 Findings</h2>
+    <table>
+      <thead>
+        <tr><th scope="col">Plugin</th><th scope="col">Target</th><th scope="col">Evidence</th><th scope="col">Detected At</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>alpha</td><td>https://a</td><td>alpha high</td><td>2024-02-10T10:00:00Z</td></tr>
+        <tr><td>beta</td><td>https://b</td><td>beta medium</td><td>2024-02-10T06:00:00Z</td></tr>
+      </tbody>
+    </table>
+  </section>
+</body>
+</html>

--- a/plugins/scribe/README.md
+++ b/plugins/scribe/README.md
@@ -16,4 +16,10 @@ Scribe renders investigation output into human-friendly reports, summarizing fin
    ```
 3. Compare the output with `plugins/samples/report.golden.md` or wire it into downstream automation.
 
+To export HTML instead of Markdown, supply the format flag:
+
+```bash
+go run ./cmd/glyphctl -- report --input ./plugins/samples/findings.jsonl --format html --out ./out/report.html
+```
+
 The `internal/reporter` package powers the CLI and exposes helpers for other components that need Markdown summaries.


### PR DESCRIPTION
## Summary
- add a pure HTML renderer and shared summary helpers for report generation
- allow `glyphctl report` to choose between markdown and HTML output via a `--format` flag
- document the HTML export workflow in the scribe plugin README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d2a226f450832aa436ae1e19b6e31f