### PR TITLE
Add scope policy editor with validation workflow

### DIFF
--- a/apps/desktop-shell/package.json
+++ b/apps/desktop-shell/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\""
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-slot": "^1.0.3",
     "@tanstack/react-router": "^1.132.47",
     "@tanstack/router-devtools": "^1.132.50",
@@ -20,6 +21,7 @@
     "clsx": "^2.1.0",
     "lucide-react": "^0.284.0",
     "mermaid": "^11.12.0",
+    "monaco-editor": "^0.54.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^2.10.3",

--- a/apps/desktop-shell/pnpm-lock.yaml
+++ b/apps/desktop-shell/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@monaco-editor/react':
+        specifier: ^4.7.0
+        version: 4.7.0(monaco-editor@0.54.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1.0.3
         version: 1.2.3(@types/react@18.3.26)(react@18.3.1)
@@ -32,6 +35,9 @@ importers:
       mermaid:
         specifier: ^11.12.0
         version: 11.12.0
+      monaco-editor:
+        specifier: ^0.54.0
+        version: 0.54.0
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -594,6 +600,16 @@ packages:
 
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
+
+  '@monaco-editor/loader@1.5.0':
+    resolution: {integrity: sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==}
+
+  '@monaco-editor/react@4.7.0':
+    resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
+    peerDependencies:
+      monaco-editor: '>= 0.25.0 < 1'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1377,6 +1393,9 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
+  dompurify@3.1.7:
+    resolution: {integrity: sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==}
+
   dompurify@3.2.7:
     resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
 
@@ -1608,6 +1627,11 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   marked@16.4.0:
     resolution: {integrity: sha512-CTPAcRBq57cn3R8n3hwc2REddc28hjR7RzDXQ+lXLmMJYqn20BaI2cGw6QjgZGIgVfp2Wdfw4aMzgNteQ6qJgQ==}
     engines: {node: '>= 20'}
@@ -1634,6 +1658,9 @@ packages:
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  monaco-editor@0.54.0:
+    resolution: {integrity: sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1918,6 +1945,9 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  state-local@1.0.7:
+    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2587,6 +2617,17 @@ snapshots:
   '@mermaid-js/parser@0.6.3':
     dependencies:
       langium: 3.3.1
+
+  '@monaco-editor/loader@1.5.0':
+    dependencies:
+      state-local: 1.0.7
+
+  '@monaco-editor/react@4.7.0(monaco-editor@0.54.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@monaco-editor/loader': 1.5.0
+      monaco-editor: 0.54.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -3419,6 +3460,8 @@ snapshots:
       '@babel/runtime': 7.28.4
       csstype: 3.1.3
 
+  dompurify@3.1.7: {}
+
   dompurify@3.2.7:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -3657,6 +3700,8 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  marked@14.0.0: {}
+
   marked@16.4.0: {}
 
   merge2@1.4.1: {}
@@ -3703,6 +3748,11 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.1
+
+  monaco-editor@0.54.0:
+    dependencies:
+      dompurify: 3.1.7
+      marked: 14.0.0
 
   ms@2.1.3: {}
 
@@ -3979,6 +4029,8 @@ snapshots:
   source-map@0.6.1: {}
 
   source-map@0.7.6: {}
+
+  state-local@1.0.7: {}
 
   string-width@4.2.3:
     dependencies:

--- a/apps/desktop-shell/src/routeTree.gen.ts
+++ b/apps/desktop-shell/src/routeTree.gen.ts
@@ -9,11 +9,17 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as ScopeRouteImport } from './routes/scope'
 import { Route as RunsRouteImport } from './routes/runs'
 import { Route as FlowsRouteImport } from './routes/flows'
 import { Route as CasesRouteImport } from './routes/cases'
 import { Route as IndexRouteImport } from './routes/index'
 
+const ScopeRoute = ScopeRouteImport.update({
+  id: '/scope',
+  path: '/scope',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const RunsRoute = RunsRouteImport.update({
   id: '/runs',
   path: '/runs',
@@ -40,12 +46,14 @@ export interface FileRoutesByFullPath {
   '/cases': typeof CasesRoute
   '/flows': typeof FlowsRoute
   '/runs': typeof RunsRoute
+  '/scope': typeof ScopeRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/cases': typeof CasesRoute
   '/flows': typeof FlowsRoute
   '/runs': typeof RunsRoute
+  '/scope': typeof ScopeRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -53,13 +61,14 @@ export interface FileRoutesById {
   '/cases': typeof CasesRoute
   '/flows': typeof FlowsRoute
   '/runs': typeof RunsRoute
+  '/scope': typeof ScopeRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/cases' | '/flows' | '/runs'
+  fullPaths: '/' | '/cases' | '/flows' | '/runs' | '/scope'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/cases' | '/flows' | '/runs'
-  id: '__root__' | '/' | '/cases' | '/flows' | '/runs'
+  to: '/' | '/cases' | '/flows' | '/runs' | '/scope'
+  id: '__root__' | '/' | '/cases' | '/flows' | '/runs' | '/scope'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -67,10 +76,18 @@ export interface RootRouteChildren {
   CasesRoute: typeof CasesRoute
   FlowsRoute: typeof FlowsRoute
   RunsRoute: typeof RunsRoute
+  ScopeRoute: typeof ScopeRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/scope': {
+      id: '/scope'
+      path: '/scope'
+      fullPath: '/scope'
+      preLoaderRoute: typeof ScopeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/runs': {
       id: '/runs'
       path: '/runs'
@@ -107,6 +124,7 @@ const rootRouteChildren: RootRouteChildren = {
   CasesRoute: CasesRoute,
   FlowsRoute: FlowsRoute,
   RunsRoute: RunsRoute,
+  ScopeRoute: ScopeRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/desktop-shell/src/routes/__root.tsx
+++ b/apps/desktop-shell/src/routes/__root.tsx
@@ -14,7 +14,8 @@ const navigation = [
   { to: '/', label: 'Dashboard' },
   { to: '/flows', label: 'Flows' },
   { to: '/runs', label: 'Runs' },
-  { to: '/cases', label: 'Cases' }
+  { to: '/cases', label: 'Cases' },
+  { to: '/scope', label: 'Scope' }
 ];
 
 function Header() {

--- a/apps/desktop-shell/src/routes/scope.tsx
+++ b/apps/desktop-shell/src/routes/scope.tsx
@@ -1,0 +1,568 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useEffect, useMemo, useState } from 'react';
+import Editor, { useMonaco } from '@monaco-editor/react';
+import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution';
+import {
+  AlertCircle,
+  AlertTriangle,
+  CheckCircle2,
+  ClipboardCopy,
+  Loader2,
+  RefreshCw,
+  ShieldAlert,
+  ShieldCheck,
+  ShieldX,
+  Sparkles,
+  Wand2
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '../components/ui/button';
+import {
+  applyScopePolicy,
+  dryRunScopePolicy,
+  fetchScopePolicy,
+  parseScopeText,
+  validateScopePolicy,
+  type ScopeApplyResponse,
+  type ScopeDryRunDecision,
+  type ScopeParseSuggestion,
+  type ScopePolicyDocument,
+  type ScopeValidationMessage,
+  type ScopeValidationResult
+} from '../lib/ipc';
+import { cn } from '../lib/utils';
+
+const scopePolicySchema = {
+  $id: 'inmemory://model/scope-policy.schema.json',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    version: {
+      type: 'number',
+      enum: [1],
+      description: 'Scope policy format version (defaults to 1).'
+    },
+    allow: {
+      type: 'array',
+      description: 'Targets that are explicitly in scope for crawling.',
+      items: { $ref: '#/definitions/rule' }
+    },
+    deny: {
+      type: 'array',
+      description: 'Targets that are out of scope.',
+      items: { $ref: '#/definitions/rule' }
+    },
+    private_networks: {
+      type: 'string',
+      enum: ['allow', 'block', 'unspecified'],
+      description: 'How private network ranges should be treated.'
+    },
+    pii: {
+      type: 'string',
+      enum: ['allow', 'forbid', 'unspecified'],
+      description: 'Whether personally identifiable information can be collected.'
+    }
+  },
+  required: [],
+  definitions: {
+    rule: {
+      type: 'object',
+      required: ['type', 'value'],
+      additionalProperties: false,
+      properties: {
+        type: {
+          type: 'string',
+          enum: ['domain', 'wildcard', 'url', 'url_prefix', 'path', 'cidr', 'ip', 'pattern']
+        },
+        value: { type: 'string' },
+        notes: { type: 'string' }
+      }
+    }
+  }
+};
+
+function describeLocation(message: ScopeValidationMessage) {
+  if (message.line == null && message.column == null) {
+    return undefined;
+  }
+  if (message.line != null && message.column != null) {
+    return `line ${message.line}, column ${message.column}`;
+  }
+  if (message.line != null) {
+    return `line ${message.line}`;
+  }
+  return `column ${message.column}`;
+}
+
+function DecisionBadge({ allowed }: { allowed: boolean }) {
+  const Icon = allowed ? ShieldCheck : ShieldX;
+  const label = allowed ? 'Allowed' : 'Denied';
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
+        allowed ? 'bg-success/10 text-success' : 'bg-destructive/10 text-destructive-foreground'
+      )}
+    >
+      <Icon className="h-3.5 w-3.5" aria-hidden />
+      {label}
+    </span>
+  );
+}
+
+function RulePreview({ rule }: { rule: { type: string; value: string; notes?: string | null } }) {
+  return (
+    <div className="rounded-md border border-border bg-background p-3 text-sm">
+      <div className="font-medium">{rule.type}</div>
+      <div className="text-muted-foreground">{rule.value}</div>
+      {rule.notes ? <div className="mt-2 text-xs text-muted-foreground">{rule.notes}</div> : null}
+    </div>
+  );
+}
+
+function useEditorTheme() {
+  const [editorTheme, setEditorTheme] = useState<'vs' | 'vs-dark'>(() => {
+    const theme = document.documentElement.dataset.theme;
+    return !theme || theme === 'light' ? 'vs' : 'vs-dark';
+  });
+
+  useEffect(() => {
+    const update = () => {
+      const theme = document.documentElement.dataset.theme;
+      setEditorTheme(!theme || theme === 'light' ? 'vs' : 'vs-dark');
+    };
+
+    const observer = new MutationObserver(update);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+    return () => observer.disconnect();
+  }, []);
+
+  return editorTheme;
+}
+
+function ScopeScreen() {
+  const monaco = useMonaco();
+  const editorTheme = useEditorTheme();
+  const [isLoading, setIsLoading] = useState(true);
+  const [policy, setPolicy] = useState('');
+  const [activePolicy, setActivePolicy] = useState<ScopePolicyDocument | null>(null);
+  const [validation, setValidation] = useState<ScopeValidationResult | null>(null);
+  const [isValidating, setIsValidating] = useState(false);
+  const [isApplying, setIsApplying] = useState(false);
+  const [parseInput, setParseInput] = useState('');
+  const [isParsing, setIsParsing] = useState(false);
+  const [suggestions, setSuggestions] = useState<ScopeParseSuggestion[]>([]);
+  const [dryRunInput, setDryRunInput] = useState('');
+  const [isDryRunning, setIsDryRunning] = useState(false);
+  const [dryRunResults, setDryRunResults] = useState<ScopeDryRunDecision[]>([]);
+  const [applyMeta, setApplyMeta] = useState<ScopeApplyResponse | null>(null);
+
+  useEffect(() => {
+    if (!monaco) {
+      return;
+    }
+    const languages = monaco.languages as typeof monaco.languages & {
+      yaml?: { yamlDefaults: { setDiagnosticsOptions: (options: unknown) => void } };
+    };
+    languages.yaml?.yamlDefaults.setDiagnosticsOptions({
+      validate: true,
+      enableSchemaRequest: false,
+      schemas: [
+        {
+          uri: scopePolicySchema.$id,
+          fileMatch: ['*'],
+          schema: scopePolicySchema
+        }
+      ]
+    });
+  }, [monaco]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadPolicy = async () => {
+      try {
+        const document = await fetchScopePolicy();
+        if (cancelled) {
+          return;
+        }
+        setPolicy(document.policy);
+        setActivePolicy(document);
+        setApplyMeta(null);
+      } catch (error) {
+        console.error('Failed to load scope policy', error);
+        toast.error('Unable to load the current scope policy.');
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadPolicy();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    setValidation(null);
+  }, [policy]);
+
+  const hasUnsavedChanges = useMemo(() => {
+    return (activePolicy?.policy ?? '') !== policy;
+  }, [activePolicy, policy]);
+
+  const handleValidate = async () => {
+    setIsValidating(true);
+    try {
+      const result = await validateScopePolicy(policy);
+      setValidation(result);
+      if (result.errors.length === 0) {
+        toast.success('Scope policy looks good.');
+      } else {
+        toast.error('Scope policy contains issues.');
+      }
+    } catch (error) {
+      console.error('Failed to validate policy', error);
+      toast.error('Unable to validate the scope policy.');
+    } finally {
+      setIsValidating(false);
+    }
+  };
+
+  const handleApply = async () => {
+    setIsApplying(true);
+    try {
+      const response = await applyScopePolicy(policy);
+      setPolicy(response.policy);
+      setActivePolicy({ policy: response.policy, source: activePolicy?.source, updatedAt: response.appliedAt });
+      setApplyMeta(response);
+      setValidation(null);
+      toast.success('Scope policy applied to the crawler.');
+    } catch (error) {
+      console.error('Failed to apply scope policy', error);
+      toast.error('Unable to apply the scope policy.');
+    } finally {
+      setIsApplying(false);
+    }
+  };
+
+  const handleParse = async () => {
+    const trimmed = parseInput.trim();
+    if (trimmed === '') {
+      toast.info('Paste some bounty program text to extract rules.');
+      return;
+    }
+    setIsParsing(true);
+    try {
+      const response = await parseScopeText(trimmed);
+      setSuggestions(response.suggestions);
+      if (response.suggestions.length === 0) {
+        toast.info('No scope rules were identified in the provided text.');
+      } else {
+        toast.success('Generated scope suggestions from bounty text.');
+      }
+    } catch (error) {
+      console.error('Failed to parse bounty text', error);
+      toast.error('Unable to generate scope suggestions.');
+    } finally {
+      setIsParsing(false);
+    }
+  };
+
+  const handleCopySuggestion = async (suggestion: ScopeParseSuggestion) => {
+    try {
+      await navigator.clipboard.writeText(suggestion.policy);
+      toast.success('Suggestion copied to clipboard');
+    } catch (error) {
+      console.error('Failed to copy suggestion', error);
+      toast.error('Unable to copy suggestion');
+    }
+  };
+
+  const handleApplySuggestion = (suggestion: ScopeParseSuggestion) => {
+    setPolicy(suggestion.policy);
+    toast.success('Replaced the editor contents with the generated policy.');
+  };
+
+  const handleDryRun = async () => {
+    const urls = dryRunInput
+      .split(/\r?\n/)
+      .map((entry) => entry.trim())
+      .filter((entry) => entry !== '');
+
+    if (urls.length === 0) {
+      toast.info('Add at least one URL to preview the policy decisions.');
+      return;
+    }
+
+    setIsDryRunning(true);
+    try {
+      const response = await dryRunScopePolicy({ policy, urls });
+      setDryRunResults(response.results);
+      if (response.results.length === 0) {
+        toast.info('No decisions were returned. Double-check the provided URLs.');
+      }
+    } catch (error) {
+      console.error('Failed to dry-run scope policy', error);
+      toast.error('Unable to preview scope decisions.');
+    } finally {
+      setIsDryRunning(false);
+    }
+  };
+
+  const lastAppliedAt = useMemo(() => {
+    const timestamp = applyMeta?.appliedAt ?? activePolicy?.updatedAt;
+    if (!timestamp) {
+      return undefined;
+    }
+    return new Date(timestamp).toLocaleString();
+  }, [activePolicy?.updatedAt, applyMeta?.appliedAt]);
+
+  return (
+    <div className="mx-auto flex h-full max-w-7xl flex-col gap-6 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Scope policy</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Edit the YAML scope policy, validate changes, and apply them directly to the crawler.
+        </p>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <div className="flex flex-col gap-4">
+          <div className="rounded-xl border border-border bg-card shadow-sm">
+            <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3">
+              <div>
+                <h2 className="text-lg font-semibold">Policy editor</h2>
+                <p className="text-xs text-muted-foreground">
+                  {lastAppliedAt ? `Last applied ${lastAppliedAt}` : 'Load the current policy and make edits before applying.'}
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={isLoading || isValidating}
+                  onClick={handleValidate}
+                >
+                  {isValidating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden /> : <CheckCircle2 className="mr-2 h-4 w-4" aria-hidden />} 
+                  Validate
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={isLoading || isApplying || policy.trim() === '' || !hasUnsavedChanges}
+                  onClick={handleApply}
+                >
+                  {isApplying ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden /> : <RefreshCw className="mr-2 h-4 w-4" aria-hidden />} 
+                  Apply
+                </Button>
+              </div>
+            </div>
+            <div className="h-[420px] overflow-hidden border-t border-border">
+              {isLoading ? (
+                <div className="flex h-full items-center justify-center text-muted-foreground">
+                  <Loader2 className="mr-2 h-5 w-5 animate-spin" aria-hidden />
+                  Loading scope policy…
+                </div>
+              ) : (
+                <Editor
+                  language="yaml"
+                  theme={editorTheme}
+                  value={policy}
+                  onChange={(value) => setPolicy(value ?? '')}
+                  options={{
+                    minimap: { enabled: false },
+                    fontSize: 14,
+                    lineNumbers: 'on',
+                    scrollBeyondLastLine: false,
+                    renderWhitespace: 'selection'
+                  }}
+                />
+              )}
+            </div>
+          </div>
+
+          {validation ? (
+            <div className="rounded-xl border border-border bg-card p-4 shadow-sm">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                {validation.errors.length === 0 ? (
+                  <CheckCircle2 className="h-4 w-4 text-success" aria-hidden />
+                ) : (
+                  <AlertCircle className="h-4 w-4 text-destructive" aria-hidden />
+                )}
+                {validation.errors.length === 0
+                  ? 'No blocking issues detected in the policy.'
+                  : `${validation.errors.length} problem${validation.errors.length === 1 ? '' : 's'} detected.`}
+              </div>
+              {validation.errors.length > 0 ? (
+                <ul className="mt-3 space-y-2 text-sm text-destructive">
+                  {validation.errors.map((message, index) => (
+                    <li key={`${message.message}-${index}`} className="flex items-start gap-2">
+                      <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden />
+                      <div>
+                        <div>{message.message}</div>
+                        {describeLocation(message) ? (
+                          <div className="text-xs text-muted-foreground">{describeLocation(message)}</div>
+                        ) : null}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+              {validation.warnings && validation.warnings.length > 0 ? (
+                <div className="mt-4 rounded-lg border border-border/60 bg-muted/10 p-3 text-sm">
+                  <div className="flex items-center gap-2 font-medium">
+                    <AlertTriangle className="h-4 w-4 text-warning" aria-hidden />
+                    {validation.warnings.length} warning{validation.warnings.length === 1 ? '' : 's'}
+                  </div>
+                  <ul className="mt-2 space-y-2 text-muted-foreground">
+                    {validation.warnings.map((warning, index) => (
+                      <li key={`${warning.message}-${index}`}>
+                        <div>{warning.message}</div>
+                        {describeLocation(warning) ? (
+                          <div className="text-xs text-muted-foreground">{describeLocation(warning)}</div>
+                        ) : null}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <div className="rounded-xl border border-border bg-card shadow-sm">
+            <div className="flex items-center justify-between border-b border-border px-4 py-3">
+              <div>
+                <h2 className="text-lg font-semibold">LLM helper</h2>
+                <p className="text-xs text-muted-foreground">
+                  Paste bounty text to generate draft allow/deny rules.
+                </p>
+              </div>
+              <Sparkles className="h-4 w-4 text-primary" aria-hidden />
+            </div>
+            <div className="space-y-3 p-4">
+              <textarea
+                value={parseInput}
+                onChange={(event) => setParseInput(event.target.value)}
+                className="h-36 w-full rounded-lg border border-border bg-background p-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                placeholder="Paste the program scope or bounty brief…"
+              />
+              <div className="flex justify-end gap-2">
+                <Button type="button" variant="ghost" size="sm" onClick={() => setParseInput('')}>
+                  Clear
+                </Button>
+                <Button type="button" size="sm" onClick={handleParse} disabled={isParsing}>
+                  {isParsing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden /> : <Wand2 className="mr-2 h-4 w-4" aria-hidden />} 
+                  Generate rules
+                </Button>
+              </div>
+              {suggestions.length > 0 ? (
+                <div className="space-y-4">
+                  {suggestions.map((suggestion, index) => (
+                    <div key={index} className="rounded-lg border border-border bg-background p-3">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div className="text-sm font-medium">Suggestion {index + 1}</div>
+                        <div className="flex gap-2">
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            onClick={() => void handleCopySuggestion(suggestion)}
+                          >
+                            <ClipboardCopy className="mr-2 h-4 w-4" aria-hidden />
+                            Copy YAML
+                          </Button>
+                          <Button type="button" size="sm" onClick={() => handleApplySuggestion(suggestion)}>
+                            Apply to editor
+                          </Button>
+                        </div>
+                      </div>
+                      {suggestion.summary ? (
+                        <p className="mt-2 text-xs text-muted-foreground">{suggestion.summary}</p>
+                      ) : null}
+                      {suggestion.rules ? (
+                        <div className="mt-3 grid gap-2 md:grid-cols-2">
+                          {suggestion.rules.allow?.map((rule, ruleIndex) => (
+                            <RulePreview key={`allow-${rule.type}-${ruleIndex}`} rule={rule} />
+                          ))}
+                          {suggestion.rules.deny?.map((rule, ruleIndex) => (
+                            <RulePreview key={`deny-${rule.type}-${ruleIndex}`} rule={rule} />
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-border bg-card shadow-sm">
+            <div className="flex items-center justify-between border-b border-border px-4 py-3">
+              <div>
+                <h2 className="text-lg font-semibold">Dry run</h2>
+                <p className="text-xs text-muted-foreground">Preview how the current policy treats sample URLs.</p>
+              </div>
+              <ShieldAlert className="h-4 w-4 text-warning" aria-hidden />
+            </div>
+            <div className="space-y-3 p-4">
+              <textarea
+                value={dryRunInput}
+                onChange={(event) => setDryRunInput(event.target.value)}
+                className="h-36 w-full rounded-lg border border-border bg-background p-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                placeholder={`https://example.com/login\nhttps://admin.example.com/\nhttps://10.0.0.5/api`}
+              />
+              <div className="flex justify-end">
+                <Button type="button" size="sm" onClick={handleDryRun} disabled={isDryRunning}>
+                  {isDryRunning ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden /> : <ShieldAlert className="mr-2 h-4 w-4" aria-hidden />} 
+                  Preview decisions
+                </Button>
+              </div>
+              {dryRunResults.length > 0 ? (
+                <div className="overflow-hidden rounded-lg border border-border">
+                  <table className="min-w-full divide-y divide-border text-sm">
+                    <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+                      <tr>
+                        <th className="px-3 py-2 text-left font-medium">URL</th>
+                        <th className="px-3 py-2 text-left font-medium">Decision</th>
+                        <th className="px-3 py-2 text-left font-medium">Reason</th>
+                        <th className="px-3 py-2 text-left font-medium">Matched rule</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border bg-background">
+                      {dryRunResults.map((result, index) => (
+                        <tr key={`${result.url}-${index}`}>
+                          <td className="px-3 py-2 align-top text-xs md:text-sm">{result.url}</td>
+                          <td className="px-3 py-2 align-top">
+                            <DecisionBadge allowed={result.allowed} />
+                          </td>
+                          <td className="px-3 py-2 align-top text-xs text-muted-foreground">
+                            {result.reason ?? '—'}
+                          </td>
+                          <td className="px-3 py-2 align-top text-xs text-muted-foreground">
+                            {result.matchedRule ? `${result.matchedRule.type}: ${result.matchedRule.value}` : '—'}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const Route = createFileRoute('/scope')({
+  component: ScopeScreen
+});
+
+export default ScopeScreen;


### PR DESCRIPTION
## Summary
- add a dedicated Scope screen with a Monaco YAML editor, schema hints, LLM suggestions, and dry-run previews
- extend the desktop IPC layer and Tauri backend with scope policy fetch, validate, apply, parse, and dry-run commands
- surface the new screen in navigation and update dependencies for Monaco support

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6d1debc5c832a98910a67f9c0214a