### PR TITLE
ci: optional fuzz targets for URL/header normalizers

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,4 +17,8 @@ jobs:
       - name: Run fuzzers
         run: |
           set -euo pipefail
-          go test ./... -run=^$ -fuzz=Fuzz -fuzztime=20s
+          for pkg in $(go list ./...); do
+            if go test "$pkg" -run=^$ -list=Fuzz | grep -q '^Fuzz'; then
+              go test "$pkg" -run=^$ -fuzz=Fuzz -fuzztime=20s
+            fi
+          done

--- a/plugins/grapher/discovery_fuzz_test.go
+++ b/plugins/grapher/discovery_fuzz_test.go
@@ -1,0 +1,19 @@
+package main
+
+import "testing"
+
+func FuzzNormalizeURL(f *testing.F) {
+	seeds := []string{
+		"https://example.com",
+		"example.com/path",
+		" http://example.com ",
+		"",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		_, _ = normalizeBaseURL(raw)
+	})
+}

--- a/plugins/grapher/testdata/fuzz/FuzzNormalizeURL/seed-empty
+++ b/plugins/grapher/testdata/fuzz/FuzzNormalizeURL/seed-empty
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("")

--- a/plugins/grapher/testdata/fuzz/FuzzNormalizeURL/seed-https
+++ b/plugins/grapher/testdata/fuzz/FuzzNormalizeURL/seed-https
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("https://example.com")

--- a/plugins/grapher/testdata/fuzz/FuzzNormalizeURL/seed-relative
+++ b/plugins/grapher/testdata/fuzz/FuzzNormalizeURL/seed-relative
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("example.com/path")

--- a/sdk/plugin-sdk/sdk_fuzz_test.go
+++ b/sdk/plugin-sdk/sdk_fuzz_test.go
@@ -1,0 +1,18 @@
+package pluginsdk
+
+import "testing"
+
+func FuzzHeaderParse(f *testing.F) {
+	seeds := [][]byte{
+		[]byte("HTTP/1.1 200 OK\nContent-Type: text/plain\n\nhello"),
+		[]byte("HTTP/1.1 204 No Content\n\n"),
+		[]byte{},
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		_, _ = parseHTTPResponse(raw)
+	})
+}

--- a/sdk/plugin-sdk/testdata/fuzz/FuzzHeaderParse/seed-empty
+++ b/sdk/plugin-sdk/testdata/fuzz/FuzzHeaderParse/seed-empty
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("")

--- a/sdk/plugin-sdk/testdata/fuzz/FuzzHeaderParse/seed-no-status
+++ b/sdk/plugin-sdk/testdata/fuzz/FuzzHeaderParse/seed-no-status
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("Content-Type: text/plain\n\nbody")

--- a/sdk/plugin-sdk/testdata/fuzz/FuzzHeaderParse/seed-valid
+++ b/sdk/plugin-sdk/testdata/fuzz/FuzzHeaderParse/seed-valid
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("HTTP/1.1 200 OK\nContent-Type: text/plain\n\nhello")


### PR DESCRIPTION
## Summary
- add fuzz target for the grapher URL normalizer along with seed inputs
- add fuzz target for parsing plugin HTTP responses and seed corpus
- update fuzz workflow to iterate over all packages that define fuzz targets

## Testing
- go test ./internal/reporter -run=^$ -fuzz=Fuzz -fuzztime=1s
- go test ./plugins/grapher -run=^$ -fuzz=Fuzz -fuzztime=1s
- go test ./sdk/plugin-sdk -run=^$ -fuzz=Fuzz -fuzztime=1s


------
https://chatgpt.com/codex/tasks/task_e_68d53bbac0c8832ab6573a180da04bf4