### PR TITLE
Improve proxy error handling and add fuzzing

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,20 @@
+name: Fuzz
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  go-fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Run fuzzers
+        run: |
+          set -euo pipefail
+          go test ./... -run=^$ -fuzz=Fuzz -fuzztime=20s

--- a/internal/proxy/proxy_error_test.go
+++ b/internal/proxy/proxy_error_test.go
@@ -1,0 +1,92 @@
+package proxy
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestProxyErrorSurface(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream url: %v", err)
+	}
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, nil))
+
+	proxy := &Proxy{transport: http.DefaultTransport, logger: logger}
+
+	originalModifier := proxyResponseModifier
+	proxyResponseModifier = func(pxy *Proxy, resp *http.Response, state *proxyFlowState) error {
+		if resp.Request.URL.Path == "/boom" {
+			return &RuleError{RuleID: "strip-server", Err: errors.New("demo failure")}
+		}
+		return defaultProxyResponseModifier(pxy, resp, state)
+	}
+	t.Cleanup(func() {
+		proxyResponseModifier = originalModifier
+	})
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		target := copyURL(r.URL)
+		target.Scheme = upstreamURL.Scheme
+		target.Host = upstreamURL.Host
+
+		state := &proxyFlowState{
+			applyRules:     true,
+			requestHeaders: r.Header.Clone(),
+			url:            target.String(),
+			protocol:       target.Scheme,
+			host:           target.Host,
+		}
+		rp := proxy.newReverseProxy(target, state)
+		rp.ServeHTTP(w, r)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	resOK, err := http.Get(server.URL + "/ok")
+	if err != nil {
+		t.Fatalf("request ok: %v", err)
+	}
+	_, _ = io.ReadAll(resOK.Body)
+	_ = resOK.Body.Close()
+	if resOK.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for ok path, got %d", resOK.StatusCode)
+	}
+
+	resFail, err := http.Get(server.URL + "/boom")
+	if err != nil {
+		t.Fatalf("request boom: %v", err)
+	}
+	_, _ = io.ReadAll(resFail.Body)
+	_ = resFail.Body.Close()
+	if resFail.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected 502 for boom path, got %d", resFail.StatusCode)
+	}
+
+	logs := logBuf.String()
+	if !strings.Contains(logs, "\"component\":\"galdr\"") {
+		t.Fatalf("expected component field in logs, got %s", logs)
+	}
+	if !strings.Contains(logs, "\"rule\":\"strip-server\"") {
+		t.Fatalf("expected rule id in logs, got %s", logs)
+	}
+	if !strings.Contains(logs, "\"url\":\"") || !strings.Contains(logs, "/boom\"") {
+		t.Fatalf("expected url field with path in logs, got %s", logs)
+	}
+}

--- a/internal/reporter/jsonl_fuzz_test.go
+++ b/internal/reporter/jsonl_fuzz_test.go
@@ -1,0 +1,30 @@
+package reporter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func FuzzJSONLReadAll(f *testing.F) {
+	valid := []byte("{\"id\":\"01HZXK4QAZ3ZKAB1Y7P5Z9Q4C4\",\"plugin\":\"p\",\"type\":\"t\",\"message\":\"m\",\"severity\":\"low\",\"detected_at\":\"2024-01-01T00:00:00Z\"}\n")
+	f.Add(valid)
+	f.Add([]byte("\n"))
+	f.Add([]byte("{bad json}\n"))
+	f.Add(append(valid, valid...))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "fuzz.jsonl")
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			t.Skip()
+		}
+
+		reporter := NewJSONL(path)
+		defer func() {
+			_ = reporter.Close()
+		}()
+
+		_, _ = reporter.ReadAll()
+	})
+}

--- a/internal/reporter/testdata/fuzz/FuzzJSONLReadAll/seed-blank
+++ b/internal/reporter/testdata/fuzz/FuzzJSONLReadAll/seed-blank
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("\n")

--- a/internal/reporter/testdata/fuzz/FuzzJSONLReadAll/seed-malformed
+++ b/internal/reporter/testdata/fuzz/FuzzJSONLReadAll/seed-malformed
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{bad json}\n")

--- a/internal/reporter/testdata/fuzz/FuzzJSONLReadAll/seed-valid
+++ b/internal/reporter/testdata/fuzz/FuzzJSONLReadAll/seed-valid
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"id\":\"01HZXK4QAZ3ZKAB1Y7P5Z9Q4C4\",\"plugin\":\"p\",\"type\":\"t\",\"message\":\"m\",\"severity\":\"low\",\"detected_at\":\"2024-01-01T00:00:00Z\"}\n")


### PR DESCRIPTION
## Summary
- wrap proxy ModifyResponse failures with contextual errors and emit structured 502 logs with rule identifiers
- add a regression test that injects a failing rule to ensure 502 responses and structured logging
- add a JSONL fuzz target with seed corpus and a manual GitHub Action to run go fuzzing

## Testing
- go test ./...
- go test -run TestProxyErrorSurface ./internal/proxy


------
https://chatgpt.com/codex/tasks/task_e_68d2ce4beaa4832a8b03b465a0b5ac65