### PR TITLE
Add plugin extensible exporters

### DIFF
--- a/cmd/glyphctl/export.go
+++ b/cmd/glyphctl/export.go
@@ -18,7 +18,16 @@ func runExport(args []string) int {
 	fs.SetOutput(os.Stderr)
 	input := fs.String("input", reporter.DefaultFindingsPath, "path to findings JSONL input")
 	out := fs.String("out", "", "path to write the exported output")
-	formatRaw := fs.String("format", "", "export format (sarif or jsonl)")
+	formats := exporter.Formats()
+	names := make([]string, 0, len(formats))
+	for _, spec := range formats {
+		names = append(names, string(spec.Format))
+	}
+	formatHelp := "export format"
+	if len(names) > 0 {
+		formatHelp = fmt.Sprintf("export format (%s)", strings.Join(names, ", "))
+	}
+	formatRaw := fs.String("format", "", formatHelp)
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -52,28 +61,20 @@ func runExport(args []string) int {
 		return 1
 	}
 
+	telemetry := exporter.BuildTelemetry(casesList, len(findingsList))
+	req := exporter.Request{Cases: casesList, Findings: findingsList, Telemetry: telemetry}
+
 	outputPath := strings.TrimSpace(*out)
 	if outputPath == "" {
-		switch format {
-		case exporter.FormatSARIF:
-			outputPath = exporter.DefaultSARIFPath
-		case exporter.FormatJSONL:
-			outputPath = exporter.DefaultJSONLPath
-		default:
-			outputPath = exporter.DefaultJSONLPath
+		if path, err := exporter.DefaultPath(format); err == nil {
+			outputPath = path
+		} else {
+			fmt.Fprintf(os.Stderr, "--out is required for format %s (%v)\n", format, err)
+			return 2
 		}
 	}
 
-	var data []byte
-	switch format {
-	case exporter.FormatSARIF:
-		data, err = exporter.EncodeSARIF(casesList)
-	case exporter.FormatJSONL:
-		telemetry := exporter.BuildTelemetry(casesList, len(findingsList))
-		data, err = exporter.EncodeJSONL(casesList, telemetry)
-	default:
-		err = fmt.Errorf("unsupported format: %s", format)
-	}
+	data, err := exporter.Encode(format, req)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "encode export: %v\n", err)
 		return 1

--- a/cmd/glyphctl/export_test.go
+++ b/cmd/glyphctl/export_test.go
@@ -67,6 +67,28 @@ func TestRunExportSARIF(t *testing.T) {
 	}
 }
 
+func TestRunExportCSV(t *testing.T) {
+	restore := silenceOutput(t)
+	defer restore()
+
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "findings.jsonl")
+	writeFixtureJSONL(t, inputPath)
+	outputPath := filepath.Join(dir, "cases.csv")
+
+	if code := runExport([]string{"--input", inputPath, "--out", outputPath, "--format", "csv"}); code != 0 {
+		t.Fatalf("runExport csv exited with %d", code)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+	if bytes.Count(data, []byte("\n")) < 1 {
+		t.Fatalf("expected csv header and rows")
+	}
+}
+
 func TestRunExportMissingFormat(t *testing.T) {
 	restore := silenceOutput(t)
 	defer restore()

--- a/docs/en/cli/index.md
+++ b/docs/en/cli/index.md
@@ -74,3 +74,26 @@ glyphctl report \
 The CLI ships both Markdown and HTML renderers; omit `--format` to default to
 Markdown. See [`plugins/scribe`]({{ config.repo_url }}/tree/main/plugins/scribe) for the reference templates and
 sample output.
+
+## Export cases for downstream tools {#export-cases}
+
+Use `glyphctl export` to transform findings into cases and serialise them into
+machine-consumable formats:
+
+```bash
+glyphctl export \
+  --input out/findings.jsonl \
+  --format sarif \
+  --out out/cases.sarif
+```
+
+Available formats include:
+
+* `sarif` – emits a SARIF 2.1.0 log for interoperability with security tooling.
+* `jsonl` – writes telemetry followed by individual case entries as newline
+  delimited JSON.
+* `csv` – generates a spreadsheet-friendly summary of each case and its sources.
+
+Third-party exporters can register additional formats at runtime. When Glyph
+detects custom exporters (for example, from a plugin bundle), `--format` will
+list the extra options automatically.

--- a/docs/en/plugins/index.md
+++ b/docs/en/plugins/index.md
@@ -116,6 +116,30 @@ schema described in [`specs/finding.md`]({{ config.repo_url }}/blob/main/specs/f
 `go run ./cmd/glyphctl findings validate --input <path>` to verify JSONL output
 before distribution.
 
+## Extend Glyph exports {#extend-exports}
+
+Export-focused plugins can register new serialisation formats with the
+`internal/exporter` package. Formats are registered during package
+initialisation, making them available to `glyphctl export` and any other
+component that resolves exporters at runtime.
+
+```go
+func init() {
+    exporter.MustRegisterFormat(exporter.FormatSpec{
+        Format:          "xlsx",
+        DefaultFilename: "cases.xlsx",
+        Description:     "Excel workbook with per-case tabs",
+        Encode: func(req exporter.Request) ([]byte, error) {
+            // Build a spreadsheet from req.Cases and req.Telemetry.
+        },
+    })
+}
+```
+
+Registered exporters receive the same case dataset and telemetry metrics as the
+built-in SARIF, JSONL, and CSV emitters. Set `DefaultFilename` so the CLI can
+derive a sensible `--out` path when the flag is omitted.
+
 ## Performance and safety guidelines {#performance-and-safety-guidelines}
 
 - **Respect backpressure**: Hooks run on the gRPC receive loop. Avoid blocking

--- a/internal/exporter/csv.go
+++ b/internal/exporter/csv.go
@@ -1,0 +1,131 @@
+package exporter
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/cases"
+)
+
+var csvHeader = []string{
+	"case_id",
+	"case_version",
+	"generated_at",
+	"asset_kind",
+	"asset_identifier",
+	"asset_details",
+	"vector_kind",
+	"vector_value",
+	"severity",
+	"risk_score",
+	"risk_rationale",
+	"confidence",
+	"summary",
+	"proof_summary",
+	"labels",
+	"source_ids",
+	"source_plugins",
+	"source_types",
+	"source_count",
+	"evidence_count",
+}
+
+// EncodeCSV renders cases as comma-separated values suitable for spreadsheets.
+func EncodeCSV(casesList []cases.Case) ([]byte, error) {
+	var buf bytes.Buffer
+	writer := csv.NewWriter(&buf)
+
+	if err := writer.Write(csvHeader); err != nil {
+		return nil, fmt.Errorf("write csv header: %w", err)
+	}
+
+	for _, c := range casesList {
+		if err := writer.Write(serialiseCase(c)); err != nil {
+			return nil, fmt.Errorf("write case %s: %w", c.ID, err)
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, fmt.Errorf("flush csv writer: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func serialiseCase(c cases.Case) []string {
+	generatedAt := ""
+	if ts := c.GeneratedAt.Time(); !ts.IsZero() {
+		generatedAt = ts.UTC().Format(time.RFC3339)
+	}
+
+	labels := flattenMap(c.Labels)
+	sourceIDs := make([]string, 0, len(c.Sources))
+	sourcePlugins := make([]string, 0, len(c.Sources))
+	sourceTypes := make([]string, 0, len(c.Sources))
+	for _, src := range c.Sources {
+		if src.ID != "" {
+			sourceIDs = append(sourceIDs, src.ID)
+		}
+		if src.Plugin != "" {
+			sourcePlugins = append(sourcePlugins, src.Plugin)
+		}
+		if src.Type != "" {
+			sourceTypes = append(sourceTypes, src.Type)
+		}
+	}
+
+	summary := strings.TrimSpace(c.Summary)
+	proofSummary := strings.TrimSpace(c.Proof.Summary)
+
+	return []string{
+		c.ID,
+		c.Version,
+		generatedAt,
+		strings.TrimSpace(c.Asset.Kind),
+		strings.TrimSpace(c.Asset.Identifier),
+		strings.TrimSpace(c.Asset.Details),
+		strings.TrimSpace(c.Vector.Kind),
+		strings.TrimSpace(c.Vector.Value),
+		string(c.Risk.Severity),
+		formatFloat(c.Risk.Score),
+		strings.TrimSpace(c.Risk.Rationale),
+		formatFloat(c.Confidence),
+		summary,
+		proofSummary,
+		labels,
+		strings.Join(sourceIDs, ";"),
+		strings.Join(sourcePlugins, ";"),
+		strings.Join(sourceTypes, ";"),
+		strconv.Itoa(len(c.Sources)),
+		strconv.Itoa(len(c.Evidence)),
+	}
+}
+
+func flattenMap(values map[string]string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	pairs := make([]string, 0, len(values))
+	for _, key := range keys {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", key, values[key]))
+	}
+	return strings.Join(pairs, ";")
+}
+
+func formatFloat(value float64) string {
+	if value == 0 {
+		return "0"
+	}
+	return strconv.FormatFloat(value, 'f', -1, 64)
+}

--- a/internal/exporter/csv_test.go
+++ b/internal/exporter/csv_test.go
@@ -1,0 +1,63 @@
+package exporter
+
+import (
+	"context"
+	"encoding/csv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/cases"
+)
+
+func TestEncodeCSVIncludesHeaderAndRows(t *testing.T) {
+	findingsList := loadSampleFindings(t)
+	builder := cases.NewBuilder(
+		cases.WithDeterministicMode(5150),
+		cases.WithClock(func() time.Time { return time.Unix(1700009000, 0).UTC() }),
+	)
+
+	casesList, err := builder.Build(context.Background(), findingsList)
+	if err != nil {
+		t.Fatalf("build cases: %v", err)
+	}
+	if len(casesList) == 0 {
+		t.Fatalf("expected fixture to produce cases")
+	}
+
+	data, err := EncodeCSV(casesList)
+	if err != nil {
+		t.Fatalf("encode csv: %v", err)
+	}
+
+	reader := csv.NewReader(strings.NewReader(string(data)))
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+
+	if got, want := len(records), len(casesList)+1; got != want {
+		t.Fatalf("expected %d records, got %d", want, got)
+	}
+
+	header := records[0]
+	if len(header) != len(csvHeader) {
+		t.Fatalf("unexpected header length: got %d want %d", len(header), len(csvHeader))
+	}
+	for i, field := range header {
+		if field != csvHeader[i] {
+			t.Fatalf("unexpected header field %d: got %q want %q", i, field, csvHeader[i])
+		}
+	}
+
+	first := records[1]
+	if got := first[0]; strings.TrimSpace(got) == "" {
+		t.Fatalf("case id missing: %#v", first)
+	}
+	if got := first[8]; strings.TrimSpace(got) == "" {
+		t.Fatalf("severity missing: %#v", first)
+	}
+	if got := first[16]; strings.TrimSpace(got) == "" {
+		t.Fatalf("source plugins missing: %#v", first)
+	}
+}

--- a/internal/exporter/formats.go
+++ b/internal/exporter/formats.go
@@ -1,0 +1,136 @@
+package exporter
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/RowanDark/Glyph/internal/cases"
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+// Request captures the data set that exporters operate on.
+type Request struct {
+	Cases     []cases.Case
+	Findings  []findings.Finding
+	Telemetry Telemetry
+}
+
+// EncodeFunc renders the provided dataset into an exportable representation.
+type EncodeFunc func(Request) ([]byte, error)
+
+// FormatSpec describes an exporter implementation registered at runtime.
+type FormatSpec struct {
+	Format          Format
+	Description     string
+	DefaultFilename string
+	Encode          EncodeFunc
+}
+
+var (
+	registryMu sync.RWMutex
+	registry   = map[Format]FormatSpec{}
+	baseOutput = defaultOutputDir
+)
+
+// RegisterFormat adds a new exporter implementation to the registry.
+func RegisterFormat(spec FormatSpec) error {
+	name := Format(strings.ToLower(strings.TrimSpace(string(spec.Format))))
+	if name == "" {
+		return fmt.Errorf("exporter format name is required")
+	}
+	if spec.Encode == nil {
+		return fmt.Errorf("exporter %q is missing an encoder", name)
+	}
+
+	spec.Format = name
+
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	if _, exists := registry[name]; exists {
+		return fmt.Errorf("export format %q already registered", name)
+	}
+	registry[name] = spec
+	return nil
+}
+
+// MustRegisterFormat adds an exporter to the registry and panics if registration fails.
+func MustRegisterFormat(spec FormatSpec) {
+	if err := RegisterFormat(spec); err != nil {
+		panic(err)
+	}
+}
+
+// ParseFormat validates the provided format string.
+func ParseFormat(raw string) (Format, error) {
+	trimmed := strings.ToLower(strings.TrimSpace(raw))
+	if trimmed == "" {
+		return "", fmt.Errorf("unsupported format %q", raw)
+	}
+
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	format := Format(trimmed)
+	if _, exists := registry[format]; exists {
+		return format, nil
+	}
+
+	names := make([]string, 0, len(registry))
+	for key := range registry {
+		names = append(names, string(key))
+	}
+	sort.Strings(names)
+
+	return "", fmt.Errorf("unsupported format %q (available: %s)", raw, strings.Join(names, ", "))
+}
+
+// Encode resolves the requested format and renders the dataset using the registered implementation.
+func Encode(format Format, req Request) ([]byte, error) {
+	registryMu.RLock()
+	spec, ok := registry[format]
+	registryMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("unregistered export format: %s", format)
+	}
+	return spec.Encode(req)
+}
+
+// DefaultPath returns the default output location for the provided format if defined.
+func DefaultPath(format Format) (string, error) {
+	registryMu.RLock()
+	spec, ok := registry[format]
+	registryMu.RUnlock()
+	if !ok {
+		return "", fmt.Errorf("unregistered export format: %s", format)
+	}
+	filename := strings.TrimSpace(spec.DefaultFilename)
+	if filename == "" {
+		return "", fmt.Errorf("format %q does not define a default output path", format)
+	}
+	return filepath.Join(baseOutput, filename), nil
+}
+
+// Formats returns the registered exporters sorted by format name.
+func Formats() []FormatSpec {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	specs := make([]FormatSpec, 0, len(registry))
+	for _, spec := range registry {
+		specs = append(specs, spec)
+	}
+	sort.Slice(specs, func(i, j int) bool {
+		return specs[i].Format < specs[j].Format
+	})
+	return specs
+}
+
+func setBaseOutput(dir string) {
+	registryMu.Lock()
+	baseOutput = dir
+	registryMu.Unlock()
+}

--- a/internal/exporter/formats_test.go
+++ b/internal/exporter/formats_test.go
@@ -1,0 +1,47 @@
+package exporter
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRegisterFormatRejectsDuplicate(t *testing.T) {
+	if err := RegisterFormat(FormatSpec{Format: FormatJSONL, Encode: func(Request) ([]byte, error) { return nil, nil }}); err == nil {
+		t.Fatalf("expected duplicate registration to fail")
+	}
+}
+
+func TestEncodeUsesRegisteredFormat(t *testing.T) {
+	formatName := Format("unit-test-format")
+	spec := FormatSpec{
+		Format:          formatName,
+		DefaultFilename: "unit-test.txt",
+		Encode: func(req Request) ([]byte, error) {
+			buf := bytes.NewBufferString("cases:")
+			buf.WriteString(fmt.Sprintf("%d", req.Telemetry.CaseCount))
+			return buf.Bytes(), nil
+		},
+	}
+	if err := RegisterFormat(spec); err != nil {
+		t.Fatalf("register format: %v", err)
+	}
+
+	req := Request{Telemetry: Telemetry{CaseCount: 2}}
+	data, err := Encode(formatName, req)
+	if err != nil {
+		t.Fatalf("encode custom format: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatalf("expected data from custom exporter")
+	}
+
+	path, err := DefaultPath(formatName)
+	if err != nil {
+		t.Fatalf("default path: %v", err)
+	}
+	if !strings.HasSuffix(path, spec.DefaultFilename) {
+		t.Fatalf("unexpected default path %q", path)
+	}
+}


### PR DESCRIPTION
## Summary
- introduce an exporter registry so formats and default output paths can be extended by plugins
- add a CSV case exporter alongside the existing SARIF and JSONL encoders and update the CLI to use the registry
- document the new export formats and how plugins can register custom exporters

## Testing
- go test ./... *(fails: plugins/samples/passive-header-scan timed out waiting for finding)*
- go test ./plugins/samples/passive-header-scan -run TestSampleEmitsFinding -count=1


------
https://chatgpt.com/codex/tasks/task_e_68e647e58940832aa1d1150321f5d791