### PR TITLE
Add release packaging workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build release artifacts
+        run: scripts/build_release.sh
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Glyph ${{ github.ref_name }}
+          body: |
+            ## Glyph ${{ github.ref_name }}
+            See the [CHANGELOG](https://github.com/RowanDark/Glyph/blob/${{ github.ref_name }}/CHANGELOG.md) for details.
+          files: |
+            dist/*.tar.gz
+            dist/*SHA256SUMS.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 - Introduced the Seer detector library for high-signal secrets with redacted evidence and unit tests.
 - Added the OSINT Well Amass wrapper (`glyphctl osint-well`) to normalise assets into `/out/assets.jsonl`.
 - Documented release processes and contribution guidelines.
+- Automated the v0.1.0-alpha release packaging with embedded version metadata, cross-compiled binaries, and GitHub publishing.

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+        VERSION="$(git describe --tags --always)"
+fi
+
+if [[ -z "$VERSION" ]]; then
+        echo "Unable to determine version for release" >&2
+        exit 1
+fi
+
+DIST_DIR="$ROOT_DIR/dist"
+rm -rf "$DIST_DIR"
+mkdir -p "$DIST_DIR"
+
+LDFLAGS="-s -w -X main.version=${VERSION}"
+
+declare -a targets=(
+        "linux amd64"
+        "linux arm64"
+        "darwin amd64"
+        "darwin arm64"
+)
+
+for target in "${targets[@]}"; do
+        read -r GOOS GOARCH <<<"$target"
+        ARCHIVE_BASENAME="glyphctl_${VERSION}_${GOOS}_${GOARCH}"
+        BUILD_DIR="$DIST_DIR/$ARCHIVE_BASENAME"
+        mkdir -p "$BUILD_DIR"
+
+        echo "Building glyphctl for $GOOS/$GOARCH"
+        GOOS="$GOOS" GOARCH="$GOARCH" CGO_ENABLED=0 \
+                go build -ldflags "$LDFLAGS" -o "$BUILD_DIR/glyphctl" ./cmd/glyphctl
+
+        cp "$ROOT_DIR/LICENSE" "$BUILD_DIR/"
+
+        (cd "$DIST_DIR" && tar -czf "$ARCHIVE_BASENAME.tar.gz" "$ARCHIVE_BASENAME")
+        rm -rf "$BUILD_DIR"
+
+done
+
+(
+        cd "$DIST_DIR"
+        sha256sum *.tar.gz > "glyphctl_${VERSION}_SHA256SUMS.txt"
+)
+
+printf '\nArtifacts written to %s\n' "$DIST_DIR"


### PR DESCRIPTION
## Summary
- add a release workflow that builds cross-compiled glyphctl artifacts and publishes tagged releases with notes
- script the release build to embed the git describe version, package LICENSEd tarballs, and emit checksums
- document the automated packaging work in the v0.1.0-alpha changelog entry

## Testing
- ./scripts/build_release.sh v0.1.0-alpha
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d534f5d770832a887c63e182c8eed8