### PR TITLE
Add HTTP/2 support and WebSocket passthrough to proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/RowanDark/Glyph
 go 1.24.3
 
 require (
-        golang.org/x/net v0.41.0 // indirect
+        golang.org/x/net v0.41.0
         golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect

--- a/internal/e2e/galdr_h2_ws_test.go
+++ b/internal/e2e/galdr_h2_ws_test.go
@@ -1,0 +1,390 @@
+package e2e
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/proxy"
+)
+
+func TestGaldrProxyHTTP2HeaderRewrite(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor != 2 {
+			t.Errorf("expected HTTP/2 request, got %s", r.Proto)
+		}
+		w.Header().Set("Server", "h2-upstream")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	upstream.EnableHTTP2 = true
+	upstream.StartTLS()
+	t.Cleanup(upstream.Close)
+
+	cert := upstream.Certificate()
+	if cert == nil {
+		t.Fatal("upstream certificate missing")
+	}
+	pool := x509PoolFromCert(cert)
+
+	tempDir := t.TempDir()
+	rulesPath := writeTempFile(t, tempDir, "rules.json", `[{"name":"h2-rewrite","match":{"url_contains":"/"},"response":{"add_headers":{"X-Glyph":"on"},"remove_headers":["Server"]}}]`)
+
+	cfg := proxy.Config{
+		Addr:        "127.0.0.1:0",
+		RulesPath:   rulesPath,
+		HistoryPath: tempDir + "/history.jsonl",
+		CACertPath:  tempDir + "/ca.pem",
+		CAKeyPath:   tempDir + "/ca.key",
+		Logger:      newTestLogger(),
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool},
+		},
+	}
+
+	p, err := proxy.New(cfg)
+	if err != nil {
+		t.Fatalf("new proxy: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- p.Run(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil && err != context.Canceled {
+				t.Fatalf("proxy exited with error: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timeout waiting for proxy shutdown")
+		}
+	})
+
+	readyCtx, readyCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer readyCancel()
+	if err := p.WaitUntilReady(readyCtx); err != nil {
+		t.Fatalf("proxy not ready: %v", err)
+	}
+
+	proxyURL, _ := url.Parse("http://" + p.Addr())
+	caPool := x509PoolFromPEM(p.CACertificatePEM(), t)
+	client := &http.Client{Transport: &http.Transport{
+		Proxy:           http.ProxyURL(proxyURL),
+		TLSClientConfig: &tls.Config{RootCAs: caPool},
+	}, Timeout: 5 * time.Second}
+
+	resp, err := client.Get(upstream.URL + "/h2")
+	if err != nil {
+		t.Fatalf("request via proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.ReadAll(resp.Body)
+
+	if resp.Header.Get("X-Glyph") != "on" {
+		t.Fatalf("expected rewritten header, got %q", resp.Header.Get("X-Glyph"))
+	}
+	if resp.Header.Get("Server") != "" {
+		t.Fatalf("expected server header stripped, got %q", resp.Header.Get("Server"))
+	}
+}
+
+func TestGaldrProxyWebSocketPassthrough(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(webSocketEchoHandler(t)))
+	t.Cleanup(upstream.Close)
+
+	tempDir := t.TempDir()
+	cfg := proxy.Config{
+		Addr:        "127.0.0.1:0",
+		HistoryPath: tempDir + "/history.jsonl",
+		CACertPath:  tempDir + "/ca.pem",
+		CAKeyPath:   tempDir + "/ca.key",
+		Logger:      newTestLogger(),
+	}
+
+	p, err := proxy.New(cfg)
+	if err != nil {
+		t.Fatalf("new proxy: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- p.Run(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil && err != context.Canceled {
+				t.Fatalf("proxy exited with error: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timeout waiting for proxy shutdown")
+		}
+	})
+
+	readyCtx, readyCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer readyCancel()
+	if err := p.WaitUntilReady(readyCtx); err != nil {
+		t.Fatalf("proxy not ready: %v", err)
+	}
+
+	conn, err := net.Dial("tcp", p.Addr())
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer conn.Close()
+
+	wsURL := upstream.URL + "/echo"
+	parsed, err := url.Parse(wsURL)
+	if err != nil {
+		t.Fatalf("parse websocket url: %v", err)
+	}
+
+	key := generateWebSocketKey(t)
+	req := fmt.Sprintf("GET %s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: %s\r\nSec-WebSocket-Version: 13\r\nOrigin: http://example.com\r\n\r\n", wsURL, parsed.Host, key)
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatalf("write handshake: %v", err)
+	}
+
+	reader := bufio.NewReader(conn)
+	status, headers, err := readHTTPResponse(reader)
+	if err != nil {
+		t.Fatalf("read handshake response: %v", err)
+	}
+	if status != "101" {
+		t.Fatalf("unexpected status code %s", status)
+	}
+	expectedAccept := computeAcceptKey(key)
+	if headers.Get("Sec-WebSocket-Accept") != expectedAccept {
+		t.Fatalf("unexpected accept key %q", headers.Get("Sec-WebSocket-Accept"))
+	}
+
+	message := []byte("glyph")
+	if err := writeWebSocketFrame(conn, message); err != nil {
+		t.Fatalf("write websocket frame: %v", err)
+	}
+
+	echoed, err := readWebSocketFrame(reader)
+	if err != nil {
+		t.Fatalf("read websocket frame: %v", err)
+	}
+	if string(echoed) != string(message) {
+		t.Fatalf("echo mismatch: got %q want %q", string(echoed), string(message))
+	}
+}
+
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func writeTempFile(t *testing.T, dir, name, contents string) string {
+	t.Helper()
+	path := dir + "/" + name
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
+}
+
+func x509PoolFromCert(cert *x509.Certificate) *x509.CertPool {
+	pool := x509.NewCertPool()
+	pool.AddCert(cert)
+	return pool
+}
+
+func x509PoolFromPEM(pemBytes []byte, t *testing.T) *x509.CertPool {
+	t.Helper()
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pemBytes) {
+		t.Fatal("failed to append certificate")
+	}
+	return pool
+}
+
+func generateWebSocketKey(t *testing.T) string {
+	t.Helper()
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		t.Fatalf("generate websocket key: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(buf)
+}
+
+func computeAcceptKey(key string) string {
+	h := sha1.Sum([]byte(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+	return base64.StdEncoding.EncodeToString(h[:])
+}
+
+func readHTTPResponse(r *bufio.Reader) (string, http.Header, error) {
+	statusLine, err := r.ReadString('\n')
+	if err != nil {
+		return "", nil, err
+	}
+	statusLine = strings.TrimSpace(statusLine)
+	parts := strings.SplitN(statusLine, " ", 3)
+	if len(parts) < 2 {
+		return "", nil, fmt.Errorf("malformed status line: %q", statusLine)
+	}
+	status := parts[1]
+	headers := http.Header{}
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return "", nil, err
+		}
+		if line == "\r\n" {
+			break
+		}
+		line = strings.TrimSuffix(line, "\r\n")
+		headerParts := strings.SplitN(line, ":", 2)
+		if len(headerParts) != 2 {
+			return "", nil, fmt.Errorf("parse header line: %q", line)
+		}
+		key := headerParts[0]
+		value := strings.TrimSpace(headerParts[1])
+		headers.Add(key, value)
+	}
+	return status, headers, nil
+}
+
+func writeWebSocketFrame(conn net.Conn, payload []byte) error {
+	mask := make([]byte, 4)
+	if _, err := rand.Read(mask); err != nil {
+		return fmt.Errorf("generate mask: %w", err)
+	}
+	frame := []byte{0x81, byte(0x80 | len(payload))}
+	frame = append(frame, mask...)
+	masked := make([]byte, len(payload))
+	for i, b := range payload {
+		masked[i] = b ^ mask[i%4]
+	}
+	frame = append(frame, masked...)
+	_, err := conn.Write(frame)
+	return err
+}
+
+func readWebSocketFrame(r *bufio.Reader) ([]byte, error) {
+	header := make([]byte, 2)
+	if _, err := io.ReadFull(r, header); err != nil {
+		return nil, fmt.Errorf("read frame header: %w", err)
+	}
+	if header[0]&0x0f != 0x1 {
+		return nil, fmt.Errorf("unexpected opcode: %x", header[0])
+	}
+	if header[1]&0x80 != 0 {
+		return nil, fmt.Errorf("server frames must be unmasked")
+	}
+	length := int(header[1] & 0x7f)
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return nil, fmt.Errorf("read payload: %w", err)
+	}
+	return payload, nil
+}
+
+func readMaskedClientFrame(r *bufio.Reader) ([]byte, error) {
+	header := make([]byte, 2)
+	if _, err := io.ReadFull(r, header); err != nil {
+		return nil, fmt.Errorf("read masked frame header: %w", err)
+	}
+	if header[0]&0x0f != 0x1 {
+		return nil, fmt.Errorf("unexpected opcode: %x", header[0])
+	}
+	if header[1]&0x80 == 0 {
+		return nil, fmt.Errorf("client frames must be masked")
+	}
+	length := int(header[1] & 0x7f)
+	if length > 125 {
+		return nil, fmt.Errorf("client frame too large: %d", length)
+	}
+	mask := make([]byte, 4)
+	if _, err := io.ReadFull(r, mask); err != nil {
+		return nil, fmt.Errorf("read mask: %w", err)
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return nil, fmt.Errorf("read payload: %w", err)
+	}
+	for i := range payload {
+		payload[i] ^= mask[i%4]
+	}
+	return payload, nil
+}
+
+func webSocketEchoHandler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !isWebSocketUpgrade(r) {
+			http.Error(w, "upgrade required", http.StatusBadRequest)
+			return
+		}
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+			return
+		}
+		conn, buf, err := hijacker.Hijack()
+		if err != nil {
+			http.Error(w, "hijack failed", http.StatusInternalServerError)
+			return
+		}
+		key := r.Header.Get("Sec-WebSocket-Key")
+		if key == "" {
+			_ = conn.Close()
+			return
+		}
+		accept := computeAcceptKey(key)
+		response := fmt.Sprintf("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\n\r\n", accept)
+		if _, err := buf.WriteString(response); err != nil {
+			_ = conn.Close()
+			return
+		}
+		if err := buf.Flush(); err != nil {
+			_ = conn.Close()
+			return
+		}
+		reader := bufio.NewReader(conn)
+		payload, err := readMaskedClientFrame(reader)
+		if err != nil {
+			_ = conn.Close()
+			return
+		}
+		frame := append([]byte{0x81, byte(len(payload))}, payload...)
+		if _, err := conn.Write(frame); err != nil {
+			t.Logf("write echo: %v", err)
+		}
+		_ = conn.Close()
+	}
+}
+
+func isWebSocketUpgrade(r *http.Request) bool {
+	if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+		return false
+	}
+	return strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
+}

--- a/internal/proxy/h2.go
+++ b/internal/proxy/h2.go
@@ -1,0 +1,56 @@
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+
+	"golang.org/x/net/http2"
+)
+
+func configureHTTP2Transport(rt http.RoundTripper) error {
+	transport, ok := rt.(*http.Transport)
+	if !ok {
+		return nil
+	}
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{}
+	}
+	transport.TLSClientConfig.NextProtos = ensureNextProtos(transport.TLSClientConfig.NextProtos)
+	transport.ForceAttemptHTTP2 = true
+	return http2.ConfigureTransport(transport)
+}
+
+func ensureNextProtos(existing []string) []string {
+	hasH2 := false
+	hasHTTP1 := false
+	for _, proto := range existing {
+		switch proto {
+		case "h2":
+			hasH2 = true
+		case "http/1.1":
+			hasHTTP1 = true
+		}
+	}
+	if !hasH2 {
+		existing = append(existing, "h2")
+	}
+	if !hasHTTP1 {
+		existing = append(existing, "http/1.1")
+	}
+	return existing
+}
+
+func (p *Proxy) serveHTTP2(conn net.Conn, meta *connMetadata) {
+	defer conn.Close()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), connMetadataContextKey{}, meta)
+		r = r.WithContext(ctx)
+		p.ServeHTTP(w, r)
+	})
+
+	server := &http2.Server{}
+	server.ServeConn(conn, &http2.ServeConnOpts{Handler: handler})
+}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -25,7 +25,7 @@ type recordedRequest struct {
 }
 
 func newTestLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
+        return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 func waitErr(t *testing.T, ch <-chan error) {

--- a/internal/proxy/ws.go
+++ b/internal/proxy/ws.go
@@ -1,0 +1,21 @@
+package proxy
+
+import "net/http"
+
+func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	meta := connectionMetadataFromContext(r.Context())
+	scheme := ""
+	host := ""
+	clientAddr := r.RemoteAddr
+	if meta != nil {
+		scheme = meta.scheme
+		if meta.host != "" {
+			host = meta.host
+		}
+		if meta.clientAddr != "" {
+			clientAddr = meta.clientAddr
+		}
+	}
+
+	p.serveProxyRequest(w, r, scheme, host, clientAddr, false, false)
+}

--- a/plugins/galdr-proxy/README.md
+++ b/plugins/galdr-proxy/README.md
@@ -7,6 +7,9 @@ Galdr Proxy is the interception layer for Glyph. It terminates client HTTP/HTTPS
 - `CAP_HTTP_PASSIVE`
 - `CAP_WS`
 
+Galdr negotiates HTTP/2 for HTTPS interceptions and transparently forwards WebSocket upgrades so modern browsers can connect wi
+thout downgrades.
+
 ## Running the proxy service
 
 `glyphd` now embeds the proxy. Launch it with your authentication token and enable the interception layer:


### PR DESCRIPTION
## Summary
- configure proxy transports and TLS handling to negotiate HTTP/2 with clients and upstream servers
- refactor HTTPS request processing to reuse the reverse proxy pipeline and add a WebSocket passthrough handler
- add end-to-end coverage for HTTP/2 header rewrites and WebSocket echo behaviour and document the new capabilities

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d2b7ea7d48832aa18c93cc542cc96c