### PR TITLE
Add real-world E2E scenario suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,3 +160,9 @@ e2e: proto
 	@echo "--- Plugin Log (plugin.log) ---"
 	@cat plugin.log
 	@rm -f glyphd glyphd.log plugin.log
+
+# Runs the real-world scenario regression tests.
+.PHONY: e2e-scenarios
+e2e-scenarios:
+	@echo "--- Running E2E scenario suite ---"
+	@go test ./internal/e2e -run TestPassiveHeaderRealWorldScenarios -count=1 -timeout 5m

--- a/cmd/glyphd/main.go
+++ b/cmd/glyphd/main.go
@@ -499,7 +499,9 @@ func serve(ctx context.Context, lis net.Listener, token string, coreLogger, busL
 	// once the gRPC server begins shutting down.
 	generatorCtx, cancelGenerator := context.WithCancel(context.Background())
 	defer cancelGenerator()
-	go busServer.StartEventGenerator(generatorCtx)
+	if os.Getenv("GLYPH_DISABLE_EVENT_GENERATOR") != "1" {
+		go busServer.StartEventGenerator(generatorCtx)
+	}
 
 	// Stop the gRPC server once the provided context is cancelled.
 	go func() {

--- a/docs/en/dev/e2e-scenarios.md
+++ b/docs/en/dev/e2e-scenarios.md
@@ -1,0 +1,53 @@
+# E2E Scenario Suite
+
+Glyph ships an end-to-end scenario harness that exercises the full stack against
+realistic, well-known training targets. The goal is to ensure that critical
+regressions in detection, proxying, or reporting are caught before a release.
+
+## Covered targets
+
+The current suite reproduces the header profiles of two public, intentionally
+insecure web applications that are widely used for capture-the-flag exercises
+and security trainings:
+
+- **OWASP Juice Shop** – a Node.js storefront that purposely omits most
+  defensive HTTP headers so that learners can explore common misconfigurations.
+- **The BodgeIt Store** – a vulnerable Java EE sample that ships with only a
+  subset of recommended protections.
+
+The fixtures live in `internal/e2e/testdata/passive_header_scenarios.json` and
+mirror the headers observed on the live targets while keeping the responses
+small and deterministic for CI.
+
+## How the tests run
+
+1. A dedicated `glyphd` instance is started with the Galdr proxy enabled.
+2. The `passive-header-scan` sample plugin is executed via `glyphctl`. The test
+   disables the synthetic event generator to ensure that only real proxy flows
+   are analysed.
+3. Traffic is replayed through the Galdr proxy to the simulated target. This is
+   enough for the passive plugin to emit missing-header findings without any
+   additional active plugins.
+4. The test asserts the findings, verifies that proxy history was recorded, and
+   renders a Markdown report for post-run analysis.
+
+All artifacts (findings, history, and report) are written to the temporary
+`GLYPH_OUT` directory and surfaced in the test logs.
+
+## Running locally or in CI
+
+Use the Makefile target to execute the suite:
+
+```bash
+make e2e-scenarios
+```
+
+The command will run `go test ./internal/e2e -run TestPassiveHeaderRealWorldScenarios`
+with a three minute timeout window, which is suitable for nightly or gated
+execution. Because the fixtures are self-contained, the tests do not require
+external network access and can safely run in continuous integration.
+
+Setting `GLYPH_DISABLE_EVENT_GENERATOR=1` for `glyphd` is recommended whenever
+replaying captured flows. The helper introduced for these tests ensures that the
+synthetic responses are skipped so that the assertions only reflect the chosen
+scenario.

--- a/internal/e2e/scenario_passive_headers_test.go
+++ b/internal/e2e/scenario_passive_headers_test.go
@@ -1,0 +1,321 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+//go:embed testdata/passive_header_scenarios.json
+var passiveHeaderScenarioData []byte
+
+type passiveHeaderScenario struct {
+	Name        string            `json:"name"`
+	App         string            `json:"app"`
+	Description string            `json:"description"`
+	Path        string            `json:"path"`
+	Status      int               `json:"status"`
+	Headers     map[string]string `json:"headers"`
+	Body        string            `json:"body"`
+}
+
+func TestPassiveHeaderRealWorldScenarios(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping passive header scenarios in short mode")
+	}
+
+	scenarios := loadPassiveHeaderScenarios(t)
+	for _, scenario := range scenarios {
+		scenario := scenario
+		t.Run(scenario.Name, func(t *testing.T) {
+			runPassiveHeaderScenario(t, scenario)
+		})
+	}
+}
+
+func runPassiveHeaderScenario(t *testing.T, scenario passiveHeaderScenario) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	target := newScenarioServer(t, scenario)
+	defer target.Close()
+
+	root := repoRoot(t)
+	glyphdBin := buildGlyphd(ctx, t, root)
+	glyphctlBin := buildGlyphctl(ctx, t, root)
+
+	outDir := filepath.Join(t.TempDir(), scenario.Name)
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatalf("create scenario output dir: %v", err)
+	}
+	findingsPath := filepath.Join(outDir, "findings.jsonl")
+	reportPath := filepath.Join(outDir, "report.md")
+	historyPath := filepath.Join(outDir, fmt.Sprintf("%s_history.jsonl", scenario.Name))
+
+	glyphdListen, glyphdDial := resolveAddresses(t)
+	proxyListen, proxyDial := resolveAddresses(t)
+
+	cmdCtx, cmdCancel := context.WithCancel(ctx)
+	glyphd := exec.CommandContext(cmdCtx, glyphdBin,
+		"--addr", glyphdListen,
+		"--token", "scenario-token",
+		"--enable-proxy",
+		"--proxy-addr", proxyListen,
+		"--proxy-history", historyPath,
+	)
+	glyphd.Dir = root
+	glyphd.Env = append(os.Environ(),
+		"GLYPH_OUT="+outDir,
+		"GLYPH_SYNC_WRITES=1",
+		"GLYPH_DISABLE_EVENT_GENERATOR=1",
+	)
+
+	var glyphdStdout, glyphdStderr bytes.Buffer
+	glyphd.Stdout = &glyphdStdout
+	glyphd.Stderr = &glyphdStderr
+
+	if err := glyphd.Start(); err != nil {
+		t.Fatalf("failed to start glyphd: %v", err)
+	}
+
+	done := make(chan struct{})
+	var glyphdErr error
+	go func() {
+		glyphdErr = glyphd.Wait()
+		close(done)
+	}()
+
+	t.Cleanup(func() {
+		cmdCancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("glyphd did not exit after cancellation\nstdout:\n%s\nstderr:\n%s", glyphdStdout.String(), glyphdStderr.String())
+		}
+	})
+
+	if err := waitForListener(cmdCtx, glyphdDial, done, func() error { return glyphdErr }); err != nil {
+		t.Fatalf("glyphd gRPC listener not ready: %v\nstdout:\n%s\nstderr:\n%s", err, glyphdStdout.String(), glyphdStderr.String())
+	}
+	if err := waitForListener(cmdCtx, proxyDial, done, func() error { return glyphdErr }); err != nil {
+		t.Fatalf("galdr proxy listener not ready: %v\nstdout:\n%s\nstderr:\n%s", err, glyphdStdout.String(), glyphdStderr.String())
+	}
+
+	pluginCmd := exec.CommandContext(ctx, glyphctlBin,
+		"plugin", "run",
+		"--sample", "passive-header-scan",
+		"--server", glyphdDial,
+		"--token", "scenario-token",
+		"--duration", "15s",
+	)
+	pluginCmd.Dir = root
+	pluginCmd.Env = append(os.Environ(),
+		"GLYPH_OUT="+outDir,
+		"GLYPH_SYNC_WRITES=1",
+	)
+
+	var pluginStdout, pluginStderr bytes.Buffer
+	pluginCmd.Stdout = &pluginStdout
+	pluginCmd.Stderr = &pluginStderr
+
+	if err := pluginCmd.Start(); err != nil {
+		t.Fatalf("start plugin: %v", err)
+	}
+	pluginDone := make(chan error, 1)
+	go func() {
+		pluginDone <- pluginCmd.Wait()
+	}()
+
+	proxyURL, err := url.Parse("http://" + proxyDial)
+	if err != nil {
+		t.Fatalf("parse proxy url: %v", err)
+	}
+	transport := &http.Transport{Proxy: http.ProxyURL(proxyURL)}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+
+	requestCtx, requestCancel := context.WithCancel(ctx)
+	defer requestCancel()
+
+	requestURL := target.URL + scenario.Path
+
+	sendRequest := func(parent context.Context) error {
+		req, err := http.NewRequestWithContext(parent, http.MethodGet, requestURL, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != scenario.statusCode() {
+			return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+		}
+		return nil
+	}
+
+	go func() {
+		ticker := time.NewTicker(400 * time.Millisecond)
+		defer ticker.Stop()
+		// Fire an immediate request before waiting on the ticker to reduce startup latency.
+		_ = sendRequest(requestCtx)
+		for {
+			select {
+			case <-requestCtx.Done():
+				return
+			case <-ticker.C:
+				_ = sendRequest(requestCtx)
+			}
+		}
+	}()
+
+	expected := expectedScenarioFindings(scenario)
+	findings := waitForFindings(t, findingsPath, len(expected), 10*time.Second)
+	comparable := normaliseFindings(findings)
+	sort.SliceStable(comparable, func(i, j int) bool {
+		return comparable[i].Message < comparable[j].Message
+	})
+	sort.SliceStable(expected, func(i, j int) bool {
+		return expected[i].Message < expected[j].Message
+	})
+
+	if len(comparable) != len(expected) {
+		t.Fatalf("unexpected number of findings: got %d want %d\nstdout:\n%s\nstderr:\n%s", len(comparable), len(expected), pluginStdout.String(), pluginStderr.String())
+	}
+	for i := range expected {
+		if !reflect.DeepEqual(comparable[i], expected[i]) {
+			t.Fatalf("scenario findings mismatch at index %d\nwant: %s\n got: %s", i, mustJSON(expected[i]), mustJSON(comparable[i]))
+		}
+	}
+
+	requestCancel()
+
+	select {
+	case err := <-pluginDone:
+		if err != nil {
+			t.Fatalf("plugin execution failed: %v\nstdout:\n%s\nstderr:\n%s", err, pluginStdout.String(), pluginStderr.String())
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatalf("plugin did not exit within timeout\nstdout:\n%s\nstderr:\n%s", pluginStdout.String(), pluginStderr.String())
+	}
+
+	if glyphd.Process != nil {
+		_ = glyphd.Process.Signal(os.Interrupt)
+	}
+
+	if _, err := os.Stat(historyPath); err != nil {
+		t.Fatalf("proxy history missing: %v", err)
+	}
+	historyData, err := os.ReadFile(historyPath)
+	if err != nil {
+		t.Fatalf("read proxy history: %v", err)
+	}
+	if strings.TrimSpace(string(historyData)) == "" {
+		t.Fatal("proxy history empty")
+	}
+
+	if err := runGlyphctlReport(ctx, root, glyphctlBin, findingsPath, reportPath); err != nil {
+		t.Fatalf("glyphctl report failed: %v", err)
+	}
+	if info, err := os.Stat(reportPath); err != nil {
+		t.Fatalf("report missing: %v", err)
+	} else if info.Size() == 0 {
+		t.Fatal("report file empty")
+	}
+
+	t.Logf("scenario %s artifacts stored in %s", scenario.Name, outDir)
+}
+
+func loadPassiveHeaderScenarios(t *testing.T) []passiveHeaderScenario {
+	t.Helper()
+
+	var scenarios []passiveHeaderScenario
+	if err := json.Unmarshal(passiveHeaderScenarioData, &scenarios); err != nil {
+		t.Fatalf("decode passive header scenarios: %v", err)
+	}
+	if len(scenarios) == 0 {
+		t.Fatal("no passive header scenarios defined")
+	}
+	return scenarios
+}
+
+func newScenarioServer(t *testing.T, scenario passiveHeaderScenario) *httptest.Server {
+	t.Helper()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for header, value := range scenario.Headers {
+			if value == "" {
+				continue
+			}
+			w.Header().Set(header, value)
+		}
+		status := scenario.statusCode()
+		w.WriteHeader(status)
+		if _, err := w.Write([]byte(scenario.Body)); err != nil {
+			t.Fatalf("write scenario body: %v", err)
+		}
+	})
+	server := httptest.NewServer(handler)
+	return server
+}
+
+func (s passiveHeaderScenario) statusCode() int {
+	if s.Status <= 0 {
+		return http.StatusOK
+	}
+	return s.Status
+}
+
+func expectedScenarioFindings(scenario passiveHeaderScenario) []goldenFinding {
+	recommendations := map[string]string{
+		"Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
+		"X-Content-Type-Options":    "nosniff",
+		"X-Frame-Options":           "DENY",
+		"Content-Security-Policy":   "default-src 'none'",
+	}
+
+	expected := make([]goldenFinding, 0, len(recommendations))
+	for header, recommendation := range recommendations {
+		if value, ok := scenario.Headers[header]; ok && strings.TrimSpace(value) != "" {
+			continue
+		}
+		expected = append(expected, goldenFinding{
+			Plugin:   "passive-header-scan",
+			Type:     "missing-security-header",
+			Message:  fmt.Sprintf("response missing %s header", header),
+			Severity: findings.SeverityMedium,
+			Metadata: map[string]string{
+				"header":         header,
+				"recommendation": recommendation,
+			},
+		})
+	}
+	return expected
+}
+
+func runGlyphctlReport(ctx context.Context, root, glyphctlBin, findingsPath, reportPath string) error {
+	reportCmd := exec.CommandContext(ctx, glyphctlBin, "report", "--input", findingsPath, "--out", reportPath)
+	reportCmd.Dir = root
+	reportCmd.Env = append(os.Environ(), "GLYPH_OUT="+filepath.Dir(reportPath))
+	output, err := reportCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("glyphctl report: %w\n%s", err, string(output))
+	}
+	return nil
+}

--- a/internal/e2e/testdata/passive_header_scenarios.json
+++ b/internal/e2e/testdata/passive_header_scenarios.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "juice-shop",
+    "app": "OWASP Juice Shop",
+    "description": "Simplified response headers captured from the OWASP Juice Shop home page; intentionally omits standard hardening headers for training.",
+    "path": "/",
+    "status": 200,
+    "headers": {
+      "Content-Type": "text/html; charset=utf-8",
+      "Server": "nginx",
+      "Set-Cookie": "token=demo; Path=/; HttpOnly"
+    },
+    "body": "<html><head><title>OWASP Juice Shop</title></head><body><h1>Juice Shop</h1></body></html>"
+  },
+  {
+    "name": "bodgeit-store",
+    "app": "The BodgeIt Store",
+    "description": "Representative login page headers from The BodgeIt Store vulnerable training application. Only X-Frame-Options is present to validate false-negative protection.",
+    "path": "/login.jsp",
+    "status": 200,
+    "headers": {
+      "Content-Type": "text/html; charset=UTF-8",
+      "Server": "Apache-Coyote/1.1",
+      "X-Frame-Options": "SAMEORIGIN"
+    },
+    "body": "<html><head><title>The BodgeIt Store</title></head><body><h1>Login</h1></body></html>"
+  }
+]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,9 @@ nav:
       - Overview: cli/index.md
       - Configuration: cli/configuration.md
       - Windows installation: cli/windows.md
-  - Developer Guide: dev-guide/index.md
+  - Developer Guide:
+      - Overview: dev-guide/index.md
+      - E2E Scenario Suite: dev/e2e-scenarios.md
   - Security:
       - Overview: security/index.md
       - Threat Model: security/threat-model.md
@@ -64,6 +66,7 @@ plugins:
           Plugins: Complementos
           CLI: CLI
           Developer Guide: Guía de desarrollo
+          E2E Scenario Suite: Escenarios E2E
           Security: Seguridad
           Versions: Versiones
           Overview: Descripción general


### PR DESCRIPTION
## Summary
- add a passive-header scenario harness that replays traffic resembling OWASP Juice Shop and The BodgeIt Store and asserts deterministic findings
- gate glyphd's synthetic event generator behind the GLYPH_DISABLE_EVENT_GENERATOR toggle so replayed flows can be exercised in isolation
- document the scenario suite, expose a Makefile target for automation, and link the page into the docs navigation

## Testing
- go test ./internal/e2e -run TestPassiveHeaderRealWorldScenarios -count=1

------
https://chatgpt.com/codex/tasks/task_e_68e65766267c832ab542fa0373562d0a