### PR TITLE
Add case schema and golden coverage for galdr dedupe

### DIFF
--- a/internal/cases/normalise.go
+++ b/internal/cases/normalise.go
@@ -129,7 +129,7 @@ func extractVectorFromFinding(f findings.Finding) string {
 		return "source_code"
 	case "excavator":
 		return "web_crawl"
-	case "proxy":
+	case "proxy", "galdr":
 		return "http_proxy"
 	default:
 		return "unknown"

--- a/internal/cases/testdata/sample_web_service_case.json
+++ b/internal/cases/testdata/sample_web_service_case.json
@@ -1,0 +1,93 @@
+{
+  "version": "1.0",
+  "id": "TZLB22243HGZ7RJDGEQY5WLMMZ",
+  "asset": {
+    "kind": "web",
+    "identifier": "app.example",
+    "details": "https://app.example/login"
+  },
+  "vector": {
+    "kind": "web",
+    "value": "login"
+  },
+  "summary": "3 plugin signal(s) indicate an issue affecting app.example (https://app.example/login).\n\nKey evidence:\n- [Excavator] Backup archive exposed (MED)\n- [Galdr] Response discloses login banner (LOW)\n- [Seer] Hardcoded API key leaked (HIGH)",
+  "evidence": [
+    {
+      "plugin": "excavator",
+      "type": "excavator.exposed_backup",
+      "message": "Backup archive exposed",
+      "evidence": "backup.zip",
+      "metadata": {
+        "asset_detail": "https://app.example/login",
+        "asset_id": "app.example",
+        "asset_kind": "web",
+        "case_key": "app.example/login",
+        "vector": "web|login"
+      }
+    },
+    {
+      "plugin": "galdr",
+      "type": "galdr.banner",
+      "message": "Response discloses login banner",
+      "evidence": "Example Service v1.2.3",
+      "metadata": {
+        "asset_detail": "https://app.example/login",
+        "asset_id": "app.example",
+        "asset_kind": "web",
+        "case_key": "app.example/login",
+        "vector": "web|login"
+      }
+    },
+    {
+      "plugin": "seer",
+      "type": "seer.secret",
+      "message": "Hardcoded API key leaked",
+      "evidence": "API_KEY=abcd1234",
+      "metadata": {
+        "asset_detail": "https://app.example/login",
+        "asset_id": "app.example",
+        "asset_kind": "web",
+        "case_key": "app.example/login",
+        "vector": "web|login"
+      }
+    }
+  ],
+  "proof": {
+    "summary": "Reproduce the issue on app.example by following 2 synthesised steps.",
+    "steps": [
+      "Review plugin evidence: You are an AI security analyst. Summarise why the following signals combine into a single case.\nAsset: app.example (web)\nAttack vector: web (login)\nEvidence:\n- Plugin=excavator Severity=MED Message=Backup archive exposed\n- Plugin=galdr Severity=LOW Message=Response discloses login banner\n- Plugin=seer Severity=HIGH Message=Hardcoded API key leaked\nProvide a concise narrative and highlight overlapping evidence.",
+      "Execute reproduction instructions synthesised from prompt: Synthesize deterministic reproduction steps for asset app.example (web).\nUse at most 4 steps. Incorporate plugin observations:\n- Excavator evidence: backup.zip\n- Galdr evidence: Example Service v1.2.3\n- Seer evidence: API_KEY=abcd1234\nReturn concise imperative steps."
+    ]
+  },
+  "risk": {
+    "severity": "high",
+    "score": 8,
+    "rationale": "Highest severity reported by contributing plugins: HIGH"
+  },
+  "confidence": 0.75,
+  "confidence_log": "3 plugin(s), 3 finding(s)",
+  "sources": [
+    {
+      "id": "01J0Y7AHAZ3ZKAB1Y7P5Z9Q4C7",
+      "plugin": "excavator",
+      "type": "excavator.exposed_backup",
+      "severity": "med",
+      "target": "https://app.example/login/backup.zip"
+    },
+    {
+      "id": "01J0Y7AHAZ3ZKAB1Y7P5Z9Q4C6",
+      "plugin": "galdr",
+      "type": "galdr.banner",
+      "severity": "low",
+      "target": "https://app.example/login"
+    },
+    {
+      "id": "01J0Y7AHAZ3ZKAB1Y7P5Z9Q4C8",
+      "plugin": "seer",
+      "type": "seer.secret",
+      "severity": "high",
+      "target": "https://app.example/login/static/app.js"
+    }
+  ],
+  "generated_at": "2023-11-15T00:43:20Z"
+}

--- a/internal/cases/testdata/sample_web_service_findings.json
+++ b/internal/cases/testdata/sample_web_service_findings.json
@@ -1,0 +1,56 @@
+[
+  {
+    "version": "0.2",
+    "id": "01J0Y7AHAZ3ZKAB1Y7P5Z9Q4C6",
+    "plugin": "galdr",
+    "type": "galdr.banner",
+    "message": "Response discloses login banner",
+    "target": "https://app.example/login",
+    "evidence": "Example Service v1.2.3",
+    "severity": "low",
+    "ts": "2024-03-04T10:00:00Z",
+    "meta": {
+      "case_key": "app.example/login",
+      "asset_kind": "web",
+      "asset_id": "app.example",
+      "asset_detail": "https://app.example/login",
+      "vector": "web|login"
+    }
+  },
+  {
+    "version": "0.2",
+    "id": "01J0Y7AHAZ3ZKAB1Y7P5Z9Q4C7",
+    "plugin": "excavator",
+    "type": "excavator.exposed_backup",
+    "message": "Backup archive exposed",
+    "target": "https://app.example/login/backup.zip",
+    "evidence": "backup.zip",
+    "severity": "med",
+    "ts": "2024-03-04T10:05:00Z",
+    "meta": {
+      "case_key": "app.example/login",
+      "asset_kind": "web",
+      "asset_id": "app.example",
+      "asset_detail": "https://app.example/login",
+      "vector": "web|login"
+    }
+  },
+  {
+    "version": "0.2",
+    "id": "01J0Y7AHAZ3ZKAB1Y7P5Z9Q4C8",
+    "plugin": "seer",
+    "type": "seer.secret",
+    "message": "Hardcoded API key leaked",
+    "target": "https://app.example/login/static/app.js",
+    "evidence": "API_KEY=abcd1234",
+    "severity": "high",
+    "ts": "2024-03-04T10:10:00Z",
+    "meta": {
+      "case_key": "app.example/login",
+      "asset_kind": "web",
+      "asset_id": "app.example",
+      "asset_detail": "https://app.example/login",
+      "vector": "web|login"
+    }
+  }
+]

--- a/specs/case.schema.json
+++ b/specs/case.schema.json
@@ -1,0 +1,215 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/RowanDark/Glyph/specs/case.schema.json",
+  "title": "Glyph Case v1.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "id",
+    "asset",
+    "vector",
+    "summary",
+    "evidence",
+    "proof",
+    "risk",
+    "confidence",
+    "sources",
+    "generated_at"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1.0",
+      "description": "Schema version marker."
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$",
+      "description": "Stable ULID identifier for the case."
+    },
+    "asset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "identifier"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Normalised asset category (for example web, repo, account)."
+        },
+        "identifier": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Primary identifier for the affected asset."
+        },
+        "details": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional human readable asset detail."
+        }
+      }
+    },
+    "vector": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Normalised attack vector grouping overlapping evidence."
+        },
+        "value": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional free-form qualifier for the attack vector."
+        }
+      }
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Consolidated narrative describing the case."
+    },
+    "evidence": {
+      "type": "array",
+      "description": "Raw plugin evidence rolled up into the case.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["plugin", "type", "message"],
+        "properties": {
+          "plugin": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Plugin that produced the evidence."
+          },
+          "type": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Machine readable evidence type from the plugin."
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Human readable explanation of the evidence."
+          },
+          "evidence": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Optional structured artefact captured by the plugin."
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Plugin-supplied metadata preserved for debugging."
+          }
+        }
+      }
+    },
+    "proof": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["steps"],
+      "properties": {
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "description": "One-line overview of the reproduction approach."
+        },
+        "steps": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Deterministic reproduction steps synthesised from plugin evidence."
+        }
+      }
+    },
+    "risk": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["severity", "score"],
+      "properties": {
+        "severity": {
+          "type": "string",
+          "enum": ["info", "low", "med", "high", "crit"],
+          "description": "Highest severity represented within the case."
+        },
+        "score": {
+          "type": "number",
+          "minimum": 0,
+          "description": "CVSS-like numeric score derived from severity."
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Supporting context that justifies the assigned risk."
+        }
+      }
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Confidence score derived from corroborating evidence."
+    },
+    "confidence_log": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human readable explanation of the confidence score."
+    },
+    "sources": {
+      "type": "array",
+      "description": "Source findings that were rolled up into the case.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "plugin", "type", "severity"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$",
+            "description": "Identifier of the contributing finding."
+          },
+          "plugin": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Plugin responsible for the finding."
+          },
+          "type": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Machine readable finding type."
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["info", "low", "med", "high", "crit"],
+            "description": "Severity assigned to the finding."
+          },
+          "target": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Optional target recorded for the finding."
+          }
+        }
+      }
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the case was generated."
+    },
+    "labels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Optional case-scoped labels derived from findings."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a JSON schema describing the Case export format
- normalise galdr proxy findings with the http_proxy vector and add a multi-plugin golden sample
- extend case tests with reusable fixture loading to validate the new sample output

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ddd45b0848832a89c70329de06d363