### PR TITLE
Add plugin hot reloading support

### DIFF
--- a/cmd/glyphd/main_test.go
+++ b/cmd/glyphd/main_test.go
@@ -33,7 +33,7 @@ func TestServeBootsAndShutsDown(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- serve(ctx, lis, "test-token", coreLogger, busLogger, false)
+		errCh <- serve(ctx, lis, "test-token", coreLogger, busLogger, false, "")
 	}()
 
 	dialCtx, dialCancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/internal/plugins/hotreload/hotreloader.go
+++ b/internal/plugins/hotreload/hotreloader.go
@@ -1,0 +1,334 @@
+package hotreload
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/bus"
+	"github.com/RowanDark/Glyph/internal/logging"
+	"github.com/RowanDark/Glyph/internal/plugins"
+	"github.com/RowanDark/Glyph/internal/plugins/integrity"
+)
+
+const defaultPollInterval = time.Second
+
+// Reloader watches the plugin directory for new or updated manifests and reloads
+// plugins without requiring a glyphd restart.
+type Reloader struct {
+	dir           string
+	repoRoot      string
+	allowlistPath string
+	pollInterval  time.Duration
+	audit         *logging.AuditLogger
+	bus           interface {
+		DisconnectPlugin(pluginName, reason string) int
+	}
+
+	mu      sync.RWMutex
+	plugins map[string]PluginState
+}
+
+// PluginState captures the currently active plugin snapshot tracked by the
+// reloader.
+type PluginState struct {
+	Name         string
+	Version      string
+	ManifestPath string
+	ArtifactPath string
+	ArtifactHash string
+	LoadedAt     time.Time
+}
+
+// Option configures the reloader.
+type Option func(*Reloader)
+
+// WithPollInterval overrides the default polling cadence.
+func WithPollInterval(interval time.Duration) Option {
+	return func(r *Reloader) {
+		if interval > 0 {
+			r.pollInterval = interval
+		}
+	}
+}
+
+// WithAuditLogger sets the audit logger used when emitting plugin lifecycle
+// events.
+func WithAuditLogger(logger *logging.AuditLogger) Option {
+	return func(r *Reloader) {
+		if logger != nil {
+			r.audit = logger
+		}
+	}
+}
+
+// New constructs a hot reloader for the provided plugin directory. The
+// allowlistPath may be empty when allowlist enforcement is not required.
+func New(pluginDir, repoRoot, allowlistPath string, busServer *bus.Server, opts ...Option) (*Reloader, error) {
+	if strings.TrimSpace(pluginDir) == "" {
+		return nil, errors.New("plugin directory is required")
+	}
+	absDir, err := filepath.Abs(pluginDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve plugin directory: %w", err)
+	}
+	info, err := os.Stat(absDir)
+	if err != nil {
+		return nil, fmt.Errorf("stat plugin directory: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("plugin directory %s is not a directory", absDir)
+	}
+
+	absAllowlist := strings.TrimSpace(allowlistPath)
+	if absAllowlist != "" {
+		absAllowlist, err = filepath.Abs(absAllowlist)
+		if err != nil {
+			return nil, fmt.Errorf("resolve allowlist path: %w", err)
+		}
+	}
+	if strings.TrimSpace(repoRoot) != "" {
+		repoRoot, err = filepath.Abs(repoRoot)
+		if err != nil {
+			return nil, fmt.Errorf("resolve repository root: %w", err)
+		}
+	}
+
+	r := &Reloader{
+		dir:           absDir,
+		repoRoot:      repoRoot,
+		allowlistPath: absAllowlist,
+		pollInterval:  defaultPollInterval,
+		audit:         logging.MustNewAuditLogger("plugin_manager"),
+		bus:           busServer,
+		plugins:       make(map[string]PluginState),
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r, nil
+}
+
+// Start begins monitoring the plugin directory until the context is cancelled.
+func (r *Reloader) Start(ctx context.Context) {
+	ticker := time.NewTicker(r.pollInterval)
+	defer ticker.Stop()
+
+	r.scan()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.scan()
+		}
+	}
+}
+
+// Plugins returns a copy of the known plugin state. It is intended for testing
+// and introspection.
+func (r *Reloader) Plugins() map[string]PluginState {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	snapshot := make(map[string]PluginState, len(r.plugins))
+	for k, v := range r.plugins {
+		snapshot[k] = v
+	}
+	return snapshot
+}
+
+func (r *Reloader) scan() {
+	manifests, err := r.discoverManifests()
+	if err != nil {
+		r.emit(logging.AuditEvent{
+			EventType: logging.EventPluginDisconnect,
+			Decision:  logging.DecisionDeny,
+			Reason:    err.Error(),
+			Metadata: map[string]any{
+				"phase": "discover",
+			},
+		})
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Handle removals.
+	for name, state := range r.plugins {
+		_, ok := manifests[name]
+		if ok {
+			continue
+		}
+		if _, err := os.Stat(state.ManifestPath); err != nil {
+			if errors.Is(err, fs.ErrNotExist) || errors.Is(err, os.ErrNotExist) {
+				delete(r.plugins, name)
+				r.emit(logging.AuditEvent{
+					EventType: logging.EventPluginDisconnect,
+					Decision:  logging.DecisionInfo,
+					PluginID:  name,
+					Reason:    "plugin removed from filesystem",
+					Metadata: map[string]any{
+						"manifest": state.ManifestPath,
+					},
+				})
+				if r.bus != nil {
+					r.bus.DisconnectPlugin(name, "plugin removed")
+				}
+			}
+		}
+	}
+
+	// Handle additions and updates.
+	for name, manifest := range manifests {
+		current, ok := r.plugins[name]
+		if ok && current.ArtifactHash == manifest.ArtifactHash {
+			continue
+		}
+
+		if ok && r.bus != nil {
+			r.bus.DisconnectPlugin(name, "plugin hot reload")
+		}
+
+		r.plugins[name] = manifest
+		metadata := map[string]any{
+			"version":       manifest.Version,
+			"manifest_path": manifest.ManifestPath,
+			"artifact_path": manifest.ArtifactPath,
+		}
+		if ok {
+			metadata["previous_hash"] = current.ArtifactHash
+			metadata["previous_version"] = current.Version
+		}
+		r.emit(logging.AuditEvent{
+			EventType: logging.EventPluginLoad,
+			Decision:  logging.DecisionAllow,
+			PluginID:  name,
+			Metadata:  metadata,
+		})
+	}
+}
+
+func (r *Reloader) discoverManifests() (map[string]PluginState, error) {
+	entries, err := os.ReadDir(r.dir)
+	if err != nil {
+		return nil, fmt.Errorf("read plugin directory: %w", err)
+	}
+
+	allowlist, err := r.loadAllowlist()
+	if err != nil && !errors.Is(err, fs.ErrNotExist) && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	manifests := make(map[string]PluginState)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		manifestPath := filepath.Join(r.dir, entry.Name(), "manifest.json")
+		manifest, err := plugins.LoadManifest(manifestPath)
+		if err != nil {
+			r.emit(logging.AuditEvent{
+				EventType: logging.EventPluginDisconnect,
+				Decision:  logging.DecisionDeny,
+				Reason:    fmt.Sprintf("load manifest: %v", err),
+				Metadata: map[string]any{
+					"manifest_path": manifestPath,
+				},
+			})
+			continue
+		}
+
+		artifactPath := manifest.Artifact
+		if !filepath.IsAbs(artifactPath) {
+			artifactPath = filepath.Join(filepath.Dir(manifestPath), artifactPath)
+		}
+		artifactPath = filepath.Clean(artifactPath)
+
+		if allowlist != nil {
+			if err := allowlist.Verify(artifactPath); err != nil {
+				r.emit(logging.AuditEvent{
+					EventType: logging.EventPluginDisconnect,
+					Decision:  logging.DecisionDeny,
+					PluginID:  manifest.Name,
+					Reason:    fmt.Sprintf("allowlist validation failed: %v", err),
+					Metadata: map[string]any{
+						"artifact_path": artifactPath,
+					},
+				})
+				continue
+			}
+		}
+		if err := integrity.VerifySignature(artifactPath, filepath.Dir(manifestPath), r.repoRoot, manifest.Signature); err != nil {
+			r.emit(logging.AuditEvent{
+				EventType: logging.EventPluginDisconnect,
+				Decision:  logging.DecisionDeny,
+				PluginID:  manifest.Name,
+				Reason:    fmt.Sprintf("signature verification failed: %v", err),
+				Metadata: map[string]any{
+					"artifact_path": artifactPath,
+				},
+			})
+			continue
+		}
+
+		hash, err := integrity.HashFile(artifactPath)
+		if err != nil {
+			r.emit(logging.AuditEvent{
+				EventType: logging.EventPluginDisconnect,
+				Decision:  logging.DecisionDeny,
+				PluginID:  manifest.Name,
+				Reason:    fmt.Sprintf("hash artifact: %v", err),
+				Metadata: map[string]any{
+					"artifact_path": artifactPath,
+				},
+			})
+			continue
+		}
+
+		manifests[manifest.Name] = PluginState{
+			Name:         manifest.Name,
+			Version:      manifest.Version,
+			ManifestPath: manifestPath,
+			ArtifactPath: artifactPath,
+			ArtifactHash: hash,
+			LoadedAt:     time.Now().UTC(),
+		}
+	}
+	return manifests, nil
+}
+
+func (r *Reloader) loadAllowlist() (*integrity.Allowlist, error) {
+	if strings.TrimSpace(r.allowlistPath) == "" {
+		return nil, nil
+	}
+	allowlist, err := integrity.LoadAllowlist(r.allowlistPath)
+	if err != nil {
+		r.emit(logging.AuditEvent{
+			EventType: logging.EventPluginDisconnect,
+			Decision:  logging.DecisionDeny,
+			Reason:    fmt.Sprintf("load allowlist: %v", err),
+			Metadata: map[string]any{
+				"allowlist_path": r.allowlistPath,
+			},
+		})
+		return nil, err
+	}
+	return allowlist, nil
+}
+
+func (r *Reloader) emit(event logging.AuditEvent) {
+	if r.audit == nil {
+		return
+	}
+	if err := r.audit.Emit(event); err != nil {
+		fmt.Fprintf(os.Stderr, "plugin manager audit log error: %v\n", err)
+	}
+}

--- a/internal/plugins/hotreload/hotreloader_test.go
+++ b/internal/plugins/hotreload/hotreloader_test.go
@@ -1,0 +1,140 @@
+package hotreload
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/bus"
+	"github.com/RowanDark/Glyph/internal/findings"
+	"github.com/RowanDark/Glyph/internal/logging"
+	"github.com/RowanDark/Glyph/internal/plugins/integrity"
+)
+
+func TestReloaderLoadsAndReloadsPlugin(t *testing.T) {
+	root := t.TempDir()
+	pluginsDir := filepath.Join(root, "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugins dir: %v", err)
+	}
+
+	pluginDir := filepath.Join(pluginsDir, "demo")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugin dir: %v", err)
+	}
+
+	artifactPath := filepath.Join(pluginDir, "plugin.bin")
+	signaturePath := filepath.Join(pluginDir, "plugin.bin.sig")
+	publicKeyPath := filepath.Join(pluginDir, "plugin.pub")
+	manifestPath := filepath.Join(pluginDir, "manifest.json")
+	allowlistPath := filepath.Join(pluginsDir, "ALLOWLIST")
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pubBytes, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal public key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes})
+	if err := os.WriteFile(publicKeyPath, pemBytes, 0o644); err != nil {
+		t.Fatalf("write public key: %v", err)
+	}
+
+	writeVersion := func(version string, content string) string {
+		if err := os.WriteFile(artifactPath, []byte(content), 0o644); err != nil {
+			t.Fatalf("write artifact: %v", err)
+		}
+		hash, err := integrity.HashFile(artifactPath)
+		if err != nil {
+			t.Fatalf("hash artifact: %v", err)
+		}
+		digest := sha256.Sum256([]byte(content))
+		sig, err := ecdsa.SignASN1(rand.Reader, priv, digest[:])
+		if err != nil {
+			t.Fatalf("sign artifact: %v", err)
+		}
+		if err := os.WriteFile(signaturePath, []byte(base64.StdEncoding.EncodeToString(sig)), 0o644); err != nil {
+			t.Fatalf("write signature: %v", err)
+		}
+		manifest := fmt.Sprintf(`{"name":"demo","version":"%s","entry":"plugin.bin","artifact":"plugin.bin","capabilities":["CAP_EMIT_FINDINGS"],"signature":{"signature":"plugin.bin.sig","publicKey":"plugin.pub"}}`, version)
+		if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+		allowlist := fmt.Sprintf("%s demo/plugin.bin\n", hash)
+		if err := os.WriteFile(allowlistPath, []byte(allowlist), 0o644); err != nil {
+			t.Fatalf("write allowlist: %v", err)
+		}
+		return hash
+	}
+
+	firstHash := writeVersion("1.0.0", "version-one")
+
+	busLogger, err := logging.NewAuditLogger("plugin_bus_test", logging.WithoutStdout(), logging.WithWriter(io.Discard))
+	if err != nil {
+		t.Fatalf("create bus audit logger: %v", err)
+	}
+	pluginLogger, err := logging.NewAuditLogger("plugin_manager_test", logging.WithoutStdout(), logging.WithWriter(io.Discard))
+	if err != nil {
+		t.Fatalf("create plugin audit logger: %v", err)
+	}
+	srv := bus.NewServer("token", findings.NewBus(), bus.WithAuditLogger(busLogger))
+
+	reloader, err := New(pluginsDir, root, allowlistPath, srv, WithAuditLogger(pluginLogger), WithPollInterval(10*time.Millisecond))
+	if err != nil {
+		t.Fatalf("construct reloader: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go reloader.Start(ctx)
+
+	waitFor := func(cond func(map[string]PluginState) bool) {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if cond(reloader.Plugins()) {
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		t.Fatalf("condition not met before timeout")
+	}
+
+	waitFor(func(m map[string]PluginState) bool {
+		st, ok := m["demo"]
+		if !ok {
+			return false
+		}
+		return st.Version == "1.0.0" && st.ArtifactHash == firstHash
+	})
+
+	secondHash := writeVersion("2.0.0", "version-two")
+
+	waitFor(func(m map[string]PluginState) bool {
+		st, ok := m["demo"]
+		if !ok {
+			return false
+		}
+		return st.Version == "2.0.0" && st.ArtifactHash == secondHash
+	})
+
+	if err := os.Remove(manifestPath); err != nil {
+		t.Fatalf("remove manifest: %v", err)
+	}
+	waitFor(func(m map[string]PluginState) bool {
+		_, ok := m["demo"]
+		return !ok
+	})
+}


### PR DESCRIPTION
## Summary
- add a plugins-dir flag to glyphd and start a hot reload manager that watches the plugin directory for signed manifest updates
- implement a hotreload package that validates manifests, verifies signatures/allowlist entries, and gracefully disconnects outdated plugin sessions while logging lifecycle events
- extend the plugin bus to support forced disconnects and cover the new behaviour with unit tests alongside end-to-end reloader coverage

## Testing
- go test ./internal/plugins/hotreload -run TestReloaderLoadsAndReloadsPlugin -v
- go test ./... *(fails: runtime/cgo pthread_create failed in internal/plugins/runner)*


------
https://chatgpt.com/codex/tasks/task_e_68e12a8d4714832a93b4b030249e9173