### PR TITLE
Enhance docs resilience and offline experience

### DIFF
--- a/docs/en/data/quickstart-demo.json
+++ b/docs/en/data/quickstart-demo.json
@@ -1,0 +1,55 @@
+{
+  "command": "glyphctl demo",
+  "steps": [
+    {
+      "title": "Start the local target server",
+      "lines": [
+        "glyphctl demo ▸ Launching static target on http://127.0.0.1:7777",
+        "glyphctl demo ▸ Using bundled fixtures so the demo works offline"
+      ]
+    },
+    {
+      "title": "Crawl the page with Excavator",
+      "lines": [
+        "excavator ▸ Discovered 4 internal links and 0 external links",
+        "excavator ▸ Wrote crawl transcript to out/demo/excavator.json"
+      ]
+    },
+    {
+      "title": "Scan rendered markup with Seer",
+      "lines": [
+        "seer ▸ Evaluated 12 audit checks in 1.4s",
+        "seer ▸ Persisted findings to out/demo/findings.jsonl"
+      ]
+    },
+    {
+      "title": "Rank and triage findings",
+      "lines": [
+        "ranker ▸ Loaded 6 findings and produced deterministic scores",
+        "ranker ▸ Saved ranked output to out/demo/ranked.jsonl"
+      ]
+    },
+    {
+      "title": "Render the interactive report",
+      "lines": [
+        "scribe ▸ Generated HTML report with evidence thumbnails",
+        "scribe ▸ Report available at out/demo/report.html"
+      ]
+    }
+  ],
+  "summary": [
+    "✔ Demo complete! Sample artifacts stored under out/demo/"
+  ],
+  "artifacts": [
+    {
+      "label": "Open sample HTML report",
+      "href": "https://github.com/RowanDark/Glyph/blob/main/examples/quickstart/report.html",
+      "description": "Review the reference report the demo builds locally."
+    },
+    {
+      "label": "View findings.jsonl",
+      "href": "https://github.com/RowanDark/Glyph/blob/main/examples/quickstart/findings.jsonl",
+      "description": "Inspect the structured findings that Seer emits."
+    }
+  ]
+}

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -16,6 +16,9 @@ feeds Seer a synthetic response that mirrors the HTML shipped in
 `examples/quickstart/demo-response.html`.
 
 <div id="run-the-pipeline"></div>
+
+The interactive sandbox above replays a full `glyphctl demo` run directly in
+your browser so you can preview the pipeline before installing anything.
 ## Getting started {#getting-started}
 
 ```bash

--- a/docs/es/quickstart.md
+++ b/docs/es/quickstart.md
@@ -15,6 +15,9 @@ si Glyph no puede llegar a `example.com`, la demostración alimenta a Seer con u
 el HTML incluido en `examples/quickstart/demo-response.html`.
 
 <div id="run-the-pipeline"></div>
+
+La caja interactiva anterior reproduce `glyphctl demo` directamente en tu
+navegador para que puedas explorar la canalización antes de instalar nada.
 ## Primeros pasos {#getting-started}
 
 ```bash

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
+from html import escape
 from pathlib import Path
+import re
 from typing import Any
+import uuid
+from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile
 
 from mkdocs.structure.pages import Page
 
@@ -33,6 +38,9 @@ def on_post_build(config: dict[str, Any]) -> None:
     target = site_dir / "api" / "plugin-stats.json"
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(json.dumps(badge_payload, indent=2) + "\n", encoding="utf-8")
+    _minify_static_assets(site_dir)
+    _write_asset_metrics(site_dir)
+    _build_epub_archive(site_dir, config)
 
 
 def _build_badge_payload(docs_dir: Path) -> dict[str, Any]:
@@ -73,3 +81,257 @@ def _build_badge_payload(docs_dir: Path) -> dict[str, Any]:
         "color": "1f6feb",
         "cacheSeconds": 3600,
     }
+
+
+def _minify_static_assets(site_dir: Path) -> None:
+    """Minify custom CSS and JavaScript bundles copied into the site."""
+
+    tasks: list[tuple[Path, str, Any]] = [
+        (site_dir / "stylesheets", ".css", _minify_css),
+        (site_dir / "javascripts", ".js", _minify_js),
+    ]
+
+    for directory, extension, reducer in tasks:
+        if not directory.exists():
+            continue
+        for path in directory.rglob(f"*{extension}"):
+            original = path.read_text(encoding="utf-8")
+            optimised = reducer(original)
+            if optimised and len(optimised) < len(original):
+                path.write_text(optimised, encoding="utf-8")
+
+
+def _write_asset_metrics(site_dir: Path) -> None:
+    """Capture bundle sizes for JS and CSS assets."""
+
+    assets_dir = site_dir / "assets"
+    if not assets_dir.exists():
+        return
+
+    entries: list[dict[str, Any]] = []
+    for path in assets_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix not in {".js", ".css"}:
+            continue
+        relative_path = path.relative_to(site_dir).as_posix()
+        size = path.stat().st_size
+        entries.append({"path": relative_path, "bytes": size})
+
+    entries.sort(key=lambda item: item["bytes"], reverse=True)
+    total_js = sum(item["bytes"] for item in entries if item["path"].endswith(".js"))
+    total_css = sum(item["bytes"] for item in entries if item["path"].endswith(".css"))
+
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "total_js_bytes": total_js,
+        "total_css_bytes": total_css,
+        "top_assets": entries[:25],
+    }
+
+    target = site_dir / "api" / "asset-metrics.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _minify_css(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    text = re.sub(r"\s+", " ", text)
+    text = re.sub(r"\s*([{};:,])\s*", r"\1", text)
+    text = text.replace(";}", "}")
+    return text.strip()
+
+
+def _minify_js(text: str) -> str:
+    result: list[str] = []
+    length = len(text)
+    i = 0
+    in_string = False
+    string_char = ""
+
+    while i < length:
+        char = text[i]
+        if in_string:
+            result.append(char)
+            if char == "\\":
+                i += 2
+                continue
+            if char == string_char:
+                in_string = False
+            i += 1
+            continue
+        if char in {'"', "'", "`"}:
+            in_string = True
+            string_char = char
+            result.append(char)
+            i += 1
+            continue
+        if char == "/" and i + 1 < length:
+            nxt = text[i + 1]
+            if nxt == "/":
+                i += 2
+                while i < length and text[i] not in "\r\n":
+                    i += 1
+                continue
+            if nxt == "*":
+                i += 2
+                while i + 1 < length and not (text[i] == "*" and text[i + 1] == "/"):
+                    i += 1
+                i += 2
+                continue
+        result.append(char)
+        i += 1
+
+    minified = "".join(result)
+    minified = "\n".join(line.rstrip() for line in minified.splitlines())
+    minified = re.sub(r"\n{2,}", "\n", minified)
+    return minified.strip()
+
+
+def _build_epub_archive(site_dir: Path, config: dict[str, Any]) -> None:
+    """Generate a lightweight EPUB snapshot of the rendered documentation."""
+
+    extra = config.get("extra") or {}
+    download_config = extra.get("pdf_download") or {}
+    relative_output = download_config.get("path", "assets/offline/glyph-docs.epub")
+    output_path = site_dir / relative_output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    html_files: list[Path] = []
+    for path in site_dir.glob("**/*.html"):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(site_dir)
+        # Skip assets, APIs, alternate languages, and the 404 page itself.
+        if not relative.parts:
+            continue
+        if relative.parts[0] in {"assets", "api", "es"}:
+            continue
+        if relative.name == "404.html":
+            continue
+        html_files.append(path)
+
+    if not html_files:
+        return
+
+    def sort_key(path: Path) -> tuple[Any, ...]:
+        relative = path.relative_to(site_dir)
+        priority = 1
+        if relative.name == "index.html":
+            priority = 0
+        return (priority, str(relative))
+
+    html_files.sort(key=sort_key)
+
+    items: list[dict[str, Any]] = []
+    for index, path in enumerate(html_files):
+        html = path.read_text(encoding="utf-8")
+        title_match = re.search(r"<title>(.*?)</title>", html, flags=re.IGNORECASE | re.DOTALL)
+        title = title_match.group(1).strip() if title_match else path.stem
+        article_match = re.search(
+            r"<article[^>]*>(.*?)</article>", html, flags=re.IGNORECASE | re.DOTALL
+        )
+        if article_match:
+            body = article_match.group(1).strip()
+        else:
+            body_match = re.search(r"<body[^>]*>(.*)</body>", html, flags=re.IGNORECASE | re.DOTALL)
+            body = body_match.group(1).strip() if body_match else ""
+        if not body:
+            continue
+        relative = path.relative_to(site_dir).with_suffix(".xhtml")
+        href = (Path("text") / relative).as_posix()
+        items.append(
+            {
+                "id": f"doc{index}",
+                "title": title,
+                "href": href,
+                "content": body,
+            }
+        )
+
+    if not items:
+        return
+
+    modified = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    identifier = f"urn:uuid:{uuid.uuid4()}"
+
+    manifest_entries = "\n".join(
+        f'    <item id="{escape(item["id"])}" href="{escape(item["href"])}" media-type="application/xhtml+xml"/>'
+        for item in items
+    )
+    spine_entries = "\n".join(f'    <itemref idref="{escape(item["id"])}"/>' for item in items)
+    nav_entries = "\n".join(
+        f'        <li><a href="{escape(item["href"])}">{escape(item["title"])}</a></li>' for item in items
+    )
+
+    opf = (
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+        "<package version=\"3.0\" xmlns=\"http://www.idpf.org/2007/opf\" unique-identifier=\"bookid\">\n"
+        "  <metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:dcterms=\"http://purl.org/dc/terms/\">\n"
+        f"    <dc:identifier id=\"bookid\">{escape(identifier)}</dc:identifier>\n"
+        "    <dc:title>Glyph Documentation</dc:title>\n"
+        "    <dc:language>en</dc:language>\n"
+        f"    <meta property=\"dcterms:modified\">{escape(modified)}</meta>\n"
+        "  </metadata>\n"
+        "  <manifest>\n"
+        "    <item id=\"nav\" href=\"nav.xhtml\" media-type=\"application/xhtml+xml\" properties=\"nav\"/>\n"
+        f"{manifest_entries}\n"
+        "  </manifest>\n"
+        "  <spine>\n"
+        f"{spine_entries}\n"
+        "  </spine>\n"
+        "</package>\n"
+    )
+
+    nav = (
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+        "<!DOCTYPE html>\n"
+        "<html xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"en\">\n"
+        "  <head>\n"
+        "    <meta charset=\"utf-8\"/>\n"
+        "    <title>Glyph Documentation</title>\n"
+        "  </head>\n"
+        "  <body>\n"
+        "    <nav epub:type=\"toc\">\n"
+        "      <h1>Glyph Documentation</h1>\n"
+        "      <ol>\n"
+        f"{nav_entries}\n"
+        "      </ol>\n"
+        "    </nav>\n"
+        "  </body>\n"
+        "</html>\n"
+    )
+
+    def render_page(item: dict[str, Any]) -> str:
+        return (
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            "<!DOCTYPE html>\n"
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"en\">\n"
+            "  <head>\n"
+            "    <meta charset=\"utf-8\"/>\n"
+            f"    <title>{escape(item['title'])}</title>\n"
+            "    <style>body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:1.5rem;line-height:1.6;}" \
+            "h1,h2,h3{color:#0f172a;} code{background:#f1f5f9;padding:0.1rem 0.3rem;border-radius:0.25rem;}</style>\n"
+            "  </head>\n"
+            "  <body>\n"
+            f"{item['content']}\n"
+            "  </body>\n"
+            "</html>\n"
+        )
+
+    with ZipFile(output_path, "w") as archive:
+        archive.writestr("mimetype", "application/epub+zip", compress_type=ZIP_STORED)
+        archive.writestr(
+            "META-INF/container.xml",
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">\n"
+            "  <rootfiles>\n"
+            "    <rootfile full-path=\"OEBPS/content.opf\" media-type=\"application/oebps-package+xml\"/>\n"
+            "  </rootfiles>\n"
+            "</container>\n",
+            compress_type=ZIP_DEFLATED,
+        )
+        archive.writestr("OEBPS/content.opf", opf, compress_type=ZIP_DEFLATED)
+        archive.writestr("OEBPS/nav.xhtml", nav, compress_type=ZIP_DEFLATED)
+        for item in items:
+            archive.writestr(f"OEBPS/{item['href']}", render_page(item), compress_type=ZIP_DEFLATED)

--- a/docs/javascripts/lazy-media.js
+++ b/docs/javascripts/lazy-media.js
@@ -1,0 +1,57 @@
+(function () {
+  const applyLazyAttributes = () => {
+    const images = document.querySelectorAll('img:not([loading])');
+    images.forEach((image) => {
+      image.setAttribute('loading', 'lazy');
+      if (!image.hasAttribute('decoding')) {
+        image.setAttribute('decoding', 'async');
+      }
+    });
+
+    const observers = [];
+    const attachObserver = (element) => {
+      if ('IntersectionObserver' in window) {
+        const observer = new IntersectionObserver((entries, current) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              const target = entry.target;
+              const lazySrc = target.getAttribute('data-lazy-src');
+              if (lazySrc && !target.src) {
+                target.src = lazySrc;
+              }
+              current.unobserve(target);
+            }
+          });
+        }, {
+          rootMargin: '150px',
+        });
+        observer.observe(element);
+        observers.push(observer);
+      } else {
+        const lazySrc = element.getAttribute('data-lazy-src');
+        if (lazySrc && !element.src) {
+          element.src = lazySrc;
+        }
+      }
+    };
+
+    document.querySelectorAll('iframe[data-lazy-src]').forEach((frame) => {
+      if (frame.src) {
+        return;
+      }
+      attachObserver(frame);
+    });
+  };
+
+  const schedule = () => window.requestAnimationFrame(applyLazyAttributes);
+
+  if (window.document$ && typeof window.document$.subscribe === 'function') {
+    window.document$.subscribe(schedule);
+  }
+
+  if (document.readyState !== 'loading') {
+    schedule();
+  } else {
+    document.addEventListener('DOMContentLoaded', schedule, { once: true });
+  }
+})();

--- a/docs/javascripts/quickstart-demo.js
+++ b/docs/javascripts/quickstart-demo.js
@@ -1,0 +1,303 @@
+(function () {
+  const scriptId = 'quickstart-demo.js';
+  let cachedScenario = null;
+
+  const STRINGS = {
+    en: {
+      title: 'Try Glyph now',
+      description: 'Simulate the `glyphctl demo` command and watch each stage complete without leaving your browser.',
+      statusReady: 'Ready to simulate `glyphctl demo`.',
+      statusRunning: 'Running the walkthrough…',
+      statusComplete: 'Demo finished — explore the generated artifacts below.',
+      run: 'Run full demo',
+      step: 'Step through',
+      reset: 'Reset',
+      artifacts: 'Generated artifacts',
+      artifactHint: 'Open the reference outputs that `glyphctl demo` produces.',
+      commandPrefix: '$ ',
+    },
+    es: {
+      title: 'Prueba Glyph ahora',
+      description: 'Simula el comando `glyphctl demo` y observa cada etapa sin salir de la documentación.',
+      statusReady: 'Listo para simular `glyphctl demo`.',
+      statusRunning: 'Ejecutando la demostración…',
+      statusComplete: 'Demostración finalizada; explora los artefactos generados más abajo.',
+      run: 'Ejecutar demostración',
+      step: 'Avanzar paso a paso',
+      reset: 'Restablecer',
+      artifacts: 'Artefactos generados',
+      artifactHint: 'Abre las salidas de referencia que produce `glyphctl demo`.',
+      commandPrefix: '$ ',
+    },
+  };
+
+  const resolveLocale = () => {
+    const htmlLang = (document.documentElement.getAttribute('lang') || 'en').toLowerCase();
+    return htmlLang.startsWith('es') ? 'es' : 'en';
+  };
+
+  const resolveDocsRoot = (name) => {
+    let script = document.currentScript;
+    if (!script || !(script.src || '').includes(name)) {
+      script = Array.from(document.getElementsByTagName('script')).find((element) =>
+        (element.src || '').includes(name),
+      );
+    }
+    if (!script) {
+      return new URL('.', window.location.href);
+    }
+    const scriptUrl = new URL(script.src, window.location.href);
+    return new URL('..', scriptUrl);
+  };
+
+  const fetchScenario = () => {
+    if (cachedScenario) {
+      return Promise.resolve(cachedScenario);
+    }
+    const docsRoot = resolveDocsRoot(scriptId);
+    const url = new URL('data/quickstart-demo.json', docsRoot);
+    return fetch(url)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Unable to load quickstart scenario: ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((scenario) => {
+        cachedScenario = scenario;
+        return scenario;
+      });
+  };
+
+  const initialise = () => {
+    const host = document.getElementById('run-the-pipeline');
+    if (!host || host.dataset.demoInitialised) {
+      return;
+    }
+
+    host.dataset.demoInitialised = 'true';
+    host.classList.add('demo-runner');
+
+    const locale = resolveLocale();
+    const strings = STRINGS[locale] || STRINGS.en;
+
+    const heading = document.createElement('h3');
+    heading.className = 'demo-runner__heading';
+    heading.textContent = strings.title;
+
+    const description = document.createElement('p');
+    description.className = 'demo-runner__lead';
+    description.textContent = strings.description;
+
+    const terminal = document.createElement('div');
+    terminal.className = 'demo-runner__terminal';
+    terminal.setAttribute('tabindex', '0');
+    terminal.setAttribute('role', 'log');
+    terminal.setAttribute('aria-live', 'polite');
+    terminal.setAttribute('aria-label', strings.title);
+
+    const status = document.createElement('p');
+    status.className = 'demo-runner__status';
+    status.textContent = strings.statusReady;
+
+    const actions = document.createElement('div');
+    actions.className = 'demo-runner__actions';
+
+    const runButton = document.createElement('button');
+    runButton.type = 'button';
+    runButton.textContent = strings.run;
+    runButton.dataset.variant = 'primary';
+
+    const stepButton = document.createElement('button');
+    stepButton.type = 'button';
+    stepButton.textContent = strings.step;
+    stepButton.dataset.variant = 'secondary';
+
+    const resetButton = document.createElement('button');
+    resetButton.type = 'button';
+    resetButton.textContent = strings.reset;
+    resetButton.dataset.variant = 'ghost';
+
+    actions.append(runButton, stepButton, resetButton);
+
+    const artifactsPanel = document.createElement('section');
+    artifactsPanel.className = 'demo-runner__artifacts';
+    artifactsPanel.hidden = true;
+
+    const artifactsHeading = document.createElement('h4');
+    artifactsHeading.textContent = strings.artifacts;
+
+    const artifactsHint = document.createElement('p');
+    artifactsHint.className = 'demo-runner__hint';
+    artifactsHint.textContent = strings.artifactHint;
+
+    const artifactsList = document.createElement('ul');
+
+    artifactsPanel.append(artifactsHeading, artifactsHint, artifactsList);
+
+    host.append(heading, description, terminal, status, actions, artifactsPanel);
+
+    let timer = null;
+    let lineIndex = 0;
+    let lines = [];
+
+    const updateStatus = (text) => {
+      status.textContent = text;
+    };
+
+    const stopTimer = () => {
+      if (timer) {
+        window.clearInterval(timer);
+        timer = null;
+      }
+    };
+
+    const resetDemo = () => {
+      stopTimer();
+      lineIndex = 0;
+      lines = [];
+      terminal.innerHTML = '';
+      artifactsList.innerHTML = '';
+      artifactsPanel.hidden = true;
+      updateStatus(strings.statusReady);
+      runButton.disabled = false;
+      stepButton.disabled = false;
+    };
+
+    const appendLine = (content, className) => {
+      const line = document.createElement('div');
+      line.className = 'demo-runner__output-line';
+      if (className) {
+        line.classList.add(className);
+      }
+      line.textContent = content;
+      terminal.appendChild(line);
+      terminal.scrollTop = terminal.scrollHeight;
+    };
+
+    const revealArtifacts = (scenario) => {
+      artifactsList.innerHTML = '';
+      (scenario.artifacts || []).forEach((artifact) => {
+        const item = document.createElement('li');
+        const link = document.createElement('a');
+        link.href = artifact.href;
+        link.target = '_blank';
+        link.rel = 'noreferrer noopener';
+        link.textContent = artifact.label;
+        item.appendChild(link);
+        if (artifact.description) {
+          const details = document.createElement('div');
+          details.textContent = artifact.description;
+          item.appendChild(details);
+        }
+        artifactsList.appendChild(item);
+      });
+      artifactsPanel.hidden = !artifactsList.childElementCount;
+    };
+
+    const completeRun = (scenario) => {
+      stopTimer();
+      runButton.disabled = false;
+      stepButton.disabled = true;
+      updateStatus(strings.statusComplete);
+      revealArtifacts(scenario);
+    };
+
+    const playNextLine = (scenario) => {
+      if (!lines.length) {
+        return completeRun(scenario);
+      }
+      if (lineIndex >= lines.length) {
+        return completeRun(scenario);
+      }
+      const entry = lines[lineIndex];
+      appendLine(entry.text, entry.kind);
+      lineIndex += 1;
+      if (lineIndex >= lines.length) {
+        completeRun(scenario);
+      }
+    };
+
+    const scheduleRun = (scenario) => {
+      stopTimer();
+      timer = window.setInterval(() => playNextLine(scenario), 650);
+    };
+
+    const hydrate = (scenario) => {
+      resetDemo();
+      const compiled = [];
+      compiled.push({ text: `${strings.commandPrefix}${scenario.command}`, kind: 'demo-runner__prompt' });
+      (scenario.steps || []).forEach((step) => {
+        if (step.title) {
+          compiled.push({ text: `▶ ${step.title}`, kind: 'demo-runner__step' });
+        }
+        (step.lines || []).forEach((line) => {
+          compiled.push({ text: `  ${line}`, kind: 'demo-runner__line' });
+        });
+      });
+      (scenario.summary || []).forEach((line) => {
+        compiled.push({ text: line, kind: 'demo-runner__summary' });
+      });
+      lines = compiled;
+    };
+
+    const ensureScenario = () =>
+      fetchScenario()
+        .then((scenario) => {
+          hydrate(scenario);
+          return scenario;
+        })
+        .catch((error) => {
+          console.error(error); // eslint-disable-line no-console
+          resetDemo();
+          updateStatus('Unable to load the interactive demo.');
+          runButton.disabled = true;
+          stepButton.disabled = true;
+          return null;
+        });
+
+    runButton.addEventListener('click', () => {
+      ensureScenario().then((scenario) => {
+        if (!scenario) {
+          return;
+        }
+        updateStatus(strings.statusRunning);
+        runButton.disabled = true;
+        stepButton.disabled = false;
+        scheduleRun(scenario);
+      });
+    });
+
+    stepButton.addEventListener('click', () => {
+      ensureScenario().then((scenario) => {
+        if (!scenario) {
+          return;
+        }
+        if (!timer && lineIndex === 0) {
+          updateStatus(strings.statusRunning);
+        }
+        stopTimer();
+        runButton.disabled = false;
+        playNextLine(scenario);
+      });
+    });
+
+    resetButton.addEventListener('click', () => {
+      resetDemo();
+    });
+
+    ensureScenario();
+  };
+
+  const init = () => window.requestAnimationFrame(initialise);
+
+  if (window.document$ && typeof window.document$.subscribe === 'function') {
+    window.document$.subscribe(init);
+  }
+
+  if (document.readyState !== 'loading') {
+    init();
+  } else {
+    document.addEventListener('DOMContentLoaded', init);
+  }
+})();

--- a/docs/overrides/404.html
+++ b/docs/overrides/404.html
@@ -1,0 +1,53 @@
+{% extends "main.html" %}
+
+{% block content %}
+  {% set locale = page.lang | d('en') %}
+  {% if locale.startswith('es') %}
+    {% set title = 'No encontramos esa página' %}
+    {% set summary = 'Tal vez el enlace cambió de nombre. Usa las opciones siguientes para volver a la documentación.' %}
+    {% set home_label = 'Volver al inicio' %}
+    {% set search_label = 'Buscar en la documentación' %}
+  {% else %}
+    {% set title = 'We couldn\'t find that page' %}
+    {% set summary = 'The link you followed may be outdated. Use the options below to get back on track.' %}
+    {% set home_label = 'Return home' %}
+    {% set search_label = 'Search the docs' %}
+  {% endif %}
+  <section class="glyph-404" aria-labelledby="glyph-404-title">
+    <h1 class="glyph-404__title" id="glyph-404-title">{{ title }}</h1>
+    <p class="glyph-404__summary">{{ summary }}</p>
+    <div class="glyph-404__actions" role="group" aria-label="404 navigation">
+      <a class="glyph-404__link" data-variant="primary" href="{{ nav.homepage.url | url }}">
+        {% set icon = config.theme.icon.home or 'material/home' %}
+        {% include '.icons/' ~ icon ~ '.svg' %}
+        <span>{{ home_label }}</span>
+      </a>
+      <button class="glyph-404__link" type="button" data-action="open-search">
+        {% set icon = config.theme.icon.search or 'material/magnify' %}
+        {% include '.icons/' ~ icon ~ '.svg' %}
+        <span>{{ search_label }}</span>
+      </button>
+    </div>
+  </section>
+  <script>
+    (function () {
+      const triggerSearch = () => {
+        const toggle = document.querySelector('label[for="__search"]');
+        if (toggle) {
+          toggle.click();
+          const searchField = document.querySelector('input[data-md-component="search-query"]');
+          if (searchField) {
+            searchField.focus({ preventScroll: false });
+          }
+        }
+      };
+      document.addEventListener('click', (event) => {
+        const control = event.target.closest('[data-action="open-search"]');
+        if (control) {
+          event.preventDefault();
+          triggerSearch();
+        }
+      });
+    })();
+  </script>
+{% endblock %}

--- a/docs/overrides/partials/footer.html
+++ b/docs/overrides/partials/footer.html
@@ -1,0 +1,66 @@
+<footer class="md-footer">
+  {% if "navigation.footer" in features %}
+    {% if page.previous_page or page.next_page %}
+      {% if page.meta and page.meta.hide %}
+        {% set hidden = "hidden" if "footer" in page.meta.hide %}
+      {% endif %}
+      <nav class="md-footer__inner md-grid" aria-label="{{ lang.t('footer') }}" {{ hidden }}>
+        {% if page.previous_page %}
+          {% set direction = lang.t("footer.previous") %}
+          <a href="{{ page.previous_page.url | url }}" class="md-footer__link md-footer__link--prev" aria-label="{{ direction }}: {{ page.previous_page.title | e }}">
+            <div class="md-footer__button md-icon">
+              {% set icon = config.theme.icon.previous or "material/arrow-left" %}
+              {% include ".icons/" ~ icon ~ ".svg" %}
+            </div>
+            <div class="md-footer__title">
+              <span class="md-footer__direction">
+                {{ direction }}
+              </span>
+              <div class="md-ellipsis">
+                {{ page.previous_page.title }}
+              </div>
+            </div>
+          </a>
+        {% endif %}
+        {% if page.next_page %}
+          {% set direction = lang.t("footer.next") %}
+          <a href="{{ page.next_page.url | url }}" class="md-footer__link md-footer__link--next" aria-label="{{ direction }}: {{ page.next_page.title | e }}">
+            <div class="md-footer__title">
+              <span class="md-footer__direction">
+                {{ direction }}
+              </span>
+              <div class="md-ellipsis">
+                {{ page.next_page.title }}
+              </div>
+            </div>
+            <div class="md-footer__button md-icon">
+              {% set icon = config.theme.icon.next or "material/arrow-right" %}
+              {% include ".icons/" ~ icon ~ ".svg" %}
+            </div>
+          </a>
+        {% endif %}
+      </nav>
+    {% endif %}
+  {% endif %}
+  <div class="md-footer-meta md-typeset">
+    <div class="md-footer-meta__inner md-grid">
+      {% set pdf_config = config.extra.pdf_download %}
+      {% if pdf_config %}
+        {% set lang_code = page.lang | d('en') %}
+        {% set labels = pdf_config.labels or {} %}
+        {% set descriptions = pdf_config.descriptions or {} %}
+        {% set label = labels[lang_code] | d(labels['en'] | d('Download docs')) %}
+        {% set description = descriptions[lang_code] | d(descriptions['en'] | d(label)) %}
+        <div class="md-footer__download">
+          {% set icon = config.theme.icon.download or 'material/file-download' %}
+          {% include '.icons/' ~ icon ~ '.svg' %}
+          <a href="{{ pdf_config.path | url }}" download title="{{ description }}">{{ label }}</a>
+        </div>
+      {% endif %}
+      {% include "partials/copyright.html" %}
+      {% if config.extra.social %}
+        {% include "partials/social.html" %}
+      {% endif %}
+    </div>
+  </div>
+</footer>

--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -1,0 +1,79 @@
+{% set class = "md-header" %}
+{% if "navigation.tabs.sticky" in features %}
+  {% set class = class ~ " md-header--shadow md-header--lifted" %}
+{% elif "navigation.tabs" not in features %}
+  {% set class = class ~ " md-header--shadow" %}
+{% endif %}
+<header class="{{ class }}" data-md-component="header">
+  <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header') }}">
+    <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}" class="md-header__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
+      {% include "partials/logo.html" %}
+    </a>
+    <label class="md-header__button md-icon" for="__drawer">
+      {% set icon = config.theme.icon.menu or "material/menu" %}
+      {% include ".icons/" ~ icon ~ ".svg" %}
+    </label>
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis">
+        <div class="md-header__topic">
+          <span class="md-ellipsis">
+            {{ config.site_name }}
+          </span>
+        </div>
+        <div class="md-header__topic" data-md-component="header-topic">
+          <span class="md-ellipsis">
+            {% if page.meta and page.meta.title %}
+              {{ page.meta.title }}
+            {% else %}
+              {{ page.title }}
+            {% endif %}
+          </span>
+        </div>
+      </div>
+    </div>
+    {% if config.theme.palette %}
+      {% if not config.theme.palette is mapping %}
+        {% include "partials/palette.html" %}
+      {% endif %}
+    {% endif %}
+    {% if not config.theme.palette is mapping %}
+      {% include "partials/javascripts/palette.html" %}
+    {% endif %}
+    {% if config.extra.alternate %}
+      {% include "partials/alternate.html" %}
+    {% endif %}
+    {% if "material/search" in config.plugins %}
+      {% set search = config.plugins["material/search"] | attr("config") %}
+      {% if search.enabled %}
+        <label class="md-header__button md-icon" for="__search">
+          {% set icon = config.theme.icon.search or "material/magnify" %}
+          {% include ".icons/" ~ icon ~ ".svg" %}
+        </label>
+        {% include "partials/search.html" %}
+      {% endif %}
+    {% endif %}
+    {% set pdf_config = config.extra.pdf_download %}
+    {% if pdf_config %}
+      {% set lang_code = page.lang | d('en') %}
+      {% set labels = pdf_config.labels or {} %}
+      {% set descriptions = pdf_config.descriptions or {} %}
+      {% set label = labels[lang_code] | d(labels['en'] | d('Download docs')) %}
+      {% set description = descriptions[lang_code] | d(descriptions['en'] | d(label)) %}
+      <a class="md-header__button md-header__button--download" href="{{ pdf_config.path | url }}" download title="{{ description }}">
+        {% set icon = config.theme.icon.download or 'material/file-download' %}
+        {% include '.icons/' ~ icon ~ '.svg' %}
+        <span>{{ label }}</span>
+      </a>
+    {% endif %}
+    {% if config.repo_url %}
+      <div class="md-header__source">
+        {% include "partials/source.html" %}
+      </div>
+    {% endif %}
+  </nav>
+  {% if "navigation.tabs.sticky" in features %}
+    {% if "navigation.tabs" in features %}
+      {% include "partials/tabs.html" %}
+    {% endif %}
+  {% endif %}
+</header>

--- a/docs/stylesheets/experience.css
+++ b/docs/stylesheets/experience.css
@@ -1,0 +1,237 @@
+.demo-runner {
+  margin: 1.5rem 0;
+  padding: 1.25rem;
+  border: 1px solid rgba(31, 111, 235, 0.3);
+  border-radius: 0.75rem;
+  background: var(--md-code-bg-color, rgba(31, 111, 235, 0.05));
+  box-shadow: 0 0 0 1px rgba(31, 111, 235, 0.05);
+}
+
+.demo-runner__heading {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 1.3rem;
+}
+
+.demo-runner__lead {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.demo-runner__terminal {
+  background: #0d1117;
+  color: #f6f8fa;
+  border-radius: 0.6rem;
+  padding: 1rem;
+  font-family: var(--md-code-font, monospace);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  max-height: 22rem;
+  overflow-y: auto;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.demo-runner__terminal:focus {
+  outline: 2px solid var(--md-accent-fg-color);
+  outline-offset: 0.2rem;
+}
+
+.demo-runner__output-line {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.demo-runner__output-line.demo-runner__prompt {
+  color: #8be9fd;
+  font-weight: 600;
+}
+
+.demo-runner__output-line.demo-runner__step {
+  color: #58a6ff;
+  font-weight: 600;
+}
+
+.demo-runner__output-line.demo-runner__summary {
+  color: #7ee787;
+  font-weight: 600;
+}
+
+.demo-runner__output-line + .demo-runner__output-line {
+  margin-top: 0.3rem;
+}
+
+.demo-runner__status {
+  margin-top: 1rem;
+  margin-bottom: 0.75rem;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.demo-runner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.demo-runner__actions button {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.15rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.demo-runner__actions button:focus-visible {
+  outline: 3px solid var(--md-accent-fg-color);
+  outline-offset: 2px;
+}
+
+.demo-runner__actions button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.demo-runner__actions button[data-variant="primary"] {
+  background: var(--md-accent-fg-color);
+  color: #0d1117;
+  box-shadow: 0 8px 16px rgba(31, 111, 235, 0.25);
+}
+
+.demo-runner__actions button[data-variant="secondary"] {
+  background: rgba(31, 111, 235, 0.15);
+  color: var(--md-accent-fg-color);
+}
+
+.demo-runner__actions button[data-variant="ghost"] {
+  background: transparent;
+  border: 1px solid rgba(31, 111, 235, 0.3);
+  color: var(--md-accent-fg-color);
+}
+
+.demo-runner__artifacts {
+  margin: 1rem 0 0;
+  padding: 1rem;
+  border-radius: 0.6rem;
+  background: rgba(31, 111, 235, 0.08);
+}
+
+.demo-runner__artifacts h4 {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+}
+
+.demo-runner__artifacts ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.demo-runner__artifacts li + li {
+  margin-top: 0.5rem;
+}
+
+.demo-runner__artifacts a {
+  font-weight: 600;
+}
+
+@media screen and (max-width: 680px) {
+  .demo-runner__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .demo-runner__actions button {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+.glyph-404 {
+  margin: 3rem auto;
+  padding: 2.5rem 1.5rem;
+  max-width: 640px;
+  text-align: center;
+  background: rgba(31, 111, 235, 0.05);
+  border-radius: 1rem;
+  box-shadow: 0 20px 45px rgba(31, 111, 235, 0.15);
+}
+
+.glyph-404__title {
+  font-size: 2.1rem;
+  margin-bottom: 0.75rem;
+}
+
+.glyph-404__summary {
+  font-size: 1.05rem;
+  margin-bottom: 1.5rem;
+}
+
+.glyph-404__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.glyph-404__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--md-accent-fg-color);
+  background: rgba(31, 111, 235, 0.12);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.glyph-404__link[data-variant="primary"] {
+  background: var(--md-accent-fg-color);
+  color: #0d1117;
+}
+
+.glyph-404__link:focus-visible {
+  outline: 3px solid var(--md-accent-fg-color);
+  outline-offset: 2px;
+}
+
+.glyph-404__link:hover {
+  transform: translateY(-2px);
+}
+
+.md-footer__download {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.md-footer__download a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.md-header__button--download {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  background: rgba(31, 111, 235, 0.18);
+  color: var(--md-accent-fg-color);
+}
+
+.md-header__button--download:focus-visible {
+  outline: 3px solid var(--md-accent-fg-color);
+  outline-offset: 2px;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,27 @@ plugins:
         "docs/QuickStart.html": "quickstart/"
         "docs/Quickstart/index.html": "quickstart/"
         "docs/QuickStart/index.html": "quickstart/"
+        # Broader fallbacks for legacy flat HTML exports
+        "plugins.html": "plugins/"
+        "Plugins.html": "plugins/"
+        "plugins/index.html": "plugins/"
+        "Plugins/index.html": "plugins/"
+        "Developer-Guide.html": "dev-guide/"
+        "developer-guide.html": "dev-guide/"
+        "dev-guide.html": "dev-guide/"
+        "DeveloperGuide.html": "dev-guide/"
+        "docs/Developer-Guide.html": "dev-guide/"
+        "docs/dev-guide.html": "dev-guide/"
+        "Security.html": "security/"
+        "security.html": "security/"
+        "security/index.html": "security/"
+        "docs/Security.html": "security/"
+        "docs/security.html": "security/"
+        "docs/security/index.html": "security/"
+        "docs/index.html": "./"
+        "Glyph.html": "./"
+        "docs/Glyph.html": "./"
+        "docs/docs.html": "./"
 
 hooks:
   - docs/hooks.py
@@ -115,12 +136,29 @@ extra:
     - name: Español
       link: /Glyph/es/
       lang: es
+  pdf_download:
+    path: assets/offline/glyph-docs.epub
+    labels:
+      en: Download docs (EPUB)
+      es: Descargar documentación (EPUB)
+    descriptions:
+      en: Take the complete documentation offline as an EPUB snapshot.
+      es: Lleva la documentación completa sin conexión como un EPUB.
 extra_css:
   - stylesheets/accessibility.css
   - stylesheets/last-updated.css
   - stylesheets/marketplace.css
+  - stylesheets/experience.css
 extra_javascript:
-  - javascripts/search-fallback.js
-  - javascripts/sidebar-state.js
-  - javascripts/version-dropdown.js
-  - javascripts/plugin-catalog.js
+  - path: javascripts/search-fallback.js
+    defer: true
+  - path: javascripts/sidebar-state.js
+    defer: true
+  - path: javascripts/version-dropdown.js
+    defer: true
+  - path: javascripts/plugin-catalog.js
+    defer: true
+  - path: javascripts/lazy-media.js
+    defer: true
+  - path: javascripts/quickstart-demo.js
+    defer: true


### PR DESCRIPTION
## Summary
- add a friendly 404 template with guidance back to search or the landing page and expand legacy redirect coverage
- embed a deferred "Try Glyph" quickstart sandbox plus lazy-loading helper, with styling updates for the sandbox and footer/header controls
- generate asset metrics, minify custom assets, and build an EPUB snapshot with a persistent download link in the header and footer

## Testing
- `mkdocs build --clean` *(fails locally: mkdocs-static-i18n plugin is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e397f03e78832aba708baf10645adb