### PR TITLE
Fix docs deployment workflow and README link

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
   workflow_dispatch:
 
 permissions:
@@ -15,7 +13,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -28,10 +26,10 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install documentation tooling
+      - name: Install MkDocs toolchain
         run: |
           python -m pip install --upgrade pip
-          pip install mkdocs-material
+          pip install mkdocs mkdocs-material mkdocs-redirects
 
       - name: Configure Git user
         run: |
@@ -41,23 +39,15 @@ jobs:
       - name: Build documentation
         run: mkdocs build --strict
 
-      - name: Smoke test key docs pages
-        run: |
-          python -m http.server --directory site 8000 >/tmp/mkdocs-http.log 2>&1 &
-          server_pid=$!
-          cleanup() {
-            kill $server_pid 2>/dev/null || true
-          }
-          trap cleanup EXIT
-          for _ in 1 2 3 4 5; do
-            if curl -fsS --retry 5 --retry-delay 1 --retry-connrefused http://127.0.0.1:8000/ >/dev/null; then
-              break
-            fi
-            sleep 1
-          done
-          for path in "" quickstart/ cli/ plugins/ security/; do
-            curl -fsS --retry 3 --retry-delay 1 --retry-connrefused "http://127.0.0.1:8000/${path}" >/dev/null
-          done
-
       - name: Deploy documentation
         run: mkdocs gh-deploy --force --clean --remote-name origin --remote-branch gh-pages
+
+  smoke:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check published pages
+        run: |
+          for p in "" "quickstart/" "cli/" "plugins/" "security/"; do
+            curl -fSL "https://rowandark.github.io/Glyph/${p}" >/dev/null
+          done

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Highlights include:
 * [Security overview](https://rowandark.github.io/Glyph/security/)
 * [Build provenance](https://rowandark.github.io/Glyph/security/provenance/)
 * [Supply chain security](https://rowandark.github.io/Glyph/security/supply-chain/)
-* [Threat model](THREAT_MODEL.md)
+* [Threat model](https://rowandark.github.io/Glyph/security/threat-model/)
 * [Plugin security guide](PLUGIN_GUIDE.md)
 
 ## Security

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_description: Documentation for the Glyph red-team and detection automation 
 site_url: https://rowandark.github.io/Glyph/
 repo_url: https://github.com/RowanDark/Glyph
 repo_name: RowanDark/Glyph
+use_directory_urls: true
 
 nav:
   - Home: index.md
@@ -40,6 +41,7 @@ theme:
 
 plugins:
   - search
+  - redirects
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- refresh the docs workflow to install the MkDocs toolchain, push to gh-pages, and smoke test the published site
- enable directory URLs and the redirects plugin in MkDocs so published routes match expectations
- update the README threat model link to the published documentation

## Testing
- ⚠️ `python -m pip install --quiet mkdocs mkdocs-material mkdocs-redirects` *(fails in container: proxy blocks outbound pip traffic)*

------
https://chatgpt.com/codex/tasks/task_e_68df1959886c832a94c5452ae215ada2