### PR TITLE
Escape severity label in case HTML export

### DIFF
--- a/apps/desktop-shell/src/routes/cases.tsx
+++ b/apps/desktop-shell/src/routes/cases.tsx
@@ -239,9 +239,9 @@ function CaseExplorer() {
       } else {
         const html = `<!doctype html><html lang="en"><head><meta charset="utf-8" />\n<title>${escapeHtml(
           activeCase.title
-        )}</title></head><body>\n<h1>${escapeHtml(activeCase.title)}</h1>\n<p><strong>Severity:</strong> ${
+        )}</title></head><body>\n<h1>${escapeHtml(activeCase.title)}</h1>\n<p><strong>Severity:</strong> ${escapeHtml(
           severityCopy[activeCase.severity].label
-        }</p>\n<p><strong>Asset:</strong> ${escapeHtml(activeCase.asset)}</p>\n<p>${escapeHtml(activeCase.summary)}</p>\n<h2>Deduped findings</h2><ul>${activeCase.dedupedFindings
+        )}</p>\n<p><strong>Asset:</strong> ${escapeHtml(activeCase.asset)}</p>\n<p>${escapeHtml(activeCase.summary)}</p>\n<h2>Deduped findings</h2><ul>${activeCase.dedupedFindings
           .map((finding) => `<li>${escapeHtml(finding)}</li>`)
           .join('')}</ul>\n</body></html>`;
         data = html;


### PR DESCRIPTION
## Summary
- HTML-escape the severity label before injecting it into exported case documents to avoid HTML injection

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e69dc55104832ab5bd1ede22d998cc