### PR TITLE
Add RPC and HTTP latency metrics instrumentation

### DIFF
--- a/docs/en/observability/README.md
+++ b/docs/en/observability/README.md
@@ -18,9 +18,28 @@ Key exported series include:
 | --- | --- | --- |
 | `glyph_rpc_requests_total{component,method}` | Counter | Total RPC calls handled by the component. |
 | `glyph_rpc_errors_total{component,method,code}` | Counter | Errors emitted during RPC handling. |
+| `glyph_rpc_duration_seconds_bucket{component,method,code,le}` | Histogram | Latency for each RPC handler (with `_sum` and `_count`). |
 | `glyph_plugin_event_duration_seconds_bucket{plugin,event,le}` | Histogram | Latency for processing plugin events (with `_sum` and `_count`). |
 | `glyph_plugin_queue_length{plugin}` | Gauge | Depth of each plugin's outbound queue. |
 | `glyph_active_plugins` | Gauge | Number of connected plugins. |
+| `glyph_http_request_duration_seconds_bucket{plugin,capability,method,status,le}` | Histogram | Latency for outbound HTTP requests executed via the NetGate (with `_sum` and `_count`). |
+| `glyph_http_throttle_total{scope}` | Counter | Number of outbound HTTP requests delayed by throttling. |
+| `glyph_http_backoff_total{status}` | Counter | Number of outbound HTTP retries triggered by upstream status codes. |
+
+### Prometheus scrape configuration
+
+The `/metrics` endpoint is compatible with the Prometheus text exposition format. A minimal scrape job targeting a Glyph instance running on the default metrics port looks like:
+
+```yaml
+scrape_configs:
+  - job_name: glyph
+    scrape_interval: 15s
+    static_configs:
+      - targets:
+          - localhost:9090
+```
+
+Adjust `targets` to match your deployment topology and set `metrics-addr` accordingly when launching `glyphd`.
 
 ## Grafana
 


### PR DESCRIPTION
## Summary
- add histogram collectors for RPC handler and HTTP client latency alongside existing counters and gauges
- instrument the plugin bus and NetGate HTTP client to emit the new telemetry with status code labels
- expand the observability guide with the additional series and a sample Prometheus scrape configuration

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e3ea78e334832a855b08af80f2cc98