### PR TITLE
feat: virtualize high-volume lists and improve flow streaming

### DIFF
--- a/apps/desktop-shell/package.json
+++ b/apps/desktop-shell/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-slot": "^1.0.3",
     "@tanstack/react-router": "^1.132.47",
     "@tanstack/router-devtools": "^1.132.50",
+    "@tanstack/react-virtual": "^3.10.5",
     "@tauri-apps/api": "^1.5.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",

--- a/apps/desktop-shell/pnpm-lock.yaml
+++ b/apps/desktop-shell/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.132.47
         version: 1.132.47(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-virtual':
+        specifier: ^3.10.5
+        version: 3.13.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/router-devtools':
         specifier: ^1.132.50
         version: 1.132.50(@tanstack/react-router@1.132.47(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.132.47)(@types/node@20.19.19)(csstype@3.1.3)(jiti@1.21.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(solid-js@1.9.9)(tiny-invariant@1.3.3)(tsx@4.20.6)
@@ -783,6 +786,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.13.12':
+    resolution: {integrity: sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-core@1.132.47':
     resolution: {integrity: sha512-8YKFHmG6VUqXaWAJzEqjyW6w31dARS2USd2mtI5ZeZcihqMbskK28N4iotBXNn+sSKJnPRjc7A4jTnnEf8Mn8Q==}
     engines: {node: '>=12'}
@@ -842,6 +851,9 @@ packages:
 
   '@tanstack/store@0.7.7':
     resolution: {integrity: sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ==}
+
+  '@tanstack/virtual-core@3.13.12':
+    resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
 
   '@tanstack/virtual-file-routes@1.132.31':
     resolution: {integrity: sha512-rxS8Cm2nIXroLqkm9pE/8X2lFNuvcTIIiFi5VH4PwzvKscAuaW3YRMN1WmaGDI2mVEn+GLaoY6Kc3jOczL5i4w==}
@@ -2769,6 +2781,12 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.6.0(react@18.3.1)
 
+  '@tanstack/react-virtual@3.13.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.12
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@tanstack/router-core@1.132.47':
     dependencies:
       '@tanstack/history': 1.132.31
@@ -2878,6 +2896,8 @@ snapshots:
       - supports-color
 
   '@tanstack/store@0.7.7': {}
+
+  '@tanstack/virtual-core@3.13.12': {}
 
   '@tanstack/virtual-file-routes@1.132.31': {}
 


### PR DESCRIPTION
## Summary
- virtualize the flow timeline and case explorer lists with `@tanstack/react-virtual` to keep scrolling responsive at high volumes
- add a browser-friendly SSE flow stream with buffered React 18 transitions to batch updates without blocking the UI
- harden the case explorer detail panel when filters remove all cases

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e716d2e460832ab9b39bafb981bb5c