### PR TITLE
Add raider fuzzer CLI and engine

### DIFF
--- a/cmd/glyphctl/main.go
+++ b/cmd/glyphctl/main.go
@@ -42,6 +42,8 @@ func main() {
 			fmt.Fprintf(os.Stderr, "unknown plugin subcommand: %s\n", args[1])
 			os.Exit(2)
 		}
+	case "raider":
+		os.Exit(runRaider(args[1:]))
 	case "version":
 		os.Exit(runVersion(args[1:]))
 	default:

--- a/cmd/glyphctl/raider.go
+++ b/cmd/glyphctl/raider.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/RowanDark/Glyph/internal/raider"
+)
+
+func runRaider(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "raider subcommand required")
+		return 2
+	}
+	switch args[0] {
+	case "run":
+		return runRaiderRun(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown raider subcommand: %s\n", args[0])
+		return 2
+	}
+}
+
+func runRaiderRun(args []string) int {
+	fs := flag.NewFlagSet("raider run", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	reqPath := fs.String("req", "", "path to the HTTP request template")
+	markerSpec := fs.String("positions", "{{}}", "marker delimiters for insertion points")
+	payloadSpec := fs.String("payload", "", "payload source (file, range, or comma separated list)")
+	concurrency := fs.Int("concurrency", 1, "number of concurrent workers")
+	rateSpec := fs.String("rate", "", "per-host rate limit (e.g. 5/s, 120/m)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if strings.TrimSpace(*reqPath) == "" {
+		fmt.Fprintln(os.Stderr, "--req is required")
+		return 2
+	}
+	if strings.TrimSpace(*payloadSpec) == "" {
+		fmt.Fprintln(os.Stderr, "--payload is required")
+		return 2
+	}
+
+	data, err := os.ReadFile(*reqPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read request template: %v\n", err)
+		return 1
+	}
+
+	markers, err := raider.ParseMarkers(*markerSpec)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parse positions: %v\n", err)
+		return 2
+	}
+
+	tpl, err := raider.ParseTemplate(string(data), markers)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parse template: %v\n", err)
+		return 1
+	}
+
+	payloads, err := raider.LoadPayloads(*payloadSpec)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load payloads: %v\n", err)
+		return 1
+	}
+
+	limit, err := parseRateLimit(*rateSpec)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parse rate: %v\n", err)
+		return 2
+	}
+
+	opts := []raider.EngineOption{
+		raider.WithConcurrency(*concurrency),
+		raider.WithRateLimit(limit),
+	}
+	engine := raider.NewEngine(tpl, payloads, opts...)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	go func() {
+		select {
+		case <-sigCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	encoder := jsonEncoder()
+	var mu sync.Mutex
+	err = engine.Run(ctx, func(res raider.Result) error {
+		mu.Lock()
+		defer mu.Unlock()
+		if err := encoder(res); err != nil {
+			cancel()
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "raider run failed: %v\n", err)
+		return 1
+	}
+
+	return 0
+}
+
+func parseRateLimit(spec string) (float64, error) {
+	trimmed := strings.TrimSpace(spec)
+	if trimmed == "" {
+		return 0, nil
+	}
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 2 {
+		return 0, fmt.Errorf("invalid rate format: expected <count>/<unit>")
+	}
+	count, err := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+	if err != nil || count <= 0 {
+		return 0, fmt.Errorf("invalid rate count")
+	}
+	unit := strings.ToLower(strings.TrimSpace(parts[1]))
+	switch unit {
+	case "s", "sec", "second", "seconds":
+		return count, nil
+	case "m", "min", "minute", "minutes":
+		return count / 60.0, nil
+	case "h", "hour", "hours":
+		return count / 3600.0, nil
+	default:
+		return 0, fmt.Errorf("unknown rate unit %q", unit)
+	}
+}
+
+func jsonEncoder() func(raider.Result) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetEscapeHTML(false)
+	return func(res raider.Result) error {
+		return enc.Encode(res)
+	}
+}

--- a/internal/e2e/raider_test.go
+++ b/internal/e2e/raider_test.go
@@ -1,0 +1,116 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/raider"
+)
+
+func TestGlyphctlRaiderRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping raider e2e in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	var (
+		mu   sync.Mutex
+		hits []time.Time
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		payload, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		hits = append(hits, time.Now())
+		mu.Unlock()
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	reqTemplate := fmt.Sprintf("POST %s HTTP/1.1\r\nHost: %s\r\nContent-Type: text/plain\r\n\r\nbody={{seed}}\r\n", srv.URL, srv.Listener.Addr().String())
+
+	tempDir := t.TempDir()
+	reqPath := filepath.Join(tempDir, "request.http")
+	if err := os.WriteFile(reqPath, []byte(reqTemplate), 0o600); err != nil {
+		t.Fatalf("write request template: %v", err)
+	}
+
+	payloads := []string{"alpha", "beta", "gamma"}
+	payloadPath := filepath.Join(tempDir, "payloads.txt")
+	if err := os.WriteFile(payloadPath, []byte(strings.Join(payloads, "\n")), 0o600); err != nil {
+		t.Fatalf("write payload file: %v", err)
+	}
+
+	root := repoRoot(t)
+	glyphctl := buildGlyphctl(ctx, t, root)
+
+	cmd := exec.CommandContext(ctx, glyphctl, "raider", "run", "--req", reqPath, "--positions", "{{}}", "--payload", payloadPath, "--concurrency", "3", "--rate", "2/s")
+	cmd.Dir = root
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	start := time.Now()
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("glyphctl raider run failed: %v\nstderr:\n%s", err, stderr.String())
+	}
+	duration := time.Since(start)
+
+	decoder := json.NewDecoder(&stdout)
+	var results []raider.Result
+	for decoder.More() {
+		var res raider.Result
+		if err := decoder.Decode(&res); err != nil {
+			t.Fatalf("decode result: %v", err)
+		}
+		results = append(results, res)
+	}
+
+	if len(results) != len(payloads) {
+		t.Fatalf("expected %d results, got %d", len(payloads), len(results))
+	}
+
+	if len(hits) != len(payloads) {
+		t.Fatalf("expected %d requests, got %d", len(payloads), len(hits))
+	}
+
+	counts := make(map[string]int, len(results))
+	for i, res := range results {
+		counts[res.Payload]++
+		if res.Status == "" {
+			t.Errorf("result %d missing status", i)
+		}
+	}
+	for _, payload := range payloads {
+		if counts[payload] == 0 {
+			t.Fatalf("missing payload %q in results", payload)
+		}
+	}
+
+	if len(hits) >= 2 {
+		total := hits[len(hits)-1].Sub(hits[0])
+		expected := time.Duration(float64(len(hits)-1) / 2.0 * float64(time.Second))
+		if total+150*time.Millisecond < expected {
+			t.Fatalf("requests completed too quickly (duration %v, expected at least %v)", total, expected)
+		}
+	}
+
+	if duration < 500*time.Millisecond {
+		t.Fatalf("run completed suspiciously fast: %v", duration)
+	}
+}

--- a/internal/raider/engine.go
+++ b/internal/raider/engine.go
@@ -1,0 +1,421 @@
+package raider
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultConcurrency  = 1
+	defaultCaptureBytes = 512
+	defaultBackoff      = time.Second
+)
+
+// Engine executes a fuzzing run against the supplied request template.
+type Engine struct {
+	template    *Template
+	payloads    []string
+	client      *http.Client
+	concurrency int
+	rate        float64
+	capture     int
+}
+
+// EngineOption configures the fuzzer execution behaviour.
+type EngineOption func(*Engine)
+
+// WithConcurrency overrides the worker pool size.
+func WithConcurrency(n int) EngineOption {
+	return func(e *Engine) {
+		if n > 0 {
+			e.concurrency = n
+		}
+	}
+}
+
+// WithRateLimit specifies the per-host request rate in requests per second.
+func WithRateLimit(limit float64) EngineOption {
+	return func(e *Engine) {
+		if limit > 0 {
+			e.rate = limit
+		}
+	}
+}
+
+// WithHTTPClient allows injecting a custom HTTP client.
+func WithHTTPClient(client *http.Client) EngineOption {
+	return func(e *Engine) {
+		if client != nil {
+			e.client = client
+		}
+	}
+}
+
+// WithCaptureLimit sets how many bytes of request/response bodies are
+// preserved in the output metadata.
+func WithCaptureLimit(limit int) EngineOption {
+	return func(e *Engine) {
+		if limit > 0 {
+			e.capture = limit
+		}
+	}
+}
+
+// NewEngine constructs a new Engine for the provided template and payloads.
+func NewEngine(tpl *Template, payloads []string, opts ...EngineOption) *Engine {
+	e := &Engine{template: tpl, payloads: append([]string(nil), payloads...), concurrency: defaultConcurrency, capture: defaultCaptureBytes}
+	e.client = &http.Client{Timeout: 30 * time.Second}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+type job struct {
+	position Position
+	payload  string
+}
+
+type hostState struct {
+	mu      sync.Mutex
+	rate    float64
+	next    time.Time
+	backoff time.Time
+}
+
+func (s *hostState) wait(ctx context.Context) error {
+	s.mu.Lock()
+	now := time.Now()
+	waitUntil := now
+	var interval time.Duration
+	if s.rate > 0 {
+		interval = time.Duration(float64(time.Second) / s.rate)
+		if interval <= 0 {
+			interval = time.Nanosecond
+		}
+		if now.Before(s.next) {
+			waitUntil = s.next
+		}
+		if waitUntil.Before(now) {
+			waitUntil = now
+		}
+		s.next = waitUntil.Add(interval)
+	}
+	if s.backoff.After(waitUntil) {
+		waitUntil = s.backoff
+		if interval > 0 {
+			s.next = waitUntil.Add(interval)
+		}
+	}
+	s.mu.Unlock()
+
+	sleep := time.Until(waitUntil)
+	if sleep <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(sleep)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+	}
+	return nil
+}
+
+func (s *hostState) backoffFor(d time.Duration) {
+	if d <= 0 {
+		d = defaultBackoff
+	}
+	s.mu.Lock()
+	until := time.Now().Add(d)
+	if until.After(s.backoff) {
+		s.backoff = until
+	}
+	s.mu.Unlock()
+}
+
+// Result captures the outcome for a single request/response pair.
+type Result struct {
+	Position Position        `json:"position"`
+	Payload  string          `json:"payload"`
+	Request  MessageSnapshot `json:"request"`
+	Response MessageSnapshot `json:"response"`
+	Status   string          `json:"status"`
+	Duration int64           `json:"duration_ms"`
+	Error    string          `json:"error,omitempty"`
+	Time     time.Time       `json:"time"`
+}
+
+// MessageSnapshot stores the truncated details for a HTTP message.
+type MessageSnapshot struct {
+	Method  string            `json:"method,omitempty"`
+	URL     string            `json:"url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Body    string            `json:"body,omitempty"`
+}
+
+// Run executes the fuzzing workflow. For each request result the callback is
+// invoked. Returning an error from the callback aborts the run.
+func (e *Engine) Run(ctx context.Context, cb func(Result) error) error {
+	if e.template == nil {
+		return errors.New("template is required")
+	}
+	if len(e.payloads) == 0 {
+		return errors.New("at least one payload is required")
+	}
+
+	positions := e.template.Positions()
+	if len(positions) == 0 {
+		return errors.New("no insertion points found in template")
+	}
+
+	jobs := make(chan job)
+	var wg sync.WaitGroup
+	hostStates := sync.Map{}
+
+	workers := e.concurrency
+	if workers < 1 {
+		workers = defaultConcurrency
+	}
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := range jobs {
+				res := e.execute(ctx, &hostStates, j)
+				if cb != nil {
+					if err := cb(res); err != nil {
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	go func() {
+		defer close(jobs)
+		for _, pos := range positions {
+			for _, payload := range e.payloads {
+				select {
+				case <-ctx.Done():
+					return
+				case jobs <- job{position: pos, payload: payload}:
+				}
+			}
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+		<-done
+		return ctx.Err()
+	case <-done:
+		return nil
+	}
+}
+
+func (e *Engine) execute(ctx context.Context, states *sync.Map, j job) Result {
+	rendered := e.template.RenderWith(j.position.Index, j.payload)
+	req, body, err := buildRequest(ctx, rendered)
+	if err != nil {
+		return Result{Position: j.position, Payload: j.payload, Error: err.Error(), Time: time.Now().UTC()}
+	}
+
+	host := requestHost(req)
+	state := getHostState(states, host, e.rate)
+	if err := state.wait(ctx); err != nil {
+		return Result{Position: j.position, Payload: j.payload, Error: err.Error(), Time: time.Now().UTC()}
+	}
+
+	start := time.Now()
+	resp, err := e.client.Do(req)
+	duration := time.Since(start)
+
+	result := Result{
+		Position: j.position,
+		Payload:  j.payload,
+		Duration: duration.Milliseconds(),
+		Time:     time.Now().UTC(),
+		Request:  snapshotRequest(req, body, e.capture),
+	}
+
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	defer resp.Body.Close()
+
+	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, int64(e.capture)))
+	result.Response = snapshotResponse(resp, string(responseBody), e.capture)
+	result.Status = resp.Status
+
+	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
+		backoff := parseRetryAfter(resp.Header.Get("Retry-After"))
+		state.backoffFor(backoff)
+	}
+
+	return result
+}
+
+func buildRequest(ctx context.Context, raw string) (*http.Request, []byte, error) {
+	reader := bufio.NewReader(strings.NewReader(raw))
+	req, err := http.ReadRequest(reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse request: %w", err)
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read request body: %w", err)
+	}
+	_ = req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	req.ContentLength = int64(len(body))
+
+	if req.URL.Scheme == "" {
+		if strings.HasPrefix(req.RequestURI, "http://") || strings.HasPrefix(req.RequestURI, "https://") {
+			parsed, err := url.Parse(req.RequestURI)
+			if err != nil {
+				return nil, nil, fmt.Errorf("parse request url: %w", err)
+			}
+			req.URL = parsed
+		} else {
+			host := req.Host
+			if host == "" {
+				host = req.Header.Get("Host")
+			}
+			if host == "" {
+				return nil, nil, errors.New("request missing host header")
+			}
+			req.URL = &url.URL{Scheme: "http", Host: host, Path: req.RequestURI}
+		}
+	}
+
+	if req.Host == "" {
+		req.Host = req.URL.Host
+	}
+
+	req.RequestURI = ""
+	return req.WithContext(ctx), body, nil
+}
+
+func getHostState(states *sync.Map, host string, rate float64) *hostState {
+	if host == "" {
+		host = "default"
+	}
+	actual, _ := states.LoadOrStore(host, &hostState{rate: rate})
+	state := actual.(*hostState)
+	if rate > 0 {
+		state.mu.Lock()
+		state.rate = rate
+		state.mu.Unlock()
+	}
+	return state
+}
+
+func requestHost(req *http.Request) string {
+	if req == nil {
+		return ""
+	}
+	if req.URL != nil && req.URL.Host != "" {
+		return req.URL.Host
+	}
+	return req.Host
+}
+
+func snapshotRequest(req *http.Request, body []byte, limit int) MessageSnapshot {
+	snap := MessageSnapshot{}
+	if req == nil {
+		return snap
+	}
+	snap.Method = req.Method
+	if req.URL != nil {
+		snap.URL = req.URL.String()
+	}
+	snap.Headers = flattenHeaders(req.Header)
+	if len(body) > 0 {
+		snap.Body = truncate(string(body), limit)
+	}
+	return snap
+}
+
+func snapshotResponse(resp *http.Response, body string, limit int) MessageSnapshot {
+	snap := MessageSnapshot{Headers: flattenHeaders(resp.Header)}
+	if resp.Request != nil {
+		snap.Method = resp.Request.Method
+		if resp.Request.URL != nil {
+			snap.URL = resp.Request.URL.String()
+		}
+	}
+	snap.Body = truncate(body, limit)
+	return snap
+}
+
+func flattenHeaders(h http.Header) map[string]string {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(h))
+	for k, v := range h {
+		out[k] = strings.Join(v, "; ")
+	}
+	return out
+}
+
+func truncate(body string, limit int) string {
+	if limit <= 0 || len(body) <= limit {
+		return body
+	}
+	if limit < 3 {
+		return body[:limit]
+	}
+	return body[:limit-3] + "..."
+}
+
+func parseRetryAfter(header string) time.Duration {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return defaultBackoff
+	}
+	if secs, err := strconv.Atoi(header); err == nil {
+		if secs <= 0 {
+			return defaultBackoff
+		}
+		return time.Duration(secs) * time.Second
+	}
+	if ts, err := http.ParseTime(header); err == nil {
+		now := time.Now()
+		if ts.After(now) {
+			return ts.Sub(now)
+		}
+	}
+	return defaultBackoff
+}
+
+// EncodeResult writes the result as a JSONL line to the provided writer.
+func EncodeResult(w io.Writer, res Result) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(res)
+}

--- a/internal/raider/engine_test.go
+++ b/internal/raider/engine_test.go
@@ -1,0 +1,53 @@
+package raider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestEngineRespectsRateLimit(t *testing.T) {
+	var times []time.Time
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		times = append(times, time.Now())
+		time.Sleep(10 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	markers, err := ParseMarkers("{{}}")
+	if err != nil {
+		t.Fatalf("parse markers: %v", err)
+	}
+
+	template := "POST " + srv.URL + " HTTP/1.1\nContent-Type: text/plain\n\nvalue={{seed}}"
+	tpl, err := ParseTemplate(template, markers)
+	if err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+
+	payloads := []string{"1", "2", "3", "4"}
+	limit := 2.0 // 2 requests per second
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	engine := NewEngine(tpl, payloads, WithConcurrency(4), WithRateLimit(limit))
+	if err := engine.Run(ctx, func(Result) error { return nil }); err != nil {
+		t.Fatalf("engine run failed: %v", err)
+	}
+
+	if len(times) != len(payloads) {
+		t.Fatalf("expected %d requests, got %d", len(payloads), len(times))
+	}
+
+	if len(times) >= 2 {
+		total := times[len(times)-1].Sub(times[0])
+		expected := time.Duration(float64(len(times)-1) / limit * float64(time.Second))
+		if total+100*time.Millisecond < expected {
+			t.Fatalf("requests completed too quickly: got %v, expected at least %v", total, expected)
+		}
+	}
+}

--- a/internal/raider/payload.go
+++ b/internal/raider/payload.go
@@ -1,0 +1,98 @@
+package raider
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// LoadPayloads expands the payload specification into a concrete slice used
+// during fuzzing. The specification can reference a file, a numeric range or a
+// comma separated word list.
+func LoadPayloads(spec string) ([]string, error) {
+	trimmed := strings.TrimSpace(spec)
+	if trimmed == "" {
+		return nil, fmt.Errorf("payload specification is required")
+	}
+
+	if exists(trimmed) {
+		return readPayloadFile(trimmed)
+	}
+
+	if values, ok := parseNumericRange(trimmed); ok {
+		return values, nil
+	}
+
+	return parseWordList(trimmed), nil
+}
+
+func exists(path string) bool {
+	if _, err := os.Stat(path); err == nil {
+		return true
+	}
+	return false
+}
+
+func readPayloadFile(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open payload file: %w", err)
+	}
+	defer file.Close()
+
+	var values []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimRight(scanner.Text(), "\r\n")
+		if line == "" {
+			continue
+		}
+		values = append(values, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read payload file: %w", err)
+	}
+	if len(values) == 0 {
+		return nil, fmt.Errorf("payload file %s contained no values", filepath.Base(path))
+	}
+	return values, nil
+}
+
+func parseNumericRange(input string) ([]string, bool) {
+	parts := strings.Split(input, "-")
+	if len(parts) != 2 {
+		return nil, false
+	}
+	start, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return nil, false
+	}
+	end, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil || end < start {
+		return nil, false
+	}
+	values := make([]string, 0, end-start+1)
+	for i := start; i <= end; i++ {
+		values = append(values, strconv.Itoa(i))
+	}
+	return values, true
+}
+
+func parseWordList(input string) []string {
+	if !strings.Contains(input, ",") {
+		return []string{input}
+	}
+	parts := strings.Split(input, ",")
+	values := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed == "" {
+			continue
+		}
+		values = append(values, trimmed)
+	}
+	return values
+}

--- a/internal/raider/payload_test.go
+++ b/internal/raider/payload_test.go
@@ -1,0 +1,55 @@
+package raider
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadPayloadsFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "payloads.txt")
+	if err := os.WriteFile(path, []byte("one\ntwo\n"), 0o600); err != nil {
+		t.Fatalf("write payload file: %v", err)
+	}
+
+	values, err := LoadPayloads(path)
+	if err != nil {
+		t.Fatalf("load payloads: %v", err)
+	}
+	if len(values) != 2 || values[0] != "one" || values[1] != "two" {
+		t.Fatalf("unexpected payloads: %#v", values)
+	}
+}
+
+func TestLoadPayloadsRange(t *testing.T) {
+	values, err := LoadPayloads("3-5")
+	if err != nil {
+		t.Fatalf("load payloads: %v", err)
+	}
+	expected := []string{"3", "4", "5"}
+	if len(values) != len(expected) {
+		t.Fatalf("expected %d values, got %d", len(expected), len(values))
+	}
+	for i, v := range expected {
+		if values[i] != v {
+			t.Fatalf("unexpected value at %d: %q", i, values[i])
+		}
+	}
+}
+
+func TestLoadPayloadsWordList(t *testing.T) {
+	values, err := LoadPayloads("alpha,beta , gamma")
+	if err != nil {
+		t.Fatalf("load payloads: %v", err)
+	}
+	expected := []string{"alpha", "beta", "gamma"}
+	if len(values) != len(expected) {
+		t.Fatalf("expected %d values, got %d", len(expected), len(values))
+	}
+	for i, v := range expected {
+		if values[i] != v {
+			t.Fatalf("unexpected value at %d: %q", i, values[i])
+		}
+	}
+}

--- a/internal/raider/template.go
+++ b/internal/raider/template.go
@@ -1,0 +1,128 @@
+package raider
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Markers defines the delimiters used to mark payload insertion points.
+type Markers struct {
+	Open  string
+	Close string
+}
+
+// ParseMarkers interprets a specification describing the opening and closing
+// marker delimiters. The default markers are "{{" and "}}".
+func ParseMarkers(spec string) (Markers, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return Markers{Open: "{{", Close: "}}"}, nil
+	}
+	if strings.Contains(spec, " ") {
+		parts := strings.Fields(spec)
+		if len(parts) != 2 {
+			return Markers{}, fmt.Errorf("positions must contain exactly two markers")
+		}
+		return Markers{Open: parts[0], Close: parts[1]}, nil
+	}
+	if len(spec)%2 != 0 {
+		return Markers{}, fmt.Errorf("positions marker %q must have even length or be two space separated tokens", spec)
+	}
+	half := len(spec) / 2
+	return Markers{Open: spec[:half], Close: spec[half:]}, nil
+}
+
+// Position describes a placeholder found in the request template.
+type Position struct {
+	Index   int
+	Name    string
+	Default string
+}
+
+type segment struct {
+	literal  string
+	position int
+}
+
+// Template represents a parsed request template with tracked payload
+// placeholders.
+type Template struct {
+	segments  []segment
+	positions []Position
+}
+
+// Positions returns the placeholders discovered in the template.
+func (t *Template) Positions() []Position {
+	result := make([]Position, len(t.positions))
+	copy(result, t.positions)
+	return result
+}
+
+// RenderWith replaces the placeholder at the provided index with the supplied
+// payload while leaving other placeholders at their default values.
+func (t *Template) RenderWith(position int, payload string) string {
+	var builder strings.Builder
+	for _, seg := range t.segments {
+		if seg.position < 0 {
+			builder.WriteString(seg.literal)
+			continue
+		}
+		pos := t.positions[seg.position]
+		if pos.Index == position {
+			builder.WriteString(payload)
+		} else {
+			builder.WriteString(pos.Default)
+		}
+	}
+	return builder.String()
+}
+
+// RenderDefault returns the template with all placeholders replaced by their
+// default values.
+func (t *Template) RenderDefault() string {
+	var builder strings.Builder
+	for _, seg := range t.segments {
+		if seg.position < 0 {
+			builder.WriteString(seg.literal)
+		} else {
+			builder.WriteString(t.positions[seg.position].Default)
+		}
+	}
+	return builder.String()
+}
+
+// ParseTemplate identifies the insertion points in the provided request
+// template according to the supplied marker delimiters.
+func ParseTemplate(input string, markers Markers) (*Template, error) {
+	if markers.Open == "" || markers.Close == "" {
+		return nil, fmt.Errorf("markers must not be empty")
+	}
+
+	var segments []segment
+	var positions []Position
+	cursor := 0
+	for cursor < len(input) {
+		start := strings.Index(input[cursor:], markers.Open)
+		if start == -1 {
+			segments = append(segments, segment{literal: input[cursor:], position: -1})
+			break
+		}
+		start += cursor
+		if start > cursor {
+			segments = append(segments, segment{literal: input[cursor:start], position: -1})
+		}
+		end := strings.Index(input[start+len(markers.Open):], markers.Close)
+		if end == -1 {
+			return nil, fmt.Errorf("unclosed marker starting at offset %d", start)
+		}
+		end += start + len(markers.Open)
+		name := input[start+len(markers.Open) : end]
+		trimmed := strings.TrimSpace(name)
+		pos := Position{Index: len(positions), Name: trimmed, Default: name}
+		positions = append(positions, pos)
+		segments = append(segments, segment{position: len(positions) - 1})
+		cursor = end + len(markers.Close)
+	}
+
+	return &Template{segments: segments, positions: positions}, nil
+}

--- a/internal/raider/template_test.go
+++ b/internal/raider/template_test.go
@@ -1,0 +1,36 @@
+package raider
+
+import "testing"
+
+func TestParseTemplatePositions(t *testing.T) {
+	markers, err := ParseMarkers("{{}}")
+	if err != nil {
+		t.Fatalf("parse markers: %v", err)
+	}
+
+	raw := "POST /test HTTP/1.1\nHost: example.com\n\nfield={{ value }}&other={{second}}"
+	tpl, err := ParseTemplate(raw, markers)
+	if err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+
+	positions := tpl.Positions()
+	if len(positions) != 2 {
+		t.Fatalf("expected 2 positions, got %d", len(positions))
+	}
+	if positions[0].Name != "value" {
+		t.Errorf("unexpected first position name %q", positions[0].Name)
+	}
+	if positions[0].Default != " value " {
+		t.Errorf("unexpected first default %q", positions[0].Default)
+	}
+	if positions[1].Name != "second" {
+		t.Errorf("unexpected second position name %q", positions[1].Name)
+	}
+
+	rendered := tpl.RenderWith(0, "FUZZ")
+	want := "POST /test HTTP/1.1\nHost: example.com\n\nfield=FUZZ&other=second"
+	if rendered != want {
+		t.Fatalf("rendered mismatch:\nwant: %q\n got: %q", want, rendered)
+	}
+}


### PR DESCRIPTION
## Summary
- add a `glyphctl raider run` subcommand that reads request templates and payload specifications before delegating to the fuzzer engine
- implement the `internal/raider` package to parse insertion markers, expand payload sources, execute rate-limited requests, and emit findings-style JSON lines
- cover the new behaviour with parser/payload/unit tests and an end-to-end echo-server fuzzing test

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d2db0ef9c8832abb9b6921f0768fae