### PR TITLE
feat: add central config loader and CLI inspection

### DIFF
--- a/cmd/glyphctl/config_cmd.go
+++ b/cmd/glyphctl/config_cmd.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/RowanDark/Glyph/internal/config"
+)
+
+func runConfig(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "config subcommand required")
+		return 2
+	}
+
+	switch args[0] {
+	case "print":
+		return runConfigPrint()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown config subcommand: %s\n", args[0])
+		return 2
+	}
+}
+
+func runConfigPrint() int {
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load config: %v\n", err)
+		return 1
+	}
+
+	printResolvedConfig(os.Stdout, cfg)
+	return 0
+}
+
+func printResolvedConfig(out io.Writer, cfg config.Config) {
+	fmt.Fprintf(out, "server_addr: %s\n", cfg.ServerAddr)
+	fmt.Fprintf(out, "auth_token: %s\n", cfg.AuthToken)
+	fmt.Fprintf(out, "output_dir: %s\n", cfg.OutputDir)
+	fmt.Fprintln(out, "proxy:")
+	fmt.Fprintf(out, "  enable: %t\n", cfg.Proxy.Enable)
+	fmt.Fprintf(out, "  addr: %s\n", cfg.Proxy.Addr)
+	fmt.Fprintf(out, "  rules_path: %s\n", cfg.Proxy.RulesPath)
+	fmt.Fprintf(out, "  history_path: %s\n", cfg.Proxy.HistoryPath)
+	fmt.Fprintf(out, "  ca_cert_path: %s\n", cfg.Proxy.CACertPath)
+	fmt.Fprintf(out, "  ca_key_path: %s\n", cfg.Proxy.CAKeyPath)
+}

--- a/cmd/glyphctl/config_cmd_test.go
+++ b/cmd/glyphctl/config_cmd_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/RowanDark/Glyph/internal/config"
+)
+
+func TestPrintResolvedConfig(t *testing.T) {
+	cfg := config.Config{
+		ServerAddr: "1.2.3.4:1111",
+		AuthToken:  "token",
+		OutputDir:  "/somewhere",
+		Proxy: config.ProxyConfig{
+			Enable:      true,
+			Addr:        "proxy:1234",
+			RulesPath:   "rules.yaml",
+			HistoryPath: "history.jsonl",
+			CACertPath:  "ca.pem",
+			CAKeyPath:   "ca.key",
+		},
+	}
+
+	var buf bytes.Buffer
+	printResolvedConfig(&buf, cfg)
+
+	output := buf.String()
+	expected := []string{
+		"server_addr: 1.2.3.4:1111",
+		"auth_token: token",
+		"output_dir: /somewhere",
+		"proxy:",
+		"  enable: true",
+		"  addr: proxy:1234",
+		"  rules_path: rules.yaml",
+		"  history_path: history.jsonl",
+		"  ca_cert_path: ca.pem",
+		"  ca_key_path: ca.key",
+	}
+	for _, line := range expected {
+		if !strings.Contains(output, line) {
+			t.Fatalf("expected line %q in output: %s", line, output)
+		}
+	}
+}
+
+func TestRunConfigRequiresSubcommand(t *testing.T) {
+	if code := runConfig(nil); code != 2 {
+		t.Fatalf("expected exit code 2 for missing subcommand, got %d", code)
+	}
+	if code := runConfig([]string{"unknown"}); code != 2 {
+		t.Fatalf("expected exit code 2 for unknown subcommand, got %d", code)
+	}
+}

--- a/cmd/glyphctl/main.go
+++ b/cmd/glyphctl/main.go
@@ -30,6 +30,8 @@ func main() {
 		os.Exit(runOSINTWell(args[1:]))
 	case "rank":
 		os.Exit(runRank(args[1:]))
+	case "config":
+		os.Exit(runConfig(args[1:]))
 	case "plugin":
 		if len(args) < 2 {
 			fmt.Fprintln(os.Stderr, "plugin subcommand required")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,74 @@
+# Configuration
+
+Glyph reads configuration from a single resolved source that combines defaults,
+optional configuration files, and environment variable overrides. This keeps the
+platform easy to tune locally and in production deployments.
+
+## Resolution order
+
+1. Built-in defaults.
+2. `~/.glyph/config.toml` (optional).
+3. `./glyph.yml` in the current working directory (optional).
+4. Environment variables beginning with `GLYPH_`.
+
+Each subsequent source overrides values defined in the previous ones. Local
+project configuration therefore beats the user-level TOML file, and environment
+variables have the final say.
+
+## Supported fields
+
+```yaml
+server_addr: 127.0.0.1:50051
+auth_token: supersecrettoken
+output_dir: /out
+proxy:
+  enable: false
+  addr: ""
+  rules_path: ""
+  history_path: ""
+  ca_cert_path: ""
+  ca_key_path: ""
+```
+
+The TOML representation uses matching keys and section names.
+
+## Environment overrides
+
+The loader accepts the following variables:
+
+| Variable | Description |
+| --- | --- |
+| `GLYPH_SERVER` | Overrides `server_addr`. |
+| `GLYPH_AUTH_TOKEN` | Overrides `auth_token`. |
+| `GLYPH_OUT` | Overrides `output_dir`. |
+| `GLYPH_ENABLE_PROXY` / `GLYPH_PROXY_ENABLE` | Controls `proxy.enable`. |
+| `GLYPH_PROXY_ADDR` | Overrides `proxy.addr`. |
+| `GLYPH_PROXY_RULES` | Overrides `proxy.rules_path`. |
+| `GLYPH_PROXY_HISTORY` | Overrides `proxy.history_path`. |
+| `GLYPH_PROXY_CA_CERT` | Overrides `proxy.ca_cert_path`. |
+| `GLYPH_PROXY_CA_KEY` | Overrides `proxy.ca_key_path`. |
+
+All variables accept whitespace-trimmed values. Boolean variables treat `1`,
+`true`, `yes`, and `on` as true, and `0`, `false`, `no`, and `off` as false.
+
+## Inspecting the resolved configuration
+
+Run the following command to print the merged configuration as seen by
+`glyphctl`:
+
+```bash
+$ glyphctl config print
+server_addr: 127.0.0.1:50051
+auth_token: supersecrettoken
+output_dir: /out
+proxy:
+  enable: false
+  addr: 
+  rules_path: 
+  history_path: 
+  ca_cert_path: 
+  ca_key_path: 
+```
+
+This output reflects every override the loader applied, making it easier to
+confirm the active settings in environments where multiple sources are involved.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,374 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Config captures the Glyph configuration resolved from defaults, optional files,
+// and environment overrides.
+type Config struct {
+	ServerAddr string      `yaml:"server_addr" toml:"server_addr"`
+	AuthToken  string      `yaml:"auth_token" toml:"auth_token"`
+	OutputDir  string      `yaml:"output_dir" toml:"output_dir"`
+	Proxy      ProxyConfig `yaml:"proxy" toml:"proxy"`
+}
+
+// ProxyConfig controls proxy-related behaviour for glyphd.
+type ProxyConfig struct {
+	Enable      bool   `yaml:"enable" toml:"enable"`
+	Addr        string `yaml:"addr" toml:"addr"`
+	RulesPath   string `yaml:"rules_path" toml:"rules_path"`
+	HistoryPath string `yaml:"history_path" toml:"history_path"`
+	CACertPath  string `yaml:"ca_cert_path" toml:"ca_cert_path"`
+	CAKeyPath   string `yaml:"ca_key_path" toml:"ca_key_path"`
+}
+
+// Default returns the built-in Glyph configuration.
+func Default() Config {
+	return Config{
+		ServerAddr: "127.0.0.1:50051",
+		AuthToken:  "supersecrettoken",
+		OutputDir:  "/out",
+		Proxy: ProxyConfig{
+			Enable:      false,
+			Addr:        "",
+			RulesPath:   "",
+			HistoryPath: "",
+			CACertPath:  "",
+			CAKeyPath:   "",
+		},
+	}
+}
+
+// Load resolves the Glyph configuration using defaults, configuration files, and
+// environment overrides. The lookup order for configuration files is:
+//  1. ./glyph.yml (YAML)
+//  2. ~/.glyph/config.toml (TOML)
+//
+// Environment variables prefixed with GLYPH_ have the highest precedence.
+func Load() (Config, error) {
+	cfg := Default()
+
+	if err := loadHomeConfig(&cfg); err != nil {
+		return Config{}, err
+	}
+	if err := loadLocalConfig(&cfg); err != nil {
+		return Config{}, err
+	}
+
+	applyEnvOverrides(&cfg)
+
+	return cfg, nil
+}
+
+func loadHomeConfig(cfg *Config) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("determine home directory: %w", err)
+	}
+	path := filepath.Join(home, ".glyph", "config.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read config %s: %w", path, err)
+	}
+	if err := applyFileConfig(cfg, data, "toml"); err != nil {
+		return fmt.Errorf("parse config %s: %w", path, err)
+	}
+	return nil
+}
+
+func loadLocalConfig(cfg *Config) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("determine working directory: %w", err)
+	}
+	path := filepath.Join(wd, "glyph.yml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read config %s: %w", path, err)
+	}
+	if err := applyFileConfig(cfg, data, "yaml"); err != nil {
+		return fmt.Errorf("parse config %s: %w", path, err)
+	}
+	return nil
+}
+
+type fileConfig struct {
+	ServerAddr *string          `yaml:"server_addr" toml:"server_addr"`
+	AuthToken  *string          `yaml:"auth_token" toml:"auth_token"`
+	OutputDir  *string          `yaml:"output_dir" toml:"output_dir"`
+	Proxy      *fileProxyConfig `yaml:"proxy" toml:"proxy"`
+}
+
+type fileProxyConfig struct {
+	Enable      *bool   `yaml:"enable" toml:"enable"`
+	Addr        *string `yaml:"addr" toml:"addr"`
+	RulesPath   *string `yaml:"rules_path" toml:"rules_path"`
+	HistoryPath *string `yaml:"history_path" toml:"history_path"`
+	CACertPath  *string `yaml:"ca_cert_path" toml:"ca_cert_path"`
+	CAKeyPath   *string `yaml:"ca_key_path" toml:"ca_key_path"`
+}
+
+func applyFileConfig(cfg *Config, data []byte, format string) error {
+	var fc fileConfig
+	var err error
+	switch format {
+	case "yaml":
+		fc, err = parseYAML(data)
+	case "toml":
+		fc, err = parseTOML(data)
+	default:
+		return fmt.Errorf("unsupported format %q", format)
+	}
+	if err != nil {
+		return err
+	}
+
+	if fc.ServerAddr != nil {
+		cfg.ServerAddr = strings.TrimSpace(*fc.ServerAddr)
+	}
+	if fc.AuthToken != nil {
+		cfg.AuthToken = strings.TrimSpace(*fc.AuthToken)
+	}
+	if fc.OutputDir != nil {
+		cfg.OutputDir = strings.TrimSpace(*fc.OutputDir)
+	}
+	if fc.Proxy != nil {
+		if fc.Proxy.Enable != nil {
+			cfg.Proxy.Enable = *fc.Proxy.Enable
+		}
+		if fc.Proxy.Addr != nil {
+			cfg.Proxy.Addr = strings.TrimSpace(*fc.Proxy.Addr)
+		}
+		if fc.Proxy.RulesPath != nil {
+			cfg.Proxy.RulesPath = strings.TrimSpace(*fc.Proxy.RulesPath)
+		}
+		if fc.Proxy.HistoryPath != nil {
+			cfg.Proxy.HistoryPath = strings.TrimSpace(*fc.Proxy.HistoryPath)
+		}
+		if fc.Proxy.CACertPath != nil {
+			cfg.Proxy.CACertPath = strings.TrimSpace(*fc.Proxy.CACertPath)
+		}
+		if fc.Proxy.CAKeyPath != nil {
+			cfg.Proxy.CAKeyPath = strings.TrimSpace(*fc.Proxy.CAKeyPath)
+		}
+	}
+
+	return nil
+}
+
+func applyEnvOverrides(cfg *Config) {
+	if val := strings.TrimSpace(os.Getenv("GLYPH_SERVER")); val != "" {
+		cfg.ServerAddr = val
+	}
+	if val := strings.TrimSpace(os.Getenv("GLYPH_AUTH_TOKEN")); val != "" {
+		cfg.AuthToken = val
+	}
+	if val := strings.TrimSpace(os.Getenv("GLYPH_OUT")); val != "" {
+		cfg.OutputDir = val
+	}
+	if val := strings.TrimSpace(os.Getenv("GLYPH_PROXY_ENABLE")); val != "" {
+		if parsed, err := strconv.ParseBool(val); err == nil {
+			cfg.Proxy.Enable = parsed
+		}
+	}
+	if val := strings.TrimSpace(os.Getenv("GLYPH_ENABLE_PROXY")); val != "" {
+		if parsed, err := strconv.ParseBool(val); err == nil {
+			cfg.Proxy.Enable = parsed
+		}
+	}
+	if val := strings.TrimSpace(os.Getenv("GLYPH_PROXY_ADDR")); val != "" {
+		cfg.Proxy.Addr = val
+	}
+	if val := strings.TrimSpace(os.Getenv("GLYPH_PROXY_RULES")); val != "" {
+		cfg.Proxy.RulesPath = val
+	}
+	if val := strings.TrimSpace(os.Getenv("GLYPH_PROXY_HISTORY")); val != "" {
+		cfg.Proxy.HistoryPath = val
+	}
+	if val := strings.TrimSpace(os.Getenv("GLYPH_PROXY_CA_CERT")); val != "" {
+		cfg.Proxy.CACertPath = val
+	}
+	if val := strings.TrimSpace(os.Getenv("GLYPH_PROXY_CA_KEY")); val != "" {
+		cfg.Proxy.CAKeyPath = val
+	}
+}
+
+func parseYAML(data []byte) (fileConfig, error) {
+	lines := strings.Split(string(data), "\n")
+	var fc fileConfig
+	for i := 0; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasSuffix(trimmed, ":") {
+			key := strings.TrimSuffix(trimmed, ":")
+			if key == "proxy" {
+				proxy := &fileProxyConfig{}
+				for j := i + 1; j < len(lines); j++ {
+					nestedLine := lines[j]
+					if indentation(nestedLine) == 0 {
+						break
+					}
+					trimmedNested := strings.TrimSpace(nestedLine)
+					if trimmedNested == "" || strings.HasPrefix(trimmedNested, "#") {
+						continue
+					}
+					parts := strings.SplitN(trimmedNested, ":", 2)
+					if len(parts) != 2 {
+						return fileConfig{}, fmt.Errorf("invalid proxy entry: %q", trimmedNested)
+					}
+					key := strings.TrimSpace(parts[0])
+					value := trimQuotes(strings.TrimSpace(parts[1]))
+					switch key {
+					case "enable":
+						parsed, err := parseBool(value)
+						if err != nil {
+							return fileConfig{}, err
+						}
+						proxy.Enable = &parsed
+					case "addr":
+						proxy.Addr = &value
+					case "rules_path":
+						proxy.RulesPath = &value
+					case "history_path":
+						proxy.HistoryPath = &value
+					case "ca_cert_path":
+						proxy.CACertPath = &value
+					case "ca_key_path":
+						proxy.CAKeyPath = &value
+					}
+					i = j
+				}
+				fc.Proxy = proxy
+			}
+			continue
+		}
+		parts := strings.SplitN(trimmed, ":", 2)
+		if len(parts) != 2 {
+			return fileConfig{}, fmt.Errorf("invalid yaml line: %q", trimmed)
+		}
+		key := strings.TrimSpace(parts[0])
+		value := trimQuotes(strings.TrimSpace(parts[1]))
+		switch key {
+		case "server_addr":
+			fc.ServerAddr = &value
+		case "auth_token":
+			fc.AuthToken = &value
+		case "output_dir":
+			fc.OutputDir = &value
+		default:
+			// ignore unknown keys
+		}
+	}
+	return fc, nil
+}
+
+func parseTOML(data []byte) (fileConfig, error) {
+	lines := strings.Split(string(data), "\n")
+	var fc fileConfig
+	section := ""
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") { // # comment
+			continue
+		}
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			section = strings.TrimSuffix(strings.TrimPrefix(trimmed, "["), "]")
+			continue
+		}
+		parts := strings.SplitN(trimmed, "=", 2)
+		if len(parts) != 2 {
+			return fileConfig{}, fmt.Errorf("invalid toml line: %q", trimmed)
+		}
+		key := strings.TrimSpace(parts[0])
+		value := trimQuotes(strings.TrimSpace(parts[1]))
+		switch section {
+		case "":
+			switch key {
+			case "server_addr":
+				fc.ServerAddr = &value
+			case "auth_token":
+				fc.AuthToken = &value
+			case "output_dir":
+				fc.OutputDir = &value
+			}
+		case "proxy":
+			if fc.Proxy == nil {
+				fc.Proxy = &fileProxyConfig{}
+			}
+			switch key {
+			case "enable":
+				parsed, err := parseBool(value)
+				if err != nil {
+					return fileConfig{}, err
+				}
+				fc.Proxy.Enable = &parsed
+			case "addr":
+				fc.Proxy.Addr = &value
+			case "rules_path":
+				fc.Proxy.RulesPath = &value
+			case "history_path":
+				fc.Proxy.HistoryPath = &value
+			case "ca_cert_path":
+				fc.Proxy.CACertPath = &value
+			case "ca_key_path":
+				fc.Proxy.CAKeyPath = &value
+			}
+		}
+	}
+	return fc, nil
+}
+
+func parseBool(val string) (bool, error) {
+	v := strings.TrimSpace(strings.ToLower(val))
+	switch v {
+	case "true", "1", "yes", "on":
+		return true, nil
+	case "false", "0", "no", "off":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid boolean: %s", val)
+	}
+}
+
+func trimQuotes(val string) string {
+	if len(val) >= 2 {
+		if (strings.HasPrefix(val, "\"") && strings.HasSuffix(val, "\"")) ||
+			(strings.HasPrefix(val, "'") && strings.HasSuffix(val, "'")) {
+			return val[1 : len(val)-1]
+		}
+	}
+	return val
+}
+
+func indentation(line string) int {
+	count := 0
+	for _, r := range line {
+		switch r {
+		case ' ':
+			count++
+		case '\t':
+			count++
+		default:
+			return count
+		}
+	}
+	return count
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadPrecedence(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Configure HOME to a temp directory containing ~/.glyph/config.toml.
+	homeDir := filepath.Join(tempDir, "home")
+	if err := os.Mkdir(homeDir, 0o755); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+	t.Setenv("HOME", homeDir)
+
+	glyphDir := filepath.Join(homeDir, ".glyph")
+	if err := os.Mkdir(glyphDir, 0o755); err != nil {
+		t.Fatalf("mkdir .glyph: %v", err)
+	}
+	tomlPath := filepath.Join(glyphDir, "config.toml")
+	tomlConfig := []byte(`server_addr = "0.0.0.0:1111"
+output_dir = "/custom"
+[proxy]
+addr = "proxy-home:8080"
+`)
+	if err := os.WriteFile(tomlPath, tomlConfig, 0o644); err != nil {
+		t.Fatalf("write toml config: %v", err)
+	}
+
+	// Provide a local YAML config overriding the TOML file.
+	workDir := filepath.Join(tempDir, "work")
+	if err := os.Mkdir(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir work: %v", err)
+	}
+	yamlPath := filepath.Join(workDir, "glyph.yml")
+	yamlConfig := []byte(`server_addr: 127.0.0.1:6500
+proxy:
+  enable: true
+  addr: proxy-local:9090
+`)
+	if err := os.WriteFile(yamlPath, yamlConfig, 0o644); err != nil {
+		t.Fatalf("write yaml config: %v", err)
+	}
+
+	// Ensure env overrides beat file configuration.
+	t.Setenv("GLYPH_PROXY_ADDR", "proxy-env:5555")
+	t.Setenv("GLYPH_AUTH_TOKEN", "env-token")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(cwd)
+	}()
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	if cfg.ServerAddr != "127.0.0.1:6500" {
+		t.Fatalf("unexpected server addr: %s", cfg.ServerAddr)
+	}
+	if !cfg.Proxy.Enable {
+		t.Fatalf("expected proxy enable from YAML override")
+	}
+	if cfg.Proxy.Addr != "proxy-env:5555" {
+		t.Fatalf("expected env override for proxy addr, got %s", cfg.Proxy.Addr)
+	}
+	if cfg.OutputDir != "/custom" {
+		t.Fatalf("expected TOML output dir, got %s", cfg.OutputDir)
+	}
+	if cfg.AuthToken != "env-token" {
+		t.Fatalf("expected env token override, got %s", cfg.AuthToken)
+	}
+}
+
+func TestLoadDefaults(t *testing.T) {
+	t.Setenv("HOME", filepath.Join(t.TempDir(), "home"))
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	defaults := Default()
+	if cfg != defaults {
+		t.Fatalf("expected defaults, got %#v", cfg)
+	}
+}


### PR DESCRIPTION
## Summary
- add an internal configuration loader that merges defaults, optional TOML/YAML files, and GLYPH_* environment variables
- expose the resolved configuration through `glyphctl config print`
- document configuration resolution order and overrides

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d5308136ac832aa188b6b5cb9229f9