### PR TITLE
Add secrets broker tokenization and log redaction

### DIFF
--- a/internal/cases/testdata/sample_web_service_case.json
+++ b/internal/cases/testdata/sample_web_service_case.json
@@ -42,7 +42,7 @@
       "plugin": "seer",
       "type": "seer.secret",
       "message": "Hardcoded API key leaked",
-      "evidence": "API_KEY=abcd1234",
+      "evidence": "API_KEY=[REDACTED_SECRET]",
       "metadata": {
         "asset_detail": "https://app.example/login",
         "asset_id": "app.example",
@@ -56,7 +56,7 @@
     "summary": "Reproduce the issue on app.example by following 2 synthesised steps.",
     "steps": [
       "Review plugin evidence: You are an AI security analyst. Summarise why the following signals combine into a single case.\nAsset: app.example (web)\nAttack vector: web (login)\nEvidence:\n- Plugin=excavator Severity=MED Message=Backup archive exposed\n- Plugin=galdr Severity=LOW Message=Response discloses login banner\n- Plugin=seer Severity=HIGH Message=Hardcoded API key leaked\nProvide a concise narrative and highlight overlapping evidence.",
-      "Execute reproduction instructions synthesised from prompt: Synthesize deterministic reproduction steps for asset app.example (web).\nUse at most 4 steps. Incorporate plugin observations:\n- Excavator evidence: backup.zip\n- Galdr evidence: Example Service v1.2.3\n- Seer evidence: API_KEY=abcd1234\nReturn concise imperative steps."
+      "Execute reproduction instructions synthesised from prompt: Synthesize deterministic reproduction steps for asset app.example (web).\nUse at most 4 steps. Incorporate plugin observations:\n- Excavator evidence: backup.zip\n- Galdr evidence: Example Service v1.2.3\n- Seer evidence: API_KEY=[REDACTED_SECRET]\nReturn concise imperative steps."
     ]
   },
   "risk": {

--- a/internal/logging/audit.go
+++ b/internal/logging/audit.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/RowanDark/Glyph/internal/redact"
 )
 
 type EventType string
@@ -24,6 +26,9 @@ const (
 	EventFindingRejected  EventType = "finding_rejected"
 	EventProxyLifecycle   EventType = "proxy_lifecycle"
 	EventReporter         EventType = "reporter_event"
+	EventSecretsToken     EventType = "secrets_token_issue"
+	EventSecretsAccess    EventType = "secrets_access"
+	EventSecretsDenied    EventType = "secrets_denied"
 )
 
 type Decision string
@@ -169,6 +174,10 @@ func (l *AuditLogger) Emit(event AuditEvent) error {
 	}
 	if event.Component == "" {
 		event.Component = l.component
+	}
+	event.Reason = redact.String(event.Reason)
+	if len(event.Metadata) > 0 {
+		event.Metadata = redact.Map(event.Metadata)
 	}
 	l.core.mu.Lock()
 	defer l.core.mu.Unlock()

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,104 @@
+package redact
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type stringer interface {
+	String() string
+}
+
+var (
+	emailRe     = regexp.MustCompile(`[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}`)
+	kvSecretRe  = regexp.MustCompile(`(?i)((?:api|token|secret|key|password)[-_ ]*(?:id|key|token)?\s*[:=]\s*)(['\"]?)([A-Za-z0-9+/=_\-]{8,})(['\"]?)`)
+	bearerRe    = regexp.MustCompile(`(?i)\b(bearer|token)\s+([A-Za-z0-9._\-]{10,})`)
+	longTokenRe = regexp.MustCompile(`\b[A-Za-z0-9]{32,}\b`)
+)
+
+// String redacts common secret patterns and PII from the provided string.
+func String(in string) string {
+	if strings.TrimSpace(in) == "" {
+		return in
+	}
+	masked := emailRe.ReplaceAllStringFunc(in, func(_ string) string {
+		return "[REDACTED_EMAIL]"
+	})
+	masked = kvSecretRe.ReplaceAllString(masked, `$1$2[REDACTED_SECRET]$4`)
+	masked = bearerRe.ReplaceAllString(masked, `$1 [REDACTED_SECRET]`)
+	masked = longTokenRe.ReplaceAllString(masked, "[REDACTED_SECRET]")
+	return masked
+}
+
+// Interface redacts recognised sensitive values within nested structures.
+func Interface(value any) any {
+	switch v := value.(type) {
+	case string:
+		return String(v)
+	case stringer:
+		return String(v.String())
+	case fmt.Stringer:
+		return String(v.String())
+	case []string:
+		out := make([]string, len(v))
+		for i, s := range v {
+			out[i] = String(s)
+		}
+		return out
+	case []any:
+		out := make([]any, len(v))
+		for i, elem := range v {
+			out[i] = Interface(elem)
+		}
+		return out
+	case map[string]string:
+		return MapString(v)
+	case map[string]any:
+		return Map(v)
+	case []fmt.Stringer:
+		out := make([]string, len(v))
+		for i, s := range v {
+			out[i] = String(s.String())
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+// Map redacts sensitive values within a map of arbitrary values.
+func Map(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = Interface(v)
+	}
+	return out
+}
+
+// MapString redacts sensitive values within a string map.
+func MapString(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = String(v)
+	}
+	return out
+}
+
+// Slice redacts sensitive values within a slice of strings.
+func Slice(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, len(in))
+	for i, v := range in {
+		out[i] = String(v)
+	}
+	return out
+}

--- a/internal/secrets/env.go
+++ b/internal/secrets/env.go
@@ -1,0 +1,39 @@
+package secrets
+
+import "strings"
+
+const envPrefix = "GLYPH_SECRET_"
+
+// FromEnv parses environment variables and returns a plugin -> secret map.
+// Variables must follow the pattern GLYPH_SECRET_<PLUGIN>__<SECRET>=value.
+func FromEnv(env []string) map[string]map[string]string {
+	secrets := make(map[string]map[string]string)
+	for _, entry := range env {
+		if !strings.HasPrefix(entry, envPrefix) {
+			continue
+		}
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimPrefix(parts[0], envPrefix)
+		value := parts[1]
+		segments := strings.SplitN(key, "__", 2)
+		if len(segments) != 2 {
+			continue
+		}
+		plugin := normalise(strings.ReplaceAll(segments[0], "_", "-"))
+		secret := normalise(segments[1])
+		if plugin == "" || secret == "" || strings.TrimSpace(value) == "" {
+			continue
+		}
+		if secrets[plugin] == nil {
+			secrets[plugin] = make(map[string]string)
+		}
+		secrets[plugin][secret] = value
+	}
+	if len(secrets) == 0 {
+		return nil
+	}
+	return secrets
+}

--- a/internal/secrets/manager.go
+++ b/internal/secrets/manager.go
@@ -1,0 +1,262 @@
+package secrets
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/logging"
+)
+
+var (
+	// ErrPluginRequired indicates the plugin name was not supplied.
+	ErrPluginRequired = errors.New("plugin name is required")
+	// ErrSecretRequired indicates no secrets were requested.
+	ErrSecretRequired = errors.New("at least one secret is required")
+	// ErrSecretNotProvisioned signals the requested secret has not been provisioned.
+	ErrSecretNotProvisioned = errors.New("requested secret not provisioned")
+	// ErrTokenNotRecognised indicates the broker does not recognise the provided token.
+	ErrTokenNotRecognised = errors.New("secrets token not recognised")
+	// ErrTokenExpired indicates the token is no longer valid.
+	ErrTokenExpired = errors.New("secrets token expired")
+	// ErrTokenPluginMismatch indicates the token was issued for a different plugin.
+	ErrTokenPluginMismatch = errors.New("secrets token issued for different plugin")
+	// ErrSecretNotGranted signals the requested secret was not included in the grant.
+	ErrSecretNotGranted = errors.New("secret not granted for token")
+)
+
+const defaultTokenTTL = time.Minute
+
+type secretGrant struct {
+	plugin  string
+	secrets map[string]string
+	expires time.Time
+}
+
+// Manager issues short-lived secrets tokens and resolves secret material when authorised.
+type Manager struct {
+	mu sync.Mutex
+
+	secrets map[string]map[string]string
+	grants  map[string]secretGrant
+	clock   func() time.Time
+	ttl     time.Duration
+	audit   *logging.AuditLogger
+}
+
+// Option configures the manager.
+type Option func(*Manager)
+
+// WithClock overrides the time source used for expiry checks.
+func WithClock(clock func() time.Time) Option {
+	return func(m *Manager) {
+		if clock != nil {
+			m.clock = clock
+		}
+	}
+}
+
+// WithTTL overrides the lifetime of issued tokens.
+func WithTTL(ttl time.Duration) Option {
+	return func(m *Manager) {
+		if ttl > 0 {
+			m.ttl = ttl
+		}
+	}
+}
+
+// WithAuditLogger attaches an audit logger used to record issuance events.
+func WithAuditLogger(logger *logging.AuditLogger) Option {
+	return func(m *Manager) {
+		if logger != nil {
+			m.audit = logger
+		}
+	}
+}
+
+// NewManager constructs a Manager initialised with the provided secrets map.
+// The input map is copied to avoid external mutation.
+func NewManager(initial map[string]map[string]string, opts ...Option) *Manager {
+	mgr := &Manager{
+		secrets: make(map[string]map[string]string),
+		grants:  make(map[string]secretGrant),
+		clock:   time.Now,
+		ttl:     defaultTokenTTL,
+	}
+	for plugin, secrets := range initial {
+		mgr.setSecretsLocked(plugin, secrets)
+	}
+	for _, opt := range opts {
+		opt(mgr)
+	}
+	return mgr
+}
+
+// Set registers or updates a secret value for the plugin. Empty values clear the secret.
+func (m *Manager) Set(plugin, name, value string) {
+	pluginKey := normalise(plugin)
+	secretKey := normalise(name)
+	if pluginKey == "" || secretKey == "" {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.secrets == nil {
+		m.secrets = make(map[string]map[string]string)
+	}
+	pluginSecrets, ok := m.secrets[pluginKey]
+	if !ok {
+		pluginSecrets = make(map[string]string)
+		m.secrets[pluginKey] = pluginSecrets
+	}
+	if strings.TrimSpace(value) == "" {
+		delete(pluginSecrets, secretKey)
+		return
+	}
+	pluginSecrets[secretKey] = value
+}
+
+// Issue generates a short-lived token authorising the provided secrets for the plugin.
+func (m *Manager) Issue(plugin string, requested []string) (string, time.Time, error) {
+	pluginName := strings.TrimSpace(plugin)
+	if pluginName == "" {
+		return "", time.Time{}, ErrPluginRequired
+	}
+	if len(requested) == 0 {
+		return "", time.Time{}, ErrSecretRequired
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := m.clock()
+	m.pruneExpiredLocked(now)
+
+	pluginKey := normalise(pluginName)
+	available, ok := m.secrets[pluginKey]
+	if !ok || len(available) == 0 {
+		return "", time.Time{}, fmt.Errorf("%w: %s", ErrSecretNotProvisioned, pluginName)
+	}
+
+	granted := make(map[string]string)
+	sanitizedNames := make([]string, 0, len(requested))
+	for _, name := range requested {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			continue
+		}
+		canonical := normalise(trimmed)
+		value, ok := available[canonical]
+		if !ok {
+			return "", time.Time{}, fmt.Errorf("%w: %s", ErrSecretNotProvisioned, trimmed)
+		}
+		granted[canonical] = value
+		sanitizedNames = append(sanitizedNames, trimmed)
+	}
+	if len(granted) == 0 {
+		return "", time.Time{}, ErrSecretRequired
+	}
+
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", time.Time{}, fmt.Errorf("generate token: %w", err)
+	}
+	token := base64.RawURLEncoding.EncodeToString(raw)
+	expires := now.Add(m.ttl)
+	if m.grants == nil {
+		m.grants = make(map[string]secretGrant)
+	}
+	m.grants[token] = secretGrant{plugin: pluginKey, secrets: granted, expires: expires}
+	if m.audit != nil {
+		_ = m.audit.Emit(logging.AuditEvent{
+			EventType: logging.EventSecretsToken,
+			Decision:  logging.DecisionAllow,
+			PluginID:  pluginName,
+			Metadata: map[string]any{
+				"secrets":    sanitizedNames,
+				"expires_at": expires.UTC(),
+			},
+		})
+	}
+	return token, expires, nil
+}
+
+// Resolve returns the secret value authorised for the provided token.
+func (m *Manager) Resolve(token, plugin, secret string) (string, error) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return "", ErrTokenNotRecognised
+	}
+	pluginName := strings.TrimSpace(plugin)
+	if pluginName == "" {
+		return "", ErrPluginRequired
+	}
+	secretName := strings.TrimSpace(secret)
+	if secretName == "" {
+		return "", ErrSecretRequired
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := m.clock()
+
+	grant, ok := m.grants[token]
+	if !ok {
+		m.pruneExpiredLocked(now)
+		return "", ErrTokenNotRecognised
+	}
+	pluginKey := normalise(pluginName)
+	if grant.plugin != pluginKey {
+		return "", ErrTokenPluginMismatch
+	}
+	if now.After(grant.expires) {
+		delete(m.grants, token)
+		m.pruneExpiredLocked(now)
+		return "", ErrTokenExpired
+	}
+	value, ok := grant.secrets[normalise(secretName)]
+	if !ok {
+		return "", ErrSecretNotGranted
+	}
+	m.pruneExpiredLocked(now)
+	return value, nil
+}
+
+func (m *Manager) pruneExpiredLocked(now time.Time) {
+	for token, grant := range m.grants {
+		if now.After(grant.expires) {
+			delete(m.grants, token)
+		}
+	}
+}
+
+func (m *Manager) setSecretsLocked(plugin string, secrets map[string]string) {
+	pluginKey := normalise(plugin)
+	if pluginKey == "" {
+		return
+	}
+	if len(secrets) == 0 {
+		return
+	}
+	if m.secrets == nil {
+		m.secrets = make(map[string]map[string]string)
+	}
+	copyMap := make(map[string]string, len(secrets))
+	for name, value := range secrets {
+		key := normalise(name)
+		if key == "" || strings.TrimSpace(value) == "" {
+			continue
+		}
+		copyMap[key] = value
+	}
+	if len(copyMap) > 0 {
+		m.secrets[pluginKey] = copyMap
+	}
+}
+
+func normalise(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}

--- a/internal/secrets/manager_test.go
+++ b/internal/secrets/manager_test.go
@@ -1,0 +1,63 @@
+package secrets
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestManagerIssueAndResolve(t *testing.T) {
+	current := time.Unix(0, 0).UTC()
+	clock := func() time.Time { return current }
+	mgr := NewManager(map[string]map[string]string{
+		"seer": {"api_token": "super-secret"},
+	}, WithClock(clock), WithTTL(2*time.Minute))
+
+	token, expires, err := mgr.Issue("seer", []string{"API_TOKEN"})
+	if err != nil {
+		t.Fatalf("Issue returned error: %v", err)
+	}
+	if token == "" {
+		t.Fatalf("expected token to be issued")
+	}
+	if want := current.Add(2 * time.Minute); !expires.Equal(want) {
+		t.Fatalf("expected expiry %v, got %v", want, expires)
+	}
+
+	value, err := mgr.Resolve(token, "seer", "API_TOKEN")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if value != "super-secret" {
+		t.Fatalf("unexpected secret value %q", value)
+	}
+
+	nextToken, _, err := mgr.Issue("seer", []string{"API_TOKEN"})
+	if err != nil {
+		t.Fatalf("Issue second token: %v", err)
+	}
+	if nextToken == token {
+		t.Fatalf("expected new token per issuance")
+	}
+
+	current = current.Add(5 * time.Minute)
+	if _, err := mgr.Resolve(token, "seer", "API_TOKEN"); !errors.Is(err, ErrTokenExpired) {
+		t.Fatalf("expected ErrTokenExpired after ttl, got %v", err)
+	}
+}
+
+func TestManagerDeniesUnknownSecret(t *testing.T) {
+	mgr := NewManager(map[string]map[string]string{
+		"seer": {"api_token": "super-secret"},
+	})
+	token, _, err := mgr.Issue("seer", []string{"API_TOKEN"})
+	if err != nil {
+		t.Fatalf("Issue returned error: %v", err)
+	}
+	if _, err := mgr.Resolve(token, "seer", "DB_PASSWORD"); !errors.Is(err, ErrSecretNotGranted) {
+		t.Fatalf("expected ErrSecretNotGranted, got %v", err)
+	}
+	if _, _, err := mgr.Issue("seer", []string{"DB_PASSWORD"}); !errors.Is(err, ErrSecretNotProvisioned) {
+		t.Fatalf("expected ErrSecretNotProvisioned, got %v", err)
+	}
+}

--- a/internal/secrets/server.go
+++ b/internal/secrets/server.go
@@ -1,0 +1,114 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/RowanDark/Glyph/internal/logging"
+	pb "github.com/RowanDark/Glyph/proto/gen/go/proto/glyph"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Server implements the SecretsBroker gRPC service.
+type Server struct {
+	pb.UnimplementedSecretsBrokerServer
+	manager *Manager
+	audit   *logging.AuditLogger
+}
+
+// ServerOption configures the server.
+type ServerOption func(*Server)
+
+// WithServerAuditLogger overrides the audit logger used by the server.
+func WithServerAuditLogger(logger *logging.AuditLogger) ServerOption {
+	return func(s *Server) {
+		if logger != nil {
+			s.audit = logger
+		}
+	}
+}
+
+// NewServer constructs a secrets broker backed by the provided manager.
+func NewServer(manager *Manager, opts ...ServerOption) *Server {
+	if manager == nil {
+		manager = NewManager(nil)
+	}
+	srv := &Server{
+		manager: manager,
+		audit:   logging.MustNewAuditLogger("secrets_broker"),
+	}
+	for _, opt := range opts {
+		opt(srv)
+	}
+	return srv
+}
+
+// GetSecret resolves the requested secret when authorised by the provided token.
+func (s *Server) GetSecret(ctx context.Context, req *pb.SecretAccessRequest) (*pb.SecretAccessResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+	plugin := strings.TrimSpace(req.GetPluginName())
+	token := strings.TrimSpace(req.GetToken())
+	name := strings.TrimSpace(req.GetSecretName())
+	if plugin == "" {
+		return nil, status.Error(codes.InvalidArgument, "plugin_name is required")
+	}
+	if token == "" {
+		return nil, status.Error(codes.InvalidArgument, "token is required")
+	}
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "secret_name is required")
+	}
+
+	value, err := s.manager.Resolve(token, plugin, name)
+	if err != nil {
+		return nil, s.handleResolveError(plugin, name, err)
+	}
+	s.emit(logging.AuditEvent{
+		EventType: logging.EventSecretsAccess,
+		Decision:  logging.DecisionAllow,
+		PluginID:  plugin,
+		Metadata: map[string]any{
+			"secret_name": name,
+		},
+	})
+	return &pb.SecretAccessResponse{Value: value}, nil
+}
+
+func (s *Server) handleResolveError(plugin, name string, err error) error {
+	var code codes.Code
+	switch {
+	case errors.Is(err, ErrTokenNotRecognised),
+		errors.Is(err, ErrTokenExpired),
+		errors.Is(err, ErrTokenPluginMismatch),
+		errors.Is(err, ErrSecretNotGranted),
+		errors.Is(err, ErrPluginRequired),
+		errors.Is(err, ErrSecretRequired):
+		code = codes.PermissionDenied
+	default:
+		code = codes.Internal
+	}
+	s.emit(logging.AuditEvent{
+		EventType: logging.EventSecretsDenied,
+		Decision:  logging.DecisionDeny,
+		PluginID:  plugin,
+		Reason:    err.Error(),
+		Metadata: map[string]any{
+			"secret_name": name,
+		},
+	})
+	if code == codes.Internal {
+		return status.Error(code, "resolve secret")
+	}
+	return status.Error(code, err.Error())
+}
+
+func (s *Server) emit(event logging.AuditEvent) {
+	if s.audit == nil {
+		return
+	}
+	_ = s.audit.Emit(event)
+}

--- a/internal/secrets/server_test.go
+++ b/internal/secrets/server_test.go
@@ -1,0 +1,99 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/RowanDark/Glyph/internal/logging"
+	pb "github.com/RowanDark/Glyph/proto/gen/go/proto/glyph"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestServerGetSecret(t *testing.T) {
+	mgr := NewManager(map[string]map[string]string{
+		"seer": {"api_token": "top-secret"},
+	})
+	token, _, err := mgr.Issue("seer", []string{"API_TOKEN"})
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	logger, buf := newAuditLogger(t)
+	srv := NewServer(mgr, WithServerAuditLogger(logger))
+
+	resp, err := srv.GetSecret(context.Background(), &pb.SecretAccessRequest{
+		PluginName: "seer",
+		Token:      token,
+		SecretName: "API_TOKEN",
+	})
+	if err != nil {
+		t.Fatalf("GetSecret returned error: %v", err)
+	}
+	if resp.GetValue() != "top-secret" {
+		t.Fatalf("unexpected secret value %q", resp.GetValue())
+	}
+	if strings.Contains(buf.String(), "top-secret") {
+		t.Fatalf("secret leaked to audit log: %s", buf.String())
+	}
+	event := decodeAuditEvent(t, buf.Bytes())
+	if event.EventType != logging.EventSecretsAccess {
+		t.Fatalf("expected secrets access event, got %q", event.EventType)
+	}
+	if event.Decision != logging.DecisionAllow {
+		t.Fatalf("expected allow decision, got %q", event.Decision)
+	}
+}
+
+func TestServerDeniesUnrequestedSecret(t *testing.T) {
+	mgr := NewManager(map[string]map[string]string{
+		"seer": {"api_token": "top-secret"},
+	})
+	token, _, err := mgr.Issue("seer", []string{"API_TOKEN"})
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	logger, buf := newAuditLogger(t)
+	srv := NewServer(mgr, WithServerAuditLogger(logger))
+
+	_, err = srv.GetSecret(context.Background(), &pb.SecretAccessRequest{
+		PluginName: "seer",
+		Token:      token,
+		SecretName: "DB_PASSWORD",
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected permission denied, got %v", err)
+	}
+	events := bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n"))
+	if len(events) == 0 {
+		t.Fatalf("expected audit event for denial")
+	}
+	event := decodeAuditEvent(t, events[len(events)-1])
+	if event.EventType != logging.EventSecretsDenied {
+		t.Fatalf("expected secrets denied event, got %q", event.EventType)
+	}
+	if event.Decision != logging.DecisionDeny {
+		t.Fatalf("expected deny decision, got %q", event.Decision)
+	}
+}
+
+func newAuditLogger(t *testing.T) (*logging.AuditLogger, *bytes.Buffer) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	logger, err := logging.NewAuditLogger("test", logging.WithoutStdout(), logging.WithWriter(buf))
+	if err != nil {
+		t.Fatalf("create audit logger: %v", err)
+	}
+	return logger, buf
+}
+
+func decodeAuditEvent(t *testing.T, data []byte) logging.AuditEvent {
+	t.Helper()
+	var event logging.AuditEvent
+	if err := json.Unmarshal(data, &event); err != nil {
+		t.Fatalf("decode audit event: %v", err)
+	}
+	return event
+}


### PR DESCRIPTION
## Summary
- register the new secrets broker in glyphd using a per-run manager that can load provisioned secrets from environment variables
- implement the secrets manager/server/token issuance logic with audit coverage and comprehensive unit tests
- add a reusable redaction helper and apply it to audit logging and case assembly with refreshed fixtures/tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dde30614e4832a8ff0c7e67d56f03c