### PR TITLE
Add rate-limited queue manager and browser pool for Excavator

### DIFF
--- a/plugins/excavator/browser_pool.js
+++ b/plugins/excavator/browser_pool.js
@@ -1,0 +1,248 @@
+'use strict';
+
+function createBrowserPool(options = {}) {
+  const {
+    size = 2,
+    createContext,
+    destroyContext,
+    applyFingerprint,
+    resetContext,
+    fingerprints = [],
+    warmup = true,
+  } = options;
+
+  if (typeof createContext !== 'function') {
+    throw new Error('createContext function is required');
+  }
+
+  const capacity = Math.max(1, Math.floor(size));
+  const pending = [];
+  const available = [];
+  const resources = new Set();
+  const inUse = new Set();
+  const creationPromises = new Set();
+  let creating = 0;
+  let closing = false;
+  let closed = false;
+  let fingerprintIndex = 0;
+
+  function selectFingerprint() {
+    if (!Array.isArray(fingerprints) || fingerprints.length === 0) {
+      return null;
+    }
+    const index = fingerprintIndex % fingerprints.length;
+    fingerprintIndex += 1;
+    return fingerprints[index];
+  }
+
+  function ensureCapacity() {
+    if (closing || closed) {
+      return;
+    }
+
+    const existing = resources.size;
+    const totalWithCreating = existing + creating;
+    const demand = pending.length;
+    const idle = available.length;
+    const deficitDemand = Math.max(0, demand - idle);
+
+    let desiredTotal;
+    if (warmup) {
+      desiredTotal = capacity;
+    } else {
+      desiredTotal = Math.min(capacity, existing + deficitDemand);
+      if (desiredTotal === 0 && demand > 0) {
+        desiredTotal = Math.min(capacity, demand);
+      }
+    }
+
+    const deficit = Math.max(0, desiredTotal - totalWithCreating);
+    for (let i = 0; i < deficit; i += 1) {
+      spawnContext();
+    }
+  }
+
+  async function destroyResource(resource) {
+    if (!resource || resource.destroyed) {
+      if (resource && typeof resource.resolveClosed === 'function') {
+        resource.resolveClosed();
+      }
+      return;
+    }
+    resource.destroyed = true;
+    resources.delete(resource);
+    try {
+      if (typeof destroyContext === 'function') {
+        await destroyContext(resource.context);
+      } else if (resource.context && typeof resource.context.close === 'function') {
+        await resource.context.close();
+      }
+    } finally {
+      if (typeof resource.resolveClosed === 'function') {
+        resource.resolveClosed();
+      }
+    }
+  }
+
+  function dispatch() {
+    if (closing || closed) {
+      return;
+    }
+
+    while (pending.length > 0 && available.length > 0) {
+      const request = pending.shift();
+      const resource = available.shift();
+      inUse.add(resource);
+      const fingerprint = selectFingerprint();
+
+      Promise.resolve()
+        .then(() => {
+          if (fingerprint && typeof applyFingerprint === 'function') {
+            return applyFingerprint(resource.context, fingerprint);
+          }
+          return undefined;
+        })
+        .then(() => {
+          resource.released = false;
+          request.resolve({
+            context: resource.context,
+            fingerprint,
+            release: (options) => release(resource, options),
+          });
+        })
+        .catch(async (error) => {
+          inUse.delete(resource);
+          await destroyResource(resource);
+          ensureCapacity();
+          request.reject(error);
+        });
+    }
+
+    ensureCapacity();
+  }
+
+  function release(resource, options) {
+    if (!resource || resource.released) {
+      return Promise.resolve();
+    }
+    resource.released = true;
+    inUse.delete(resource);
+
+    const performReset = () => {
+      if (typeof resetContext === 'function') {
+        return resetContext(resource.context, options);
+      }
+      return Promise.resolve();
+    };
+
+    return Promise.resolve()
+      .then(() => performReset())
+      .then(async () => {
+        if (closing || closed) {
+          await destroyResource(resource);
+          return;
+        }
+        resource.released = false;
+        available.push(resource);
+        dispatch();
+      })
+      .catch(async (error) => {
+        await destroyResource(resource);
+        ensureCapacity();
+        throw error;
+      });
+  }
+
+  function spawnContext() {
+    creating += 1;
+    const creation = Promise.resolve()
+      .then(() => createContext())
+      .then((context) => {
+        if (closing || closed) {
+          if (typeof destroyContext === 'function') {
+            return destroyContext(context);
+          }
+          if (context && typeof context.close === 'function') {
+            return context.close();
+          }
+          return undefined;
+        }
+
+        const resource = {
+          context,
+          released: false,
+          destroyed: false,
+        };
+        resource.closedPromise = new Promise((resolve) => {
+          resource.resolveClosed = resolve;
+        });
+        resources.add(resource);
+        available.push(resource);
+        dispatch();
+        return undefined;
+      })
+      .catch((error) => {
+        if (pending.length > 0) {
+          const request = pending.shift();
+          request.reject(error);
+        }
+      })
+      .finally(() => {
+        creating = Math.max(0, creating - 1);
+        creationPromises.delete(creation);
+      });
+    creationPromises.add(creation);
+  }
+
+  function acquire() {
+    if (closing || closed) {
+      return Promise.reject(new Error('browser pool is closed'));
+    }
+    return new Promise((resolve, reject) => {
+      const request = { resolve, reject };
+      pending.push(request);
+      dispatch();
+    });
+  }
+
+  async function close() {
+    if (closed) {
+      return;
+    }
+    closing = true;
+
+    while (pending.length > 0) {
+      const request = pending.shift();
+      request.reject(new Error('browser pool is closed'));
+    }
+
+    if (creationPromises.size > 0) {
+      await Promise.all(Array.from(creationPromises));
+    }
+
+    const destruction = [];
+    for (const resource of Array.from(resources)) {
+      if (!inUse.has(resource)) {
+        destruction.push(destroyResource(resource));
+      }
+    }
+    await Promise.all(destruction);
+
+    if (inUse.size > 0) {
+      await Promise.all(Array.from(inUse, (resource) => resource.closedPromise));
+    }
+
+    closed = true;
+  }
+
+  if (warmup) {
+    ensureCapacity();
+  }
+
+  return {
+    acquire,
+    close,
+  };
+}
+
+module.exports = { createBrowserPool };

--- a/plugins/excavator/queue_manager.js
+++ b/plugins/excavator/queue_manager.js
@@ -1,0 +1,362 @@
+'use strict';
+
+const { URL } = require('node:url');
+
+function createRateLimitedQueue(options = {}) {
+  const {
+    perHost = {},
+    globalLimit = 5,
+    minBackoffMs = 1000,
+    maxBackoffMs = 30000,
+    backoffMultiplier = 2,
+    now = () => Date.now(),
+    setTimeoutFn = (fn, ms) => setTimeout(fn, ms),
+    clearTimeoutFn = (id) => clearTimeout(id),
+    onTelemetry,
+  } = options;
+
+  const tokensPerInterval = Number(perHost.tokens);
+  if (!Number.isFinite(tokensPerInterval) || tokensPerInterval <= 0) {
+    throw new Error('perHost.tokens must be a positive number');
+  }
+
+  const intervalMsRaw = Number(perHost.intervalMs);
+  if (!Number.isFinite(intervalMsRaw) || intervalMsRaw <= 0) {
+    throw new Error('perHost.intervalMs must be a positive number of milliseconds');
+  }
+
+  const burstRaw = Number(perHost.burst);
+  const bucketCapacity =
+    Number.isFinite(burstRaw) && burstRaw > 0 ? burstRaw : Math.max(tokensPerInterval, 1);
+
+  const tokensPerMs = tokensPerInterval / intervalMsRaw;
+
+  const globalCap = Number.isFinite(globalLimit) && globalLimit > 0 ? Math.floor(globalLimit) : Infinity;
+  if (!Number.isFinite(globalCap) || globalCap <= 0) {
+    throw new Error('globalLimit must be a positive number');
+  }
+
+  const minBackoff = Number(minBackoffMs);
+  if (!Number.isFinite(minBackoff) || minBackoff < 0) {
+    throw new Error('minBackoffMs must be a non-negative number');
+  }
+
+  const maxBackoff = Number(maxBackoffMs);
+  if (!Number.isFinite(maxBackoff) || maxBackoff < 0) {
+    throw new Error('maxBackoffMs must be a non-negative number');
+  }
+
+  const multiplier = Number(backoffMultiplier);
+  if (!Number.isFinite(multiplier) || multiplier <= 0) {
+    throw new Error('backoffMultiplier must be a positive number');
+  }
+
+  const queue = [];
+  const hostStates = new Map();
+  let active = 0;
+  let processing = false;
+  let scheduledTimer = null;
+  let closed = false;
+
+  const telemetry = {
+    wait: { totalMs: 0, count: 0, maxMs: 0 },
+    status429: 0,
+    status5xx: 0,
+    maxQueueDepth: 0,
+  };
+
+  function emitTelemetry() {
+    if (typeof onTelemetry === 'function') {
+      onTelemetry(getTelemetrySnapshot());
+    }
+  }
+
+  function updateQueueDepth() {
+    telemetry.maxQueueDepth = Math.max(telemetry.maxQueueDepth, queue.length);
+    emitTelemetry();
+  }
+
+  function recordWait(durationMs) {
+    if (!Number.isFinite(durationMs) || durationMs < 0) {
+      return;
+    }
+    telemetry.wait.totalMs += durationMs;
+    telemetry.wait.count += 1;
+    telemetry.wait.maxMs = Math.max(telemetry.wait.maxMs, durationMs);
+    emitTelemetry();
+  }
+
+  function getTelemetrySnapshot() {
+    const average =
+      telemetry.wait.count > 0 ? telemetry.wait.totalMs / telemetry.wait.count : 0;
+    return {
+      queueDepth: queue.length,
+      maxQueueDepth: telemetry.maxQueueDepth,
+      avgWaitMs: average,
+      maxWaitMs: telemetry.wait.maxMs,
+      waitCount: telemetry.wait.count,
+      status429: telemetry.status429,
+      status5xx: telemetry.status5xx,
+    };
+  }
+
+  function extractHost(task) {
+    if (task && typeof task.host === 'string' && task.host.trim() !== '') {
+      return task.host.trim().toLowerCase();
+    }
+    if (task && typeof task.url === 'string' && task.url.trim() !== '') {
+      try {
+        return new URL(task.url).hostname.toLowerCase();
+      } catch (error) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  function getHostState(host, timestamp) {
+    let state = hostStates.get(host);
+    if (!state) {
+      state = {
+        tokens: bucketCapacity,
+        lastRefill: timestamp,
+        backoffUntil: 0,
+        backoffLevel: 0,
+      };
+      hostStates.set(host, state);
+      return state;
+    }
+    refillTokens(state, timestamp);
+    return state;
+  }
+
+  function refillTokens(state, timestamp) {
+    if (tokensPerMs <= 0) {
+      state.tokens = bucketCapacity;
+      state.lastRefill = timestamp;
+      return;
+    }
+    const elapsed = Math.max(0, timestamp - state.lastRefill);
+    if (elapsed <= 0) {
+      return;
+    }
+    state.tokens = Math.min(bucketCapacity, state.tokens + elapsed * tokensPerMs);
+    state.lastRefill = timestamp;
+  }
+
+  function timeUntilNextToken(state) {
+    if (tokensPerMs <= 0) {
+      return 0;
+    }
+    if (state.tokens >= 1) {
+      return 0;
+    }
+    const deficit = 1 - state.tokens;
+    return Math.ceil(deficit / tokensPerMs);
+  }
+
+  function applyBackoff(state, timestamp) {
+    if (minBackoff <= 0 && maxBackoff <= 0) {
+      state.backoffUntil = 0;
+      return;
+    }
+    state.backoffLevel = Math.min(state.backoffLevel + 1, 32);
+    const effectiveMin = Math.max(minBackoff, 0);
+    const exponent = Math.max(0, state.backoffLevel - 1);
+    const calculated = effectiveMin * Math.pow(multiplier, exponent);
+    const delay = maxBackoff > 0 ? Math.min(maxBackoff, calculated || effectiveMin) : calculated || effectiveMin;
+    state.backoffUntil = timestamp + delay;
+  }
+
+  function resetBackoff(state) {
+    state.backoffLevel = 0;
+    state.backoffUntil = 0;
+  }
+
+  function getStatus(result, error) {
+    if (error) {
+      if (typeof error.status === 'number') {
+        return error.status;
+      }
+      if (typeof error.statusCode === 'number') {
+        return error.statusCode;
+      }
+      return 500;
+    }
+    if (typeof result === 'number') {
+      return result;
+    }
+    if (result && typeof result.status === 'number') {
+      return result.status;
+    }
+    if (result && typeof result.statusCode === 'number') {
+      return result.statusCode;
+    }
+    return undefined;
+  }
+
+  function scheduleNext(delayMs) {
+    if (scheduledTimer) {
+      clearTimeoutFn(scheduledTimer);
+      scheduledTimer = null;
+    }
+    if (queue.length === 0 || closed) {
+      return;
+    }
+    const delay = Math.max(1, Math.ceil(delayMs));
+    scheduledTimer = setTimeoutFn(() => {
+      scheduledTimer = null;
+      processQueue();
+    }, delay);
+  }
+
+  function finalize(entry, hostState, error, result) {
+    active = Math.max(0, active - 1);
+
+    const status = getStatus(result, error);
+    const nowTs = now();
+
+    if (status === 429) {
+      telemetry.status429 += 1;
+      applyBackoff(hostState, nowTs);
+    } else if (typeof status === 'number' && status >= 500 && status < 600) {
+      telemetry.status5xx += 1;
+      applyBackoff(hostState, nowTs);
+    } else if (!error) {
+      resetBackoff(hostState);
+    }
+
+    if (error) {
+      entry.reject(error);
+    } else {
+      entry.resolve(result);
+    }
+
+    emitTelemetry();
+    processQueue();
+  }
+
+  function processQueue() {
+    if (processing || closed) {
+      return;
+    }
+    processing = true;
+
+    if (scheduledTimer) {
+      clearTimeoutFn(scheduledTimer);
+      scheduledTimer = null;
+    }
+
+    try {
+      let nextDelay = null;
+      let nowTs = now();
+
+      for (let i = 0; i < queue.length; i += 1) {
+        if (active >= globalCap) {
+          break;
+        }
+
+        const entry = queue[i];
+        const hostState = getHostState(entry.host, nowTs);
+
+        if (hostState.backoffUntil > nowTs) {
+          const waitBackoff = hostState.backoffUntil - nowTs;
+          nextDelay = nextDelay === null ? waitBackoff : Math.min(nextDelay, waitBackoff);
+          continue;
+        }
+
+        refillTokens(hostState, nowTs);
+        if (hostState.tokens < 1) {
+          const waitForTokens = timeUntilNextToken(hostState);
+          nextDelay = nextDelay === null ? waitForTokens : Math.min(nextDelay, waitForTokens);
+          continue;
+        }
+
+        queue.splice(i, 1);
+        i -= 1;
+        hostState.tokens = Math.max(0, hostState.tokens - 1);
+        active += 1;
+        updateQueueDepth();
+
+        const startTs = now();
+        recordWait(startTs - entry.enqueuedAt);
+
+        Promise.resolve()
+          .then(() => entry.run(entry.task))
+          .then((result) => finalize(entry, hostState, null, result))
+          .catch((error) => finalize(entry, hostState, error, null));
+
+        nowTs = now();
+      }
+
+      if (queue.length > 0 && !closed) {
+        if (nextDelay === null) {
+          nextDelay = Math.max(intervalMsRaw, 10);
+        }
+        scheduleNext(nextDelay);
+      }
+    } finally {
+      processing = false;
+    }
+  }
+
+  function enqueue(task) {
+    if (closed) {
+      return Promise.reject(new Error('rate-limited queue is closed'));
+    }
+    if (!task || typeof task.run !== 'function') {
+      return Promise.reject(new Error('task.run must be a function'));
+    }
+    const host = extractHost(task);
+    if (!host) {
+      return Promise.reject(new Error('task.host or task.url must provide a valid host'));
+    }
+
+    return new Promise((resolve, reject) => {
+      const entry = {
+        host,
+        task,
+        run: task.run,
+        resolve,
+        reject,
+        enqueuedAt: now(),
+      };
+      queue.push(entry);
+      updateQueueDepth();
+      processQueue();
+    });
+  }
+
+  function size() {
+    return queue.length;
+  }
+
+  function activeCount() {
+    return active;
+  }
+
+  async function close() {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    if (scheduledTimer) {
+      clearTimeoutFn(scheduledTimer);
+      scheduledTimer = null;
+    }
+    while (queue.length > 0) {
+      const entry = queue.shift();
+      entry.reject(new Error('rate-limited queue is closed'));
+    }
+  }
+
+  return {
+    enqueue,
+    size,
+    activeCount,
+    close,
+    getTelemetry: getTelemetrySnapshot,
+  };
+}
+
+module.exports = { createRateLimitedQueue };

--- a/plugins/excavator/tests/browser_pool.test.js
+++ b/plugins/excavator/tests/browser_pool.test.js
@@ -1,0 +1,116 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createBrowserPool } = require('../browser_pool');
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test('warms and reuses browser contexts', async () => {
+  const contexts = [];
+  const pool = createBrowserPool({
+    size: 1,
+    warmup: true,
+    createContext: async () => {
+      const context = { id: contexts.length + 1, closed: false };
+      contexts.push(context);
+      return context;
+    },
+    destroyContext: async (context) => {
+      context.closed = true;
+    },
+  });
+
+  const first = await pool.acquire();
+  assert.equal(first.context.id, 1);
+  await first.release();
+
+  const second = await pool.acquire();
+  assert.equal(second.context.id, 1);
+  await second.release();
+
+  await pool.close();
+  assert.equal(contexts.length, 1);
+  assert.equal(contexts[0].closed, true);
+});
+
+test('queues acquire calls until a context is released', async () => {
+  let counter = 0;
+  const pool = createBrowserPool({
+    size: 1,
+    warmup: false,
+    createContext: async () => ({ id: ++counter }),
+  });
+
+  const first = await pool.acquire();
+  const seenContext = first.context;
+  let secondResolved = false;
+
+  const secondPromise = pool.acquire().then((entry) => {
+    secondResolved = true;
+    return entry;
+  });
+
+  await sleep(20);
+  assert.equal(secondResolved, false);
+
+  await first.release();
+  const second = await secondPromise;
+  assert.strictEqual(second.context, seenContext);
+  await second.release();
+
+  await pool.close();
+});
+
+test('rotates fingerprints and invokes reset hooks', async () => {
+  const applied = [];
+  const resets = [];
+  const pool = createBrowserPool({
+    size: 1,
+    warmup: false,
+    fingerprints: ['fp1', 'fp2', 'fp3'],
+    createContext: async () => ({ id: 1 }),
+    applyFingerprint: async (context, fingerprint) => {
+      applied.push({ id: context.id, fingerprint });
+    },
+    resetContext: async (context) => {
+      resets.push(context.id);
+    },
+  });
+
+  const first = await pool.acquire();
+  await first.release();
+  const second = await pool.acquire();
+  await second.release();
+  const third = await pool.acquire();
+  await third.release();
+
+  await pool.close();
+
+  assert.deepStrictEqual(applied.map((entry) => entry.fingerprint), ['fp1', 'fp2', 'fp3']);
+  assert.deepStrictEqual(resets, [1, 1, 1]);
+});
+
+test('close rejects pending acquires and blocks new usage', async () => {
+  let destroyed = false;
+  const pool = createBrowserPool({
+    size: 1,
+    warmup: false,
+    createContext: async () => ({ id: 1 }),
+    destroyContext: async () => {
+      destroyed = true;
+    },
+  });
+
+  const first = await pool.acquire();
+  const pendingAcquire = pool.acquire();
+
+  const closePromise = pool.close();
+
+  await assert.rejects(pendingAcquire, /closed/);
+  await first.release();
+  await closePromise;
+
+  assert.equal(destroyed, true);
+  await assert.rejects(pool.acquire(), /closed/);
+});

--- a/plugins/excavator/tests/queue_manager.test.js
+++ b/plugins/excavator/tests/queue_manager.test.js
@@ -1,0 +1,156 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createRateLimitedQueue } = require('../queue_manager');
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test('enforces per-host token bucket sequencing', async () => {
+  const queue = createRateLimitedQueue({
+    perHost: { tokens: 1, intervalMs: 40, burst: 1 },
+    globalLimit: 4,
+  });
+
+  const starts = [];
+  let active = 0;
+  const tasks = [];
+
+  for (let i = 0; i < 3; i += 1) {
+    tasks.push(
+      queue.enqueue({
+        url: `https://rate.test/page-${i}`,
+        run: async () => {
+          active += 1;
+          starts.push({ index: i, active });
+          await sleep(20);
+          active -= 1;
+          return { status: 200 };
+        },
+      })
+    );
+  }
+
+  await Promise.all(tasks);
+  await queue.close();
+
+  assert.deepStrictEqual(
+    starts.map((entry) => entry.index),
+    [0, 1, 2]
+  );
+  assert.ok(starts.every((entry) => entry.active === 1));
+});
+
+test('respects global concurrency limits across hosts', async () => {
+  const queue = createRateLimitedQueue({
+    perHost: { tokens: 5, intervalMs: 20, burst: 5 },
+    globalLimit: 1,
+  });
+
+  let concurrent = 0;
+  const observed = [];
+  const hosts = ['a.test', 'b.test', 'c.test'];
+
+  const tasks = hosts.map((host) =>
+    queue.enqueue({
+      host,
+      url: `https://${host}/resource`,
+      run: async () => {
+        concurrent += 1;
+        observed.push(concurrent);
+        await sleep(15);
+        concurrent -= 1;
+        return { status: 200 };
+      },
+    })
+  );
+
+  await Promise.all(tasks);
+  await queue.close();
+
+  assert.ok(observed.length >= hosts.length);
+  assert.ok(observed.every((value) => value === 1));
+});
+
+test('applies backoff after 429 responses', async () => {
+  const minBackoff = 40;
+  const queue = createRateLimitedQueue({
+    perHost: { tokens: 5, intervalMs: 10, burst: 5 },
+    globalLimit: 1,
+    minBackoffMs: minBackoff,
+    maxBackoffMs: 250,
+  });
+
+  let firstEnd = 0;
+  let secondStart = 0;
+
+  const first = queue.enqueue({
+    url: 'https://limit.test/start',
+    run: async () => {
+      await sleep(20);
+      firstEnd = Date.now();
+      return { status: 429 };
+    },
+  });
+
+  const second = queue.enqueue({
+    url: 'https://limit.test/next',
+    run: async () => {
+      secondStart = Date.now();
+      await sleep(5);
+      return { status: 200 };
+    },
+  });
+
+  await Promise.all([first, second]);
+  await queue.close();
+
+  assert.ok(secondStart - firstEnd >= minBackoff - 5);
+});
+
+test('reports telemetry for waits and status codes', async () => {
+  const snapshots = [];
+  const queue = createRateLimitedQueue({
+    perHost: { tokens: 1, intervalMs: 30, burst: 1 },
+    globalLimit: 1,
+    minBackoffMs: 30,
+    maxBackoffMs: 60,
+    onTelemetry: (snapshot) => {
+      snapshots.push(snapshot);
+    },
+  });
+
+  const jobs = [
+    queue.enqueue({
+      url: 'https://telemetry.test/1',
+      run: async () => {
+        await sleep(10);
+        return { status: 200 };
+      },
+    }),
+    queue.enqueue({
+      url: 'https://telemetry.test/2',
+      run: async () => {
+        await sleep(10);
+        return { status: 429 };
+      },
+    }),
+    queue.enqueue({
+      url: 'https://telemetry.test/3',
+      run: async () => {
+        await sleep(10);
+        return { status: 503 };
+      },
+    }),
+  ];
+
+  await Promise.all(jobs);
+  const telemetry = queue.getTelemetry();
+  await queue.close();
+
+  assert.ok(telemetry.maxQueueDepth >= 2);
+  assert.ok(telemetry.avgWaitMs > 0);
+  assert.equal(telemetry.status429, 1);
+  assert.equal(telemetry.status5xx, 1);
+  assert.ok(snapshots.some((snapshot) => snapshot.queueDepth >= 2));
+});


### PR DESCRIPTION
## Summary
- add a configurable rate-limited queue with per-host token buckets, global caps, and telemetry hooks for the Excavator crawler
- introduce a Playwright browser pool that warms contexts, rotates optional fingerprints, and supports graceful shutdown
- cover the new infrastructure with node:test suites for queue behavior, backoff logic, telemetry, pooling, and lifecycle handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd57df2c34832aa90fa94067249e3e