### PR TITLE
Add glyphctl export command with SARIF and JSONL outputs

### DIFF
--- a/cmd/glyphctl/export.go
+++ b/cmd/glyphctl/export.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/RowanDark/Glyph/internal/cases"
+	"github.com/RowanDark/Glyph/internal/exporter"
+	"github.com/RowanDark/Glyph/internal/reporter"
+)
+
+func runExport(args []string) int {
+	fs := flag.NewFlagSet("export", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	input := fs.String("input", reporter.DefaultFindingsPath, "path to findings JSONL input")
+	out := fs.String("out", "", "path to write the exported output")
+	formatRaw := fs.String("format", "", "export format (sarif or jsonl)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if strings.TrimSpace(*formatRaw) == "" {
+		fmt.Fprintln(os.Stderr, "--format is required")
+		return 2
+	}
+	format, err := exporter.ParseFormat(*formatRaw)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+
+	inputPath := strings.TrimSpace(*input)
+	if inputPath == "" {
+		fmt.Fprintln(os.Stderr, "--input must be provided")
+		return 2
+	}
+
+	findingsList, err := reporter.ReadJSONL(inputPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load findings: %v\n", err)
+		return 1
+	}
+
+	builder := cases.NewBuilder()
+	casesList, err := builder.Build(context.Background(), findingsList)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "build cases: %v\n", err)
+		return 1
+	}
+
+	outputPath := strings.TrimSpace(*out)
+	if outputPath == "" {
+		switch format {
+		case exporter.FormatSARIF:
+			outputPath = exporter.DefaultSARIFPath
+		case exporter.FormatJSONL:
+			outputPath = exporter.DefaultJSONLPath
+		default:
+			outputPath = exporter.DefaultJSONLPath
+		}
+	}
+
+	var data []byte
+	switch format {
+	case exporter.FormatSARIF:
+		data, err = exporter.EncodeSARIF(casesList)
+	case exporter.FormatJSONL:
+		telemetry := exporter.BuildTelemetry(casesList, len(findingsList))
+		data, err = exporter.EncodeJSONL(casesList, telemetry)
+	default:
+		err = fmt.Errorf("unsupported format: %s", format)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "encode export: %v\n", err)
+		return 1
+	}
+
+	if err := ensureParentDir(outputPath); err != nil {
+		fmt.Fprintf(os.Stderr, "create output directory: %v\n", err)
+		return 1
+	}
+	if err := os.WriteFile(outputPath, data, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "write export: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(os.Stdout, "exported %d case(s) to %s\n", len(casesList), outputPath)
+	return 0
+}
+
+func ensureParentDir(path string) error {
+	dir := filepath.Dir(path)
+	if dir == "." || dir == "" {
+		return nil
+	}
+	return os.MkdirAll(dir, 0o755)
+}

--- a/cmd/glyphctl/export_test.go
+++ b/cmd/glyphctl/export_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunExportJSONL(t *testing.T) {
+	restore := silenceOutput(t)
+	defer restore()
+
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "findings.jsonl")
+	writeFixtureJSONL(t, inputPath)
+	outputPath := filepath.Join(dir, "cases.jsonl")
+
+	if code := runExport([]string{"--input", inputPath, "--out", outputPath, "--format", "jsonl"}); code != 0 {
+		t.Fatalf("runExport jsonl exited with %d", code)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read export: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatalf("expected JSONL output")
+	}
+	lines := bytes.Split(bytes.TrimSpace(data), []byte("\n"))
+	if len(lines) != 2 {
+		t.Fatalf("expected telemetry + single case entry, got %d lines", len(lines))
+	}
+	var telemetry map[string]any
+	if err := json.Unmarshal(lines[0], &telemetry); err != nil {
+		t.Fatalf("unmarshal telemetry: %v", err)
+	}
+	if telemetry["type"] != "telemetry" {
+		t.Fatalf("expected telemetry entry, got %v", telemetry["type"])
+	}
+}
+
+func TestRunExportSARIF(t *testing.T) {
+	restore := silenceOutput(t)
+	defer restore()
+
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "findings.jsonl")
+	writeFixtureJSONL(t, inputPath)
+	outputPath := filepath.Join(dir, "cases.sarif")
+
+	if code := runExport([]string{"--input", inputPath, "--out", outputPath, "--format", "sarif"}); code != 0 {
+		t.Fatalf("runExport sarif exited with %d", code)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read sarif: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal sarif: %v", err)
+	}
+	if doc["version"] != "2.1.0" {
+		t.Fatalf("unexpected SARIF version: %v", doc["version"])
+	}
+}
+
+func TestRunExportMissingFormat(t *testing.T) {
+	restore := silenceOutput(t)
+	defer restore()
+
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "findings.jsonl")
+	writeFixtureJSONL(t, inputPath)
+
+	if code := runExport([]string{"--input", inputPath}); code != 2 {
+		t.Fatalf("expected error exit code, got %d", code)
+	}
+}
+
+func writeFixtureJSONL(t *testing.T, path string) {
+	t.Helper()
+	fixture := filepath.Join("..", "..", "internal", "cases", "testdata", "sample_web_service_findings.json")
+	data, err := os.ReadFile(fixture)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var records []map[string]any
+	if err := json.Unmarshal(data, &records); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create jsonl: %v", err)
+	}
+	defer file.Close()
+	enc := json.NewEncoder(file)
+	for _, rec := range records {
+		if err := enc.Encode(rec); err != nil {
+			t.Fatalf("encode jsonl record: %v", err)
+		}
+	}
+}

--- a/cmd/glyphctl/main.go
+++ b/cmd/glyphctl/main.go
@@ -22,14 +22,16 @@ func main() {
 	}
 
 	switch args[0] {
-	case "report":
-		os.Exit(runReport(args[1:]))
-	case "demo":
-		os.Exit(runDemo(args[1:]))
-	case "findings":
-		os.Exit(runFindings(args[1:]))
-	case "osint-well":
-		os.Exit(runOSINTWell(args[1:]))
+case "report":
+os.Exit(runReport(args[1:]))
+case "demo":
+os.Exit(runDemo(args[1:]))
+case "findings":
+os.Exit(runFindings(args[1:]))
+case "export":
+os.Exit(runExport(args[1:]))
+case "osint-well":
+os.Exit(runOSINTWell(args[1:]))
 	case "rank":
 		os.Exit(runRank(args[1:]))
 	case "config":

--- a/internal/exporter/config.go
+++ b/internal/exporter/config.go
@@ -1,0 +1,50 @@
+package exporter
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	defaultOutputDir = "/out"
+	sarifFilename    = "cases.sarif"
+	jsonlFilename    = "cases.jsonl"
+)
+
+// Format identifies the supported export encodings.
+type Format string
+
+const (
+	// FormatSARIF renders cases in SARIF 2.1.0.
+	FormatSARIF Format = "sarif"
+	// FormatJSONL renders telemetry and cases as newline-delimited JSON objects.
+	FormatJSONL Format = "jsonl"
+)
+
+var (
+	// DefaultSARIFPath is where the SARIF export is written when no --out flag is provided.
+	DefaultSARIFPath = filepath.Join(defaultOutputDir, sarifFilename)
+	// DefaultJSONLPath is where the JSONL export is written when no --out flag is provided.
+	DefaultJSONLPath = filepath.Join(defaultOutputDir, jsonlFilename)
+)
+
+func init() {
+	if custom := strings.TrimSpace(os.Getenv("GLYPH_OUT")); custom != "" {
+		DefaultSARIFPath = filepath.Join(custom, sarifFilename)
+		DefaultJSONLPath = filepath.Join(custom, jsonlFilename)
+	}
+}
+
+// ParseFormat validates the provided format string.
+func ParseFormat(raw string) (Format, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case string(FormatSARIF):
+		return FormatSARIF, nil
+	case string(FormatJSONL):
+		return FormatJSONL, nil
+	default:
+		return "", fmt.Errorf("unsupported format %q (expected sarif or jsonl)", raw)
+	}
+}

--- a/internal/exporter/jsonl.go
+++ b/internal/exporter/jsonl.go
@@ -1,0 +1,38 @@
+package exporter
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/RowanDark/Glyph/internal/cases"
+)
+
+type jsonlEntry struct {
+	Type      string       `json:"type"`
+	Telemetry *Telemetry   `json:"telemetry,omitempty"`
+	Case      *cases.Case  `json:"case,omitempty"`
+	Metrics   *CaseMetrics `json:"metrics,omitempty"`
+}
+
+// EncodeJSONL renders the telemetry snapshot followed by individual case entries as JSONL.
+func EncodeJSONL(casesList []cases.Case, telemetry Telemetry) ([]byte, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+
+	if err := encoder.Encode(jsonlEntry{Type: "telemetry", Telemetry: &telemetry}); err != nil {
+		return nil, fmt.Errorf("encode telemetry entry: %w", err)
+	}
+
+	for _, c := range casesList {
+		clone := c.Clone()
+		metrics := CaseMetrics{SourceCount: len(clone.Sources), EvidenceCount: len(clone.Evidence)}
+		entry := jsonlEntry{Type: "case", Case: &clone, Metrics: &metrics}
+		if err := encoder.Encode(entry); err != nil {
+			return nil, fmt.Errorf("encode case entry %s: %w", clone.ID, err)
+		}
+	}
+
+	return buf.Bytes(), nil
+}

--- a/internal/exporter/jsonl_test.go
+++ b/internal/exporter/jsonl_test.go
@@ -1,0 +1,125 @@
+package exporter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/cases"
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+func TestEncodeJSONLIncludesTelemetryAndCases(t *testing.T) {
+	findingsList := loadSampleFindings(t)
+
+	builder := cases.NewBuilder(
+		cases.WithDeterministicMode(5150),
+		cases.WithClock(func() time.Time { return time.Unix(1700009000, 0).UTC() }),
+	)
+
+	casesList, err := builder.Build(context.Background(), findingsList)
+	if err != nil {
+		t.Fatalf("build cases: %v", err)
+	}
+	if len(casesList) == 0 {
+		t.Fatalf("expected sample fixture to produce cases")
+	}
+
+	telemetry := BuildTelemetry(casesList, len(findingsList))
+	data, err := EncodeJSONL(casesList, telemetry)
+	if err != nil {
+		t.Fatalf("encode jsonl: %v", err)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(data), []byte("\n"))
+	if got, want := len(lines), len(casesList)+1; got != want {
+		t.Fatalf("expected %d JSONL entries, got %d", want, got)
+	}
+
+	var telemetryEntry map[string]any
+	if err := json.Unmarshal(lines[0], &telemetryEntry); err != nil {
+		t.Fatalf("unmarshal telemetry entry: %v", err)
+	}
+	if telemetryEntry["type"] != "telemetry" {
+		t.Fatalf("expected telemetry entry, got %v", telemetryEntry["type"])
+	}
+	rawTelemetry, ok := telemetryEntry["telemetry"].(map[string]any)
+	if !ok {
+		t.Fatalf("telemetry payload missing: %#v", telemetryEntry)
+	}
+	if rawTelemetry["case_count"].(float64) != float64(len(casesList)) {
+		t.Fatalf("unexpected case_count: %#v", rawTelemetry["case_count"])
+	}
+	if rawTelemetry["finding_count"].(float64) != float64(len(findingsList)) {
+		t.Fatalf("unexpected finding_count: %#v", rawTelemetry["finding_count"])
+	}
+	severityCounts, ok := rawTelemetry["severity_counts"].(map[string]any)
+	if !ok {
+		t.Fatalf("severity_counts missing: %#v", rawTelemetry)
+	}
+	for _, key := range []string{"crit", "high", "med", "low", "info"} {
+		if _, exists := severityCounts[key]; !exists {
+			t.Fatalf("severity key %q missing", key)
+		}
+	}
+	pluginCounts, ok := rawTelemetry["plugin_counts"].(map[string]any)
+	if !ok || len(pluginCounts) == 0 {
+		t.Fatalf("plugin_counts missing: %#v", rawTelemetry)
+	}
+
+	for idx, line := range lines[1:] {
+		var entry map[string]any
+		if err := json.Unmarshal(line, &entry); err != nil {
+			t.Fatalf("unmarshal case entry %d: %v", idx, err)
+		}
+		if entry["type"] != "case" {
+			t.Fatalf("expected case entry, got %v", entry["type"])
+		}
+		metrics, ok := entry["metrics"].(map[string]any)
+		if !ok {
+			t.Fatalf("case metrics missing: %#v", entry)
+		}
+		casePayload, ok := entry["case"]
+		if !ok {
+			t.Fatalf("case payload missing: %#v", entry)
+		}
+		buf, err := json.Marshal(casePayload)
+		if err != nil {
+			t.Fatalf("marshal case payload: %v", err)
+		}
+		var decoded cases.Case
+		if err := json.Unmarshal(buf, &decoded); err != nil {
+			t.Fatalf("unmarshal case payload: %v", err)
+		}
+		if decoded.ID == "" {
+			t.Fatalf("case id missing")
+		}
+		if decoded.Risk.Severity == "" {
+			t.Fatalf("risk severity missing")
+		}
+		if got := int(metrics["source_count"].(float64)); got != len(decoded.Sources) {
+			t.Fatalf("source_count mismatch: got %d want %d", got, len(decoded.Sources))
+		}
+		if got := int(metrics["evidence_count"].(float64)); got != len(decoded.Evidence) {
+			t.Fatalf("evidence_count mismatch: got %d want %d", got, len(decoded.Evidence))
+		}
+	}
+}
+
+func loadSampleFindings(t *testing.T) []findings.Finding {
+	t.Helper()
+	path := filepath.Join("..", "cases", "testdata", "sample_web_service_findings.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var fs []findings.Finding
+	if err := json.Unmarshal(data, &fs); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	return fs
+}

--- a/internal/exporter/sarif.go
+++ b/internal/exporter/sarif.go
@@ -1,0 +1,324 @@
+package exporter
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/RowanDark/Glyph/internal/cases"
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+const (
+	sarifSchemaURI = "https://json.schemastore.org/sarif-2.1.0.json"
+	sarifVersion   = "2.1.0"
+)
+
+// EncodeSARIF converts cases into a SARIF 2.1.0 log for interoperability with security tooling.
+func EncodeSARIF(casesList []cases.Case) ([]byte, error) {
+	run := sarifRun{
+		Tool: sarifTool{
+			Driver: sarifDriver{
+				Name:           "Glyph",
+				Version:        "dev",
+				InformationURI: "https://github.com/RowanDark/Glyph",
+				Rules:          make([]sarifReportingDescriptor, 0, len(casesList)),
+			},
+		},
+		Results: make([]sarifResult, 0, len(casesList)),
+	}
+
+	for idx, c := range casesList {
+		rule := buildSarifRule(c)
+		run.Tool.Driver.Rules = append(run.Tool.Driver.Rules, rule)
+
+		result := buildSarifResult(c, idx)
+		run.Results = append(run.Results, result)
+	}
+
+	log := sarifLog{
+		Schema:  sarifSchemaURI,
+		Version: sarifVersion,
+		Runs:    []sarifRun{run},
+	}
+
+	data, err := json.MarshalIndent(log, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode SARIF: %w", err)
+	}
+	data = append(data, '\n')
+	return data, nil
+}
+
+func buildSarifRule(c cases.Case) sarifReportingDescriptor {
+	short := firstLine(c.Summary)
+	helpText := buildHelpText(c)
+
+	props := map[string]any{
+		"glyph": map[string]any{
+			"asset":      c.Asset,
+			"vector":     c.Vector,
+			"risk":       map[string]any{"severity": string(c.Risk.Severity), "score": c.Risk.Score, "rationale": c.Risk.Rationale},
+			"confidence": map[string]any{"score": c.Confidence, "log": c.ConfidenceLog},
+		},
+	}
+	if len(c.Labels) > 0 {
+		props["glyph"].(map[string]any)["labels"] = c.Labels
+	}
+
+	return sarifReportingDescriptor{
+		ID:   c.ID,
+		Name: ruleName(c),
+		ShortDescription: &sarifMultiformatMessageString{
+			Text: short,
+		},
+		FullDescription: &sarifMultiformatMessageString{
+			Text: strings.TrimSpace(c.Summary),
+		},
+		Help:                 &sarifMultiformatMessageString{Text: helpText},
+		DefaultConfiguration: &sarifDefaultConfiguration{Level: severityToSARIFLevel(c.Risk.Severity)},
+		Properties:           props,
+	}
+}
+
+func buildSarifResult(c cases.Case, ruleIndex int) sarifResult {
+	level := severityToSARIFLevel(c.Risk.Severity)
+
+	glyphProps := map[string]any{
+		"case_id":    c.ID,
+		"asset":      c.Asset,
+		"vector":     c.Vector,
+		"risk":       map[string]any{"severity": string(c.Risk.Severity), "score": c.Risk.Score, "rationale": c.Risk.Rationale},
+		"confidence": map[string]any{"score": c.Confidence, "log": c.ConfidenceLog},
+		"sources":    c.Sources,
+		"evidence":   c.Evidence,
+	}
+	if len(c.Labels) > 0 {
+		glyphProps["labels"] = c.Labels
+	}
+
+	props := map[string]any{"glyph": glyphProps}
+
+	result := sarifResult{
+		RuleID:    c.ID,
+		RuleIndex: ruleIndex,
+		Level:     level,
+		Message:   sarifMessage{Text: strings.TrimSpace(c.Summary)},
+		Locations: []sarifLocation{buildSarifLocation(c)},
+		PartialFingerprints: map[string]string{
+			"glyph.case":  c.ID,
+			"glyph.asset": fingerprintForAsset(c.Asset),
+		},
+		Properties: props,
+	}
+
+	if fix := buildFix(c.Proof); fix != nil {
+		result.Fixes = []sarifFix{*fix}
+	}
+
+	return result
+}
+
+func buildSarifLocation(c cases.Case) sarifLocation {
+	var uri string
+	if u := strings.TrimSpace(c.Asset.Details); u != "" {
+		uri = u
+	} else if id := strings.TrimSpace(c.Asset.Identifier); id != "" {
+		uri = id
+	}
+
+	location := sarifLocation{}
+	if uri != "" {
+		location.PhysicalLocation = &sarifPhysicalLocation{ArtifactLocation: &sarifArtifactLocation{URI: uri}}
+	}
+
+	logical := make([]sarifLogicalLocation, 0, 2)
+	if id := strings.TrimSpace(c.Asset.Identifier); id != "" {
+		logical = append(logical, sarifLogicalLocation{Kind: "asset", Name: id, FullyQualifiedName: strings.TrimSpace(c.Asset.Kind)})
+	}
+	if vec := strings.TrimSpace(c.Vector.Kind); vec != "" {
+		name := vec
+		if value := strings.TrimSpace(c.Vector.Value); value != "" {
+			name = fmt.Sprintf("%s:%s", vec, value)
+		}
+		logical = append(logical, sarifLogicalLocation{Kind: "attack-vector", Name: name})
+	}
+	if len(logical) > 0 {
+		location.LogicalLocations = logical
+	}
+	return location
+}
+
+func buildHelpText(c cases.Case) string {
+	var b strings.Builder
+	if summary := strings.TrimSpace(c.Proof.Summary); summary != "" {
+		b.WriteString(summary)
+	}
+	if len(c.Proof.Steps) > 0 {
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString("Recommended remediation steps:\n")
+		for _, step := range c.Proof.Steps {
+			cleaned := strings.TrimSpace(step)
+			if cleaned == "" {
+				continue
+			}
+			b.WriteString("- ")
+			b.WriteString(cleaned)
+			b.WriteString("\n")
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func buildFix(proof cases.ProofOfConcept) *sarifFix {
+	if len(proof.Steps) == 0 {
+		return nil
+	}
+	var b strings.Builder
+	if summary := strings.TrimSpace(proof.Summary); summary != "" {
+		b.WriteString(summary)
+		b.WriteString("\n\n")
+	}
+	for i, step := range proof.Steps {
+		cleaned := strings.TrimSpace(step)
+		if cleaned == "" {
+			continue
+		}
+		b.WriteString(fmt.Sprintf("%d. %s\n", i+1, cleaned))
+	}
+	text := strings.TrimSpace(b.String())
+	if text == "" {
+		return nil
+	}
+	return &sarifFix{Description: &sarifMessage{Text: text}}
+}
+
+func fingerprintForAsset(asset cases.Asset) string {
+	kind := strings.ToLower(strings.TrimSpace(asset.Kind))
+	if kind == "" {
+		kind = "generic"
+	}
+	identifier := strings.TrimSpace(asset.Identifier)
+	if identifier == "" {
+		identifier = "(unspecified)"
+	}
+	return fmt.Sprintf("%s:%s", kind, identifier)
+}
+
+func ruleName(c cases.Case) string {
+	asset := strings.TrimSpace(c.Asset.Identifier)
+	if asset == "" {
+		asset = "unknown-asset"
+	}
+	vector := strings.TrimSpace(c.Vector.Kind)
+	if vector == "" {
+		vector = "unknown-vector"
+	}
+	return fmt.Sprintf("%s:%s", vector, asset)
+}
+
+func firstLine(input string) string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return ""
+	}
+	if idx := strings.IndexByte(input, '\n'); idx >= 0 {
+		return strings.TrimSpace(input[:idx])
+	}
+	return input
+}
+
+func severityToSARIFLevel(sev findings.Severity) string {
+	switch sev {
+	case findings.SeverityCritical, findings.SeverityHigh:
+		return "error"
+	case findings.SeverityMedium:
+		return "warning"
+	case findings.SeverityLow, findings.SeverityInfo:
+		return "note"
+	default:
+		return "none"
+	}
+}
+
+// SARIF domain models kept minimal for schema compliance.
+type sarifLog struct {
+	Schema  string     `json:"$schema"`
+	Version string     `json:"version"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool    sarifTool     `json:"tool"`
+	Results []sarifResult `json:"results"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name           string                     `json:"name"`
+	Version        string                     `json:"version,omitempty"`
+	InformationURI string                     `json:"informationUri,omitempty"`
+	Rules          []sarifReportingDescriptor `json:"rules,omitempty"`
+}
+
+type sarifReportingDescriptor struct {
+	ID                   string                         `json:"id"`
+	Name                 string                         `json:"name,omitempty"`
+	ShortDescription     *sarifMultiformatMessageString `json:"shortDescription,omitempty"`
+	FullDescription      *sarifMultiformatMessageString `json:"fullDescription,omitempty"`
+	Help                 *sarifMultiformatMessageString `json:"help,omitempty"`
+	DefaultConfiguration *sarifDefaultConfiguration     `json:"defaultConfiguration,omitempty"`
+	Properties           map[string]any                 `json:"properties,omitempty"`
+}
+
+type sarifDefaultConfiguration struct {
+	Level string `json:"level,omitempty"`
+}
+
+type sarifMultiformatMessageString struct {
+	Text string `json:"text,omitempty"`
+}
+
+type sarifResult struct {
+	RuleID              string            `json:"ruleId,omitempty"`
+	RuleIndex           int               `json:"ruleIndex,omitempty"`
+	Level               string            `json:"level,omitempty"`
+	Message             sarifMessage      `json:"message"`
+	Locations           []sarifLocation   `json:"locations,omitempty"`
+	PartialFingerprints map[string]string `json:"partialFingerprints,omitempty"`
+	Properties          map[string]any    `json:"properties,omitempty"`
+	Fixes               []sarifFix        `json:"fixes,omitempty"`
+}
+
+type sarifMessage struct {
+	Text     string `json:"text,omitempty"`
+	Markdown string `json:"markdown,omitempty"`
+}
+
+type sarifLocation struct {
+	PhysicalLocation *sarifPhysicalLocation `json:"physicalLocation,omitempty"`
+	LogicalLocations []sarifLogicalLocation `json:"logicalLocations,omitempty"`
+}
+
+type sarifPhysicalLocation struct {
+	ArtifactLocation *sarifArtifactLocation `json:"artifactLocation,omitempty"`
+}
+
+type sarifArtifactLocation struct {
+	URI string `json:"uri,omitempty"`
+}
+
+type sarifLogicalLocation struct {
+	Kind               string `json:"kind,omitempty"`
+	Name               string `json:"name,omitempty"`
+	FullyQualifiedName string `json:"fullyQualifiedName,omitempty"`
+}
+
+type sarifFix struct {
+	Description *sarifMessage `json:"description,omitempty"`
+}

--- a/internal/exporter/sarif_test.go
+++ b/internal/exporter/sarif_test.go
@@ -1,0 +1,100 @@
+package exporter
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/cases"
+)
+
+func TestEncodeSARIFProducesStructuredLog(t *testing.T) {
+	findingsList := loadSampleFindings(t)
+	builder := cases.NewBuilder(
+		cases.WithDeterministicMode(5150),
+		cases.WithClock(func() time.Time { return time.Unix(1700009000, 0).UTC() }),
+	)
+
+	casesList, err := builder.Build(context.Background(), findingsList)
+	if err != nil {
+		t.Fatalf("build cases: %v", err)
+	}
+
+	data, err := EncodeSARIF(casesList)
+	if err != nil {
+		t.Fatalf("encode sarif: %v", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal sarif: %v", err)
+	}
+	if doc["version"] != "2.1.0" {
+		t.Fatalf("unexpected SARIF version: %v", doc["version"])
+	}
+
+	runs, ok := doc["runs"].([]any)
+	if !ok || len(runs) == 0 {
+		t.Fatalf("runs missing in SARIF output")
+	}
+	run, ok := runs[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first run malformed: %#v", runs[0])
+	}
+	tool, ok := run["tool"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool missing: %#v", run)
+	}
+	driver, ok := tool["driver"].(map[string]any)
+	if !ok {
+		t.Fatalf("driver missing: %#v", tool)
+	}
+	if driver["name"] != "Glyph" {
+		t.Fatalf("unexpected driver name: %v", driver["name"])
+	}
+
+	rules, ok := driver["rules"].([]any)
+	if !ok || len(rules) != len(casesList) {
+		t.Fatalf("rules mismatch: got %d want %d", len(rules), len(casesList))
+	}
+
+	results, ok := run["results"].([]any)
+	if !ok || len(results) != len(casesList) {
+		t.Fatalf("results mismatch: got %d want %d", len(results), len(casesList))
+	}
+
+	firstResult, ok := results[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first result malformed: %#v", results[0])
+	}
+	if firstResult["level"] == "" {
+		t.Fatalf("result level missing")
+	}
+	message, ok := firstResult["message"].(map[string]any)
+	if !ok || strings.TrimSpace(message["text"].(string)) == "" {
+		t.Fatalf("result message missing: %#v", firstResult)
+	}
+	if _, ok := firstResult["partialFingerprints"].(map[string]any); !ok {
+		t.Fatalf("partialFingerprints missing")
+	}
+	if fixes, ok := firstResult["fixes"].([]any); !ok || len(fixes) == 0 {
+		t.Fatalf("expected remediation fixes in SARIF result")
+	}
+}
+
+func TestEncodeSARIFEmptyCases(t *testing.T) {
+	data, err := EncodeSARIF(nil)
+	if err != nil {
+		t.Fatalf("encode sarif: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal sarif: %v", err)
+	}
+	runs, ok := doc["runs"].([]any)
+	if !ok || len(runs) == 0 {
+		t.Fatalf("expected at least one run in SARIF output")
+	}
+}

--- a/internal/exporter/telemetry.go
+++ b/internal/exporter/telemetry.go
@@ -1,0 +1,95 @@
+package exporter
+
+import (
+	"strings"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/cases"
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+// Telemetry summarises a pipeline export for downstream data lakes.
+type Telemetry struct {
+	GeneratedAt    findings.Timestamp `json:"generated_at"`
+	CaseCount      int                `json:"case_count"`
+	FindingCount   int                `json:"finding_count"`
+	SeverityCounts map[string]int     `json:"severity_counts"`
+	PluginCounts   map[string]int     `json:"plugin_counts"`
+}
+
+// CaseMetrics captures per-case aggregates emitted alongside case entries.
+type CaseMetrics struct {
+	SourceCount   int `json:"source_count"`
+	EvidenceCount int `json:"evidence_count"`
+}
+
+// BuildTelemetry derives aggregate metrics for the provided cases.
+func BuildTelemetry(casesList []cases.Case, findingsCount int) Telemetry {
+	severityCounts := map[string]int{
+		string(findings.SeverityCritical): 0,
+		string(findings.SeverityHigh):     0,
+		string(findings.SeverityMedium):   0,
+		string(findings.SeverityLow):      0,
+		string(findings.SeverityInfo):     0,
+	}
+	pluginCounts := make(map[string]int)
+
+	var latest time.Time
+	for _, c := range casesList {
+		sev := normaliseSeverity(c.Risk.Severity)
+		severityCounts[sev]++
+
+		ts := c.GeneratedAt.Time().UTC()
+		if ts.After(latest) {
+			latest = ts
+		}
+
+		for _, src := range c.Sources {
+			plugin := strings.ToLower(strings.TrimSpace(src.Plugin))
+			if plugin == "" {
+				plugin = "(unknown)"
+			}
+			pluginCounts[plugin]++
+		}
+	}
+
+	if latest.IsZero() {
+		latest = time.Now().UTC()
+	}
+
+	// Ensure severity keys are present even when no cases were produced.
+	for _, key := range []string{
+		string(findings.SeverityCritical),
+		string(findings.SeverityHigh),
+		string(findings.SeverityMedium),
+		string(findings.SeverityLow),
+		string(findings.SeverityInfo),
+	} {
+		if _, ok := severityCounts[key]; !ok {
+			severityCounts[key] = 0
+		}
+	}
+
+	return Telemetry{
+		GeneratedAt:    findings.NewTimestamp(latest.Truncate(time.Second)),
+		CaseCount:      len(casesList),
+		FindingCount:   findingsCount,
+		SeverityCounts: severityCounts,
+		PluginCounts:   pluginCounts,
+	}
+}
+
+func normaliseSeverity(sev findings.Severity) string {
+	switch sev {
+	case findings.SeverityCritical:
+		return string(findings.SeverityCritical)
+	case findings.SeverityHigh:
+		return string(findings.SeverityHigh)
+	case findings.SeverityMedium:
+		return string(findings.SeverityMedium)
+	case findings.SeverityLow:
+		return string(findings.SeverityLow)
+	default:
+		return string(findings.SeverityInfo)
+	}
+}

--- a/specs/pipeline-export.schema.json
+++ b/specs/pipeline-export.schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Glyph pipeline export entry",
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["telemetry", "case"]
+    },
+    "telemetry": {
+      "$ref": "#/definitions/telemetry"
+    },
+    "case": {
+      "$ref": "./case.schema.json"
+    },
+    "metrics": {
+      "$ref": "#/definitions/metrics"
+    }
+  },
+  "required": ["type"],
+  "additionalProperties": false,
+  "definitions": {
+    "telemetry": {
+      "type": "object",
+      "required": [
+        "generated_at",
+        "case_count",
+        "finding_count",
+        "severity_counts",
+        "plugin_counts"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "generated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "case_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "finding_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "severity_counts": {
+          "type": "object",
+          "required": ["crit", "high", "med", "low", "info"],
+          "additionalProperties": false,
+          "properties": {
+            "crit": {"type": "integer", "minimum": 0},
+            "high": {"type": "integer", "minimum": 0},
+            "med": {"type": "integer", "minimum": 0},
+            "low": {"type": "integer", "minimum": 0},
+            "info": {"type": "integer", "minimum": 0}
+          }
+        },
+        "plugin_counts": {
+          "type": "object",
+          "patternProperties": {
+            ".+": {"type": "integer", "minimum": 0}
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "required": ["source_count", "evidence_count"],
+      "additionalProperties": false,
+      "properties": {
+        "source_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "evidence_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": {"const": "telemetry"}
+        }
+      },
+      "then": {
+        "required": ["telemetry"],
+        "properties": {
+          "telemetry": {"$ref": "#/definitions/telemetry"}
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {"const": "case"}
+        }
+      },
+      "then": {
+        "required": ["case"],
+        "properties": {
+          "case": {"$ref": "./case.schema.json"},
+          "metrics": {"$ref": "#/definitions/metrics"}
+        }
+      }
+    }
+  ]
+}

--- a/specs/sarif-2.1.0.schema.json
+++ b/specs/sarif-2.1.0.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SARIF 2.1.0 (subset for Glyph exports)",
+  "type": "object",
+  "required": ["version", "runs"],
+  "properties": {
+    "$schema": {"type": "string"},
+    "version": {
+      "type": "string",
+      "const": "2.1.0"
+    },
+    "runs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["tool", "results"],
+        "properties": {
+          "tool": {
+            "type": "object",
+            "required": ["driver"],
+            "properties": {
+              "driver": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {"type": "string"},
+                  "version": {"type": "string"},
+                  "informationUri": {"type": "string"},
+                  "rules": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/reportingDescriptor"}
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          },
+          "results": {
+            "type": "array",
+            "items": {"$ref": "#/definitions/result"}
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true,
+  "definitions": {
+    "reportingDescriptor": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": {"type": "string"},
+        "name": {"type": "string"},
+        "shortDescription": {"$ref": "#/definitions/multiformatMessage"},
+        "fullDescription": {"$ref": "#/definitions/multiformatMessage"},
+        "help": {"$ref": "#/definitions/multiformatMessage"},
+        "defaultConfiguration": {
+          "type": "object",
+          "properties": {
+            "level": {
+              "type": "string",
+              "enum": ["none", "note", "warning", "error"]
+            }
+          },
+          "additionalProperties": true
+        },
+        "properties": {"type": "object"}
+      },
+      "additionalProperties": true
+    },
+    "result": {
+      "type": "object",
+      "required": ["message"],
+      "properties": {
+        "ruleId": {"type": "string"},
+        "ruleIndex": {"type": "integer", "minimum": 0},
+        "level": {
+          "type": "string",
+          "enum": ["none", "note", "warning", "error"]
+        },
+        "message": {"$ref": "#/definitions/message"},
+        "locations": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/location"}
+        },
+        "partialFingerprints": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "properties": {"type": "object"},
+        "fixes": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/fix"}
+        }
+      },
+      "additionalProperties": true
+    },
+    "message": {
+      "type": "object",
+      "properties": {
+        "text": {"type": "string"},
+        "markdown": {"type": "string"}
+      },
+      "additionalProperties": true
+    },
+    "multiformatMessage": {
+      "type": "object",
+      "properties": {
+        "text": {"type": "string"}
+      },
+      "additionalProperties": true
+    },
+    "location": {
+      "type": "object",
+      "properties": {
+        "physicalLocation": {
+          "type": "object",
+          "properties": {
+            "artifactLocation": {
+              "type": "object",
+              "properties": {
+                "uri": {"type": "string"}
+              },
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        },
+        "logicalLocations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "kind": {"type": "string"},
+              "name": {"type": "string"},
+              "fullyQualifiedName": {"type": "string"}
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "fix": {
+      "type": "object",
+      "properties": {
+        "description": {"$ref": "#/definitions/message"}
+      },
+      "additionalProperties": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a glyphctl export command that builds cases from findings and writes SARIF or JSONL artifacts
- create an exporter package with telemetry aggregation plus SARIF/JSONL encoders backed by new schema files
- cover the new command and encoders with unit tests to keep CLI exports schema-compliant

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dee438b7a4832aa921da4e19857bc3