### PR TITLE
Fix docs deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install documentation tooling
         run: |
           python -m pip install --upgrade pip
-          pip install mkdocs-material mike
+          pip install mkdocs-material
 
       - name: Configure Git user
         run: |
@@ -41,14 +41,23 @@ jobs:
       - name: Build documentation
         run: mkdocs build --strict
 
-      - name: Deploy docs for main
-        if: github.ref == 'refs/heads/main'
+      - name: Smoke test key docs pages
         run: |
-          mike deploy --push --update-aliases main next
+          python -m http.server --directory site 8000 >/tmp/mkdocs-http.log 2>&1 &
+          server_pid=$!
+          cleanup() {
+            kill $server_pid 2>/dev/null || true
+          }
+          trap cleanup EXIT
+          for _ in 1 2 3 4 5; do
+            if curl -fsS --retry 5 --retry-delay 1 --retry-connrefused http://127.0.0.1:8000/ >/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+          for path in "" quickstart/ security/ plugins/; do
+            curl -fsS --retry 3 --retry-delay 1 --retry-connrefused "http://127.0.0.1:8000/${path}" >/dev/null
+          done
 
-      - name: Deploy docs for tag
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          VERSION="${GITHUB_REF#refs/tags/}"
-          mike deploy --push --update-aliases "$VERSION" latest
-          mike set-default --push latest
+      - name: Deploy documentation
+        run: mkdocs gh-deploy --force --clean

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Highlights include:
 * [CLI reference](https://rowandark.github.io/Glyph/cli/)
 * [Developer guide](https://rowandark.github.io/Glyph/dev-guide/)
 * [Security overview](https://rowandark.github.io/Glyph/security/)
+* [Build provenance](https://rowandark.github.io/Glyph/security/provenance/)
+* [Supply chain security](https://rowandark.github.io/Glyph/security/supply-chain/)
 * [Threat model](THREAT_MODEL.md)
 * [Plugin security guide](PLUGIN_GUIDE.md)
 


### PR DESCRIPTION
## Summary
- switch the docs workflow to deploy with `mkdocs gh-deploy` so GitHub Pages serves the site
- add an HTTP smoke test that checks the homepage, quickstart, security, and plugin guide routes before publishing
- surface the provenance and supply-chain guides in the README docs list so readers land on the published pages

## Testing
- N/A (mkdocs not installed in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd172be3ac832a8642f8e3bdb36aaa