### PR TITLE
Add glyphctl history search and repeater

### DIFF
--- a/cmd/glyphctl/history.go
+++ b/cmd/glyphctl/history.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/RowanDark/Glyph/internal/history"
+)
+
+func runHistorySearch(args []string) int {
+	fs := flag.NewFlagSet("history search", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	historyPath := fs.String("history", history.DefaultPath(), "path to the proxy history JSONL log")
+	query := fs.String("q", "", "search query (e.g. host:example.com method:POST)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	idx, err := history.Load(*historyPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load history: %v\n", err)
+		return 1
+	}
+
+	results, err := idx.Search(*query)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "search history: %v\n", err)
+		return 1
+	}
+
+	for _, result := range results {
+		fmt.Fprintln(os.Stdout, strings.TrimSpace(result.ID))
+	}
+
+	return 0
+}

--- a/cmd/glyphctl/history_test.go
+++ b/cmd/glyphctl/history_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/history"
+	"github.com/RowanDark/Glyph/internal/proxy"
+)
+
+func TestRunHistorySearchPrintsIDs(t *testing.T) {
+	tempDir := t.TempDir()
+	historyPath := filepath.Join(tempDir, "history.jsonl")
+
+	entries := []proxy.HistoryEntry{
+		{
+			Timestamp: time.Now().UTC(),
+			Protocol:  "https",
+			Method:    "GET",
+			URL:       "https://example.com/login",
+		},
+		{
+			Timestamp: time.Now().UTC(),
+			Protocol:  "https",
+			Method:    "POST",
+			URL:       "https://example.com/login",
+		},
+	}
+	for _, entry := range entries {
+		if err := history.Append(historyPath, entry); err != nil {
+			t.Fatalf("append history: %v", err)
+		}
+	}
+
+	output, code := captureStdout(t, func() int {
+		return runHistorySearch([]string{"--history", historyPath, "--q", "method:POST"})
+	})
+	if code != 0 {
+		t.Fatalf("runHistorySearch exit code = %d", code)
+	}
+	lines := strings.Fields(output)
+	if len(lines) != 1 || lines[0] != "2" {
+		t.Fatalf("expected to print ID 2, got %q", output)
+	}
+}
+
+func captureStdout(t *testing.T, fn func() int) (string, int) {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	code := fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	os.Stdout = old
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close reader: %v", err)
+	}
+	return string(data), code
+}

--- a/cmd/glyphctl/main.go
+++ b/cmd/glyphctl/main.go
@@ -44,6 +44,30 @@ func main() {
 		}
 	case "raider":
 		os.Exit(runRaider(args[1:]))
+	case "history":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "history subcommand required")
+			os.Exit(2)
+		}
+		switch args[1] {
+		case "search":
+			os.Exit(runHistorySearch(args[2:]))
+		default:
+			fmt.Fprintf(os.Stderr, "unknown history subcommand: %s\n", args[1])
+			os.Exit(2)
+		}
+	case "repeater":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "repeater subcommand required")
+			os.Exit(2)
+		}
+		switch args[1] {
+		case "send":
+			os.Exit(runRepeaterSend(args[2:]))
+		default:
+			fmt.Fprintf(os.Stderr, "unknown repeater subcommand: %s\n", args[1])
+			os.Exit(2)
+		}
 	case "version":
 		os.Exit(runVersion(args[1:]))
 	default:

--- a/cmd/glyphctl/repeater.go
+++ b/cmd/glyphctl/repeater.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/history"
+	"github.com/RowanDark/Glyph/internal/proxy"
+)
+
+type setArgs []string
+
+func (s *setArgs) String() string {
+	if s == nil {
+		return ""
+	}
+	return strings.Join(*s, ",")
+}
+
+func (s *setArgs) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
+
+func runRepeaterSend(args []string) int {
+	fs := flag.NewFlagSet("repeater send", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	historyPath := fs.String("history", history.DefaultPath(), "path to the proxy history JSONL log")
+	id := fs.String("id", "", "history entry identifier to replay")
+	bodyOverride := fs.String("set-body", "", "override request body (prefix with @ to read from file)")
+	timeout := fs.Duration("timeout", 30*time.Second, "request timeout")
+	var overrides setArgs
+	fs.Var(&overrides, "set", "override request attributes (e.g. Header:X-Token=value)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	trimmedID := strings.TrimSpace(*id)
+	if trimmedID == "" {
+		fmt.Fprintln(os.Stderr, "--id must be provided")
+		return 2
+	}
+
+	idx, err := history.Load(*historyPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load history: %v\n", err)
+		return 1
+	}
+	record, ok := idx.Entry(trimmedID)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "history entry %s not found\n", trimmedID)
+		return 1
+	}
+
+	headers := normaliseHeaderMap(record.Record.RequestHeaders)
+	body, err := readBodyOverride(*bodyOverride)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "set body: %v\n", err)
+		return 2
+	}
+
+	for _, raw := range overrides {
+		op, err := parseSetOperation(raw)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid --set value %q: %v\n", raw, err)
+			return 2
+		}
+		applySetOperation(headers, op)
+	}
+
+	updateContentLength(headers, len(body))
+
+	req, err := buildRequest(record.Record, headers, body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "build request: %v\n", err)
+		return 1
+	}
+
+	client := &http.Client{Timeout: *timeout}
+	start := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "replay request: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read response: %v\n", err)
+		return 1
+	}
+	latency := time.Since(start)
+
+	clientIP := clientAddress(resp.Request)
+	historyEntry := proxy.HistoryEntry{
+		Timestamp:       time.Now().UTC(),
+		ClientIP:        clientIP,
+		Protocol:        strings.ToUpper(req.URL.Scheme),
+		Method:          strings.ToUpper(req.Method),
+		URL:             req.URL.String(),
+		StatusCode:      resp.StatusCode,
+		LatencyMillis:   latency.Milliseconds(),
+		RequestSize:     len(body),
+		ResponseSize:    len(respBody),
+		RequestHeaders:  captureRequestHeaders(req),
+		ResponseHeaders: cloneHTTPHeader(resp.Header),
+	}
+
+	if err := history.Append(*historyPath, historyEntry); err != nil {
+		fmt.Fprintf(os.Stderr, "append history: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(os.Stdout, "%s %s -> %d (%d ms)\n", strings.ToUpper(req.Method), req.URL.String(), resp.StatusCode, latency.Milliseconds())
+	return 0
+}
+
+func readBodyOverride(raw string) ([]byte, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	trimmed := strings.TrimSpace(raw)
+	if strings.HasPrefix(trimmed, "@") {
+		path := strings.TrimSpace(trimmed[1:])
+		if path == "" {
+			return nil, errors.New("body file path missing after @")
+		}
+		data, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			return nil, fmt.Errorf("read body file: %w", err)
+		}
+		return data, nil
+	}
+	return []byte(raw), nil
+}
+
+func parseSetOperation(raw string) (setOperation, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return setOperation{}, errors.New("empty override")
+	}
+	parts := strings.SplitN(trimmed, ":", 2)
+	if len(parts) != 2 {
+		return setOperation{}, errors.New("expected format key:value")
+	}
+	key := strings.ToLower(strings.TrimSpace(parts[0]))
+	rest := parts[1]
+	switch key {
+	case "header":
+		nameValue := strings.SplitN(rest, "=", 2)
+		if len(nameValue) != 2 {
+			return setOperation{}, errors.New("expected Header:Name=value")
+		}
+		name := strings.TrimSpace(nameValue[0])
+		if name == "" {
+			return setOperation{}, errors.New("header name missing")
+		}
+		value := strings.TrimSpace(nameValue[1])
+		return setOperation{kind: key, name: name, value: value}, nil
+	default:
+		return setOperation{}, fmt.Errorf("unknown override %q", key)
+	}
+}
+
+func applySetOperation(headers map[string][]string, op setOperation) {
+	if headers == nil {
+		return
+	}
+	switch op.kind {
+	case "header":
+		canonical := http.CanonicalHeaderKey(op.name)
+		headers[canonical] = []string{op.value}
+	}
+}
+
+func updateContentLength(headers map[string][]string, size int) {
+	if headers == nil {
+		return
+	}
+	headers["Content-Length"] = []string{strconv.Itoa(size)}
+}
+
+func buildRequest(entry proxy.HistoryEntry, headers map[string][]string, body []byte) (*http.Request, error) {
+	var reader io.Reader
+	if len(body) > 0 {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(entry.Method, entry.URL, reader)
+	if err != nil {
+		return nil, err
+	}
+	applyHeaders(req, headers)
+	if reader == nil {
+		req.ContentLength = 0
+	} else {
+		req.ContentLength = int64(len(body))
+	}
+	return req, nil
+}
+
+func applyHeaders(req *http.Request, headers map[string][]string) {
+	if headers == nil {
+		return
+	}
+	host := ""
+	req.Header = make(http.Header)
+	for name, values := range headers {
+		if strings.EqualFold(name, "Host") {
+			if len(values) > 0 {
+				host = values[0]
+			}
+			continue
+		}
+		canonical := http.CanonicalHeaderKey(name)
+		for _, value := range values {
+			req.Header.Add(canonical, value)
+		}
+	}
+	if host != "" {
+		req.Host = host
+	}
+}
+
+func captureRequestHeaders(req *http.Request) map[string][]string {
+	if req == nil {
+		return nil
+	}
+	result := make(map[string][]string, len(req.Header)+1)
+	for name, values := range req.Header {
+		result[name] = append([]string(nil), values...)
+	}
+	if req.Host != "" {
+		result["Host"] = []string{req.Host}
+	}
+	return result
+}
+
+func cloneHTTPHeader(headers http.Header) map[string][]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	result := make(map[string][]string, len(headers))
+	for name, values := range headers {
+		result[name] = append([]string(nil), values...)
+	}
+	return result
+}
+
+func normaliseHeaderMap(in map[string][]string) map[string][]string {
+	if len(in) == 0 {
+		return make(map[string][]string)
+	}
+	result := make(map[string][]string, len(in))
+	for name, values := range in {
+		canonical := http.CanonicalHeaderKey(name)
+		result[canonical] = append([]string(nil), values...)
+	}
+	return result
+}
+
+func clientAddress(req *http.Request) string {
+	if req == nil {
+		return ""
+	}
+	addr, ok := req.Context().Value(http.LocalAddrContextKey).(net.Addr)
+	if !ok || addr == nil {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return addr.String()
+	}
+	return host
+}
+
+type setOperation struct {
+	kind  string
+	name  string
+	value string
+}

--- a/cmd/glyphctl/repeater_test.go
+++ b/cmd/glyphctl/repeater_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/history"
+	"github.com/RowanDark/Glyph/internal/proxy"
+)
+
+type capturedRequest struct {
+	header http.Header
+	host   string
+	body   []byte
+}
+
+func TestRepeaterSendOverridesHeadersAndAppendsHistory(t *testing.T) {
+	t.Helper()
+
+	captureCh := make(chan capturedRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		captureCh <- capturedRequest{header: r.Header.Clone(), host: r.Host, body: data}
+		w.Header().Set("X-From-Server", "replayed")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL + "/demo")
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+
+	tempDir := t.TempDir()
+	historyPath := filepath.Join(tempDir, "history.jsonl")
+
+	initial := proxy.HistoryEntry{
+		Timestamp: time.Now().UTC(),
+		Protocol:  "http",
+		Method:    "POST",
+		URL:       parsedURL.String(),
+		RequestHeaders: map[string][]string{
+			"Host":         []string{parsedURL.Host},
+			"Content-Type": []string{"application/json"},
+		},
+	}
+	if err := history.Append(historyPath, initial); err != nil {
+		t.Fatalf("write initial history: %v", err)
+	}
+
+	payload := []byte(`{"override":true}`)
+	bodyPath := filepath.Join(tempDir, "body.json")
+	if err := os.WriteFile(bodyPath, payload, 0o600); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	exitCode := runRepeaterSend([]string{
+		"--history", historyPath,
+		"--id", "1",
+		"--set", "Header:X-Token=override",
+		"--set-body", "@" + bodyPath,
+	})
+	if exitCode != 0 {
+		t.Fatalf("runRepeaterSend exit code = %d", exitCode)
+	}
+
+	var captured capturedRequest
+	select {
+	case captured = <-captureCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for replayed request")
+	}
+
+	if got := captured.header.Get("X-Token"); got != "override" {
+		t.Fatalf("expected X-Token header = override, got %q", got)
+	}
+	if captured.host != parsedURL.Host {
+		t.Fatalf("expected host %q, got %q", parsedURL.Host, captured.host)
+	}
+	if string(captured.body) != string(payload) {
+		t.Fatalf("unexpected request body: %q", string(captured.body))
+	}
+	if got := captured.header.Get("Content-Length"); got != strconv.Itoa(len(payload)) {
+		t.Fatalf("expected Content-Length %d, got %q", len(payload), got)
+	}
+
+	idx, err := history.Load(historyPath)
+	if err != nil {
+		t.Fatalf("reload history: %v", err)
+	}
+	entries := idx.Entries()
+	if len(entries) != 2 {
+		t.Fatalf("expected two history entries, got %d", len(entries))
+	}
+
+	latest := entries[1]
+	if latest.ID != "2" {
+		t.Fatalf("expected replay ID 2, got %s", latest.ID)
+	}
+	record := latest.Record
+	if record.StatusCode != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d", http.StatusCreated, record.StatusCode)
+	}
+	if record.RequestHeaders["X-Token"][0] != "override" {
+		t.Fatalf("history did not capture header override: %#v", record.RequestHeaders)
+	}
+	if record.RequestSize != len(payload) {
+		t.Fatalf("expected request size %d, got %d", len(payload), record.RequestSize)
+	}
+	if record.ResponseSize != 2 {
+		t.Fatalf("expected response size 2, got %d", record.ResponseSize)
+	}
+	if record.ResponseHeaders["X-From-Server"][0] != "replayed" {
+		t.Fatalf("expected response header recorded, got %#v", record.ResponseHeaders)
+	}
+	if !strings.EqualFold(record.Method, "POST") {
+		t.Fatalf("expected method POST, got %q", record.Method)
+	}
+	if record.URL != parsedURL.String() {
+		t.Fatalf("expected url %q, got %q", parsedURL.String(), record.URL)
+	}
+}

--- a/internal/history/search.go
+++ b/internal/history/search.go
@@ -1,0 +1,291 @@
+package history
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/RowanDark/Glyph/internal/proxy"
+)
+
+const defaultHistoryFilename = "proxy_history.jsonl"
+
+// Entry represents a single history record indexed from the JSONL file.
+type Entry struct {
+	ID     string
+	Record proxy.HistoryEntry
+}
+
+type indexedEntry struct {
+	id            string
+	record        proxy.HistoryEntry
+	hostLower     string
+	pathLower     string
+	methodLower   string
+	protocolLower string
+	urlLower      string
+	statusCode    int
+	matchedLower  []string
+}
+
+// Index provides in-memory search capabilities over persisted history entries.
+type Index struct {
+	entries   []indexedEntry
+	positions map[string]int
+}
+
+// DefaultPath returns the default location of the proxy history log, honouring GLYPH_OUT.
+func DefaultPath() string {
+	dir := strings.TrimSpace(os.Getenv("GLYPH_OUT"))
+	if dir == "" {
+		dir = "/out"
+	}
+	return filepath.Join(dir, defaultHistoryFilename)
+}
+
+// Load builds an index by parsing the given history JSONL file.
+func Load(path string) (*Index, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open history: %w", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	// Allow large payloads to be indexed without failing.
+	buf := make([]byte, 0, 1024*1024)
+	scanner.Buffer(buf, 10*1024*1024)
+
+	idx := &Index{
+		positions: make(map[string]int),
+	}
+	line := 0
+	id := 0
+	for scanner.Scan() {
+		line++
+		raw := strings.TrimSpace(scanner.Text())
+		if raw == "" {
+			continue
+		}
+		var record proxy.HistoryEntry
+		if err := json.Unmarshal([]byte(raw), &record); err != nil {
+			return nil, fmt.Errorf("decode history entry on line %d: %w", line, err)
+		}
+		id++
+		indexed := indexedEntry{
+			id:            strconv.Itoa(id),
+			record:        record,
+			methodLower:   strings.ToLower(record.Method),
+			protocolLower: strings.ToLower(record.Protocol),
+			urlLower:      strings.ToLower(record.URL),
+			statusCode:    record.StatusCode,
+		}
+		if u, err := url.Parse(record.URL); err == nil {
+			indexed.hostLower = strings.ToLower(u.Host)
+			indexed.pathLower = strings.ToLower(u.Path)
+		}
+		if len(record.MatchedRules) > 0 {
+			indexed.matchedLower = make([]string, len(record.MatchedRules))
+			for i, rule := range record.MatchedRules {
+				indexed.matchedLower[i] = strings.ToLower(rule)
+			}
+		}
+		idx.positions[indexed.id] = len(idx.entries)
+		idx.entries = append(idx.entries, indexed)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan history: %w", err)
+	}
+	return idx, nil
+}
+
+// Entries returns a copy of all indexed entries in chronological order.
+func (i *Index) Entries() []Entry {
+	if i == nil {
+		return nil
+	}
+	out := make([]Entry, len(i.entries))
+	for idx, entry := range i.entries {
+		out[idx] = entry.entry()
+	}
+	return out
+}
+
+// Entry retrieves a specific history record by ID.
+func (i *Index) Entry(id string) (Entry, bool) {
+	if i == nil {
+		return Entry{}, false
+	}
+	pos, ok := i.positions[id]
+	if !ok {
+		return Entry{}, false
+	}
+	return i.entries[pos].entry(), true
+}
+
+type predicate func(*indexedEntry) bool
+
+// Search returns every entry matching the provided query string.
+//
+// The query language accepts whitespace-separated terms in the form key:value.
+// Supported keys include host, method, protocol, path, url, status, and rule.
+func (i *Index) Search(rawQuery string) ([]Entry, error) {
+	if i == nil {
+		return nil, fmt.Errorf("index not initialised")
+	}
+	predicates, err := parseQuery(rawQuery)
+	if err != nil {
+		return nil, err
+	}
+	if len(predicates) == 0 {
+		results := make([]Entry, len(i.entries))
+		for idx, entry := range i.entries {
+			results[idx] = entry.entry()
+		}
+		return results, nil
+	}
+	var results []Entry
+	for idx := range i.entries {
+		entry := &i.entries[idx]
+		match := true
+		for _, predicate := range predicates {
+			if !predicate(entry) {
+				match = false
+				break
+			}
+		}
+		if match {
+			results = append(results, entry.entry())
+		}
+	}
+	return results, nil
+}
+
+func parseQuery(input string) ([]predicate, error) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return nil, nil
+	}
+	tokens := strings.Fields(trimmed)
+	predicates := make([]predicate, 0, len(tokens))
+	for _, token := range tokens {
+		parts := strings.SplitN(token, ":", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid query token %q (expected key:value)", token)
+		}
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		value := strings.TrimSpace(parts[1])
+		if value == "" {
+			return nil, fmt.Errorf("query term %q missing value", key)
+		}
+		switch key {
+		case "host":
+			host := strings.ToLower(value)
+			predicates = append(predicates, func(entry *indexedEntry) bool {
+				return entry.hostLower != "" && strings.Contains(entry.hostLower, host)
+			})
+		case "method":
+			method := strings.ToLower(value)
+			predicates = append(predicates, func(entry *indexedEntry) bool {
+				return entry.methodLower == method
+			})
+		case "protocol":
+			protocol := strings.ToLower(value)
+			predicates = append(predicates, func(entry *indexedEntry) bool {
+				return entry.protocolLower == protocol
+			})
+		case "path":
+			path := strings.ToLower(value)
+			predicates = append(predicates, func(entry *indexedEntry) bool {
+				return entry.pathLower != "" && strings.Contains(entry.pathLower, path)
+			})
+		case "url":
+			urlValue := strings.ToLower(value)
+			predicates = append(predicates, func(entry *indexedEntry) bool {
+				return strings.Contains(entry.urlLower, urlValue)
+			})
+		case "status":
+			status, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid status %q", value)
+			}
+			predicates = append(predicates, func(entry *indexedEntry) bool {
+				return entry.statusCode == status
+			})
+		case "rule":
+			rule := strings.ToLower(value)
+			predicates = append(predicates, func(entry *indexedEntry) bool {
+				for _, candidate := range entry.matchedLower {
+					if candidate == rule {
+						return true
+					}
+				}
+				return false
+			})
+		default:
+			return nil, fmt.Errorf("unsupported query field %q", key)
+		}
+	}
+	return predicates, nil
+}
+
+// Append persists a new history entry to the JSONL log.
+func Append(path string, entry proxy.HistoryEntry) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("history path must not be empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create history directory: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open history file: %w", err)
+	}
+	defer file.Close()
+	payload, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("encode history entry: %w", err)
+	}
+	payload = append(payload, '\n')
+	if _, err := file.Write(payload); err != nil {
+		return fmt.Errorf("write history entry: %w", err)
+	}
+	return nil
+}
+
+func cloneHistory(in proxy.HistoryEntry) proxy.HistoryEntry {
+	out := in
+	if in.RequestHeaders != nil {
+		out.RequestHeaders = cloneHeaderMap(in.RequestHeaders)
+	}
+	if in.ResponseHeaders != nil {
+		out.ResponseHeaders = cloneHeaderMap(in.ResponseHeaders)
+	}
+	if len(in.MatchedRules) > 0 {
+		out.MatchedRules = append([]string(nil), in.MatchedRules...)
+	}
+	return out
+}
+
+func cloneHeaderMap(in map[string][]string) map[string][]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string][]string, len(in))
+	for key, values := range in {
+		out[key] = append([]string(nil), values...)
+	}
+	return out
+}
+
+func (e indexedEntry) entry() Entry {
+	return Entry{
+		ID:     e.id,
+		Record: cloneHistory(e.record),
+	}
+}

--- a/internal/history/search_test.go
+++ b/internal/history/search_test.go
@@ -1,0 +1,130 @@
+package history_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/history"
+	"github.com/RowanDark/Glyph/internal/proxy"
+)
+
+func TestLoadAndSearch(t *testing.T) {
+	t.Helper()
+	tempDir := t.TempDir()
+	historyPath := filepath.Join(tempDir, "history.jsonl")
+
+	fixtures := []proxy.HistoryEntry{
+		{
+			Timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+			Protocol:     "https",
+			Method:       "GET",
+			URL:          "https://example.com/login",
+			StatusCode:   200,
+			MatchedRules: []string{"auth-rewrite"},
+		},
+		{
+			Timestamp:  time.Date(2024, 1, 1, 12, 5, 0, 0, time.UTC),
+			Protocol:   "https",
+			Method:     "POST",
+			URL:        "https://example.com/login",
+			StatusCode: 401,
+			RequestHeaders: map[string][]string{
+				"Content-Type": []string{"application/json"},
+			},
+		},
+		{
+			Timestamp:    time.Date(2024, 1, 1, 13, 0, 0, 0, time.UTC),
+			Protocol:     "https",
+			Method:       "POST",
+			URL:          "https://api.internal/status",
+			StatusCode:   500,
+			MatchedRules: []string{"Upstream"},
+		},
+	}
+
+	for _, entry := range fixtures {
+		if err := history.Append(historyPath, entry); err != nil {
+			t.Fatalf("append history: %v", err)
+		}
+	}
+
+	index, err := history.Load(historyPath)
+	if err != nil {
+		t.Fatalf("load history: %v", err)
+	}
+
+	results, err := index.Search("host:example.com method:POST")
+	if err != nil {
+		t.Fatalf("search history: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected one result, got %d", len(results))
+	}
+	if results[0].ID != "2" {
+		t.Fatalf("expected ID 2, got %s", results[0].ID)
+	}
+	if results[0].Record.StatusCode != 401 {
+		t.Fatalf("unexpected status code: %d", results[0].Record.StatusCode)
+	}
+
+	rules, err := index.Search("rule:auth-rewrite")
+	if err != nil {
+		t.Fatalf("search by rule: %v", err)
+	}
+	if len(rules) != 1 || rules[0].ID != "1" {
+		t.Fatalf("expected rule match ID 1, got %+v", rules)
+	}
+
+	status, err := index.Search("status:500")
+	if err != nil {
+		t.Fatalf("search by status: %v", err)
+	}
+	if len(status) != 1 || status[0].ID != "3" {
+		t.Fatalf("expected status match ID 3, got %+v", status)
+	}
+
+	all, err := index.Search("")
+	if err != nil {
+		t.Fatalf("search all: %v", err)
+	}
+	if len(all) != len(fixtures) {
+		t.Fatalf("expected %d results, got %d", len(fixtures), len(all))
+	}
+}
+
+func TestEntryLookup(t *testing.T) {
+	tempDir := t.TempDir()
+	historyPath := filepath.Join(tempDir, "history.jsonl")
+
+	entry := proxy.HistoryEntry{
+		Timestamp:  time.Now().UTC(),
+		Protocol:   "http",
+		Method:     "GET",
+		URL:        "http://example.org/demo",
+		StatusCode: 200,
+	}
+	if err := history.Append(historyPath, entry); err != nil {
+		t.Fatalf("append history: %v", err)
+	}
+
+	index, err := history.Load(historyPath)
+	if err != nil {
+		t.Fatalf("load history: %v", err)
+	}
+
+	got, ok := index.Entry("1")
+	if !ok {
+		t.Fatal("expected entry with ID 1")
+	}
+	if got.Record.URL != entry.URL {
+		t.Fatalf("expected URL %q, got %q", entry.URL, got.Record.URL)
+	}
+	if got.Record.Method != entry.Method {
+		t.Fatalf("expected method %q, got %q", entry.Method, got.Record.Method)
+	}
+
+	if _, ok := index.Entry("2"); ok {
+		t.Fatal("unexpected entry with ID 2")
+	}
+}

--- a/plugins/galdr-proxy/README.md
+++ b/plugins/galdr-proxy/README.md
@@ -87,6 +87,23 @@ Every flow is appended to `/out/proxy_history.jsonl` as JSON Lines. Each entry m
 
 The log can be tailed or post-processed by other Glyph plugins for analysis. Override the path with `--proxy-history` if you prefer a custom location.
 
+#### Searching and replaying flows
+
+Pair the recorded history with `glyphctl` to quickly rediscover and replay interesting requests:
+
+```bash
+glyphctl history search --history /out/proxy_history.jsonl --q 'host:example.com method:POST'
+
+# Replay the captured request with an updated token and body payload.
+glyphctl repeater send \
+  --history /out/proxy_history.jsonl \
+  --id 42 \
+  --set 'Header:X-Token=override' \
+  --set-body @payload.json
+```
+
+`glyphctl repeater` will print a replay summary and append the upstream response to the same history log for follow-up analysis.
+
 Example entry:
 
 ```json


### PR DESCRIPTION
## Summary
- add an internal history index for querying persisted proxy flows
- add `glyphctl history search` and `glyphctl repeater send` commands with replay support
- document searching and replaying flows in the galdr proxy README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d2e3091c40832a84aa8d52f4e5a7f7