### PR TITLE
Add automated accessibility checks with Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,40 @@ jobs:
           version: v2.1.6
           args: --out-format=github-actions ./...
 
+  web-accessibility:
+    name: Web accessibility
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+          cache-dependency-path: apps/desktop-shell/pnpm-lock.yaml
+      - name: Install dependencies
+        working-directory: apps/desktop-shell
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright browsers
+        working-directory: apps/desktop-shell
+        run: pnpm exec playwright install --with-deps
+      - name: Run accessibility checks
+        working-directory: apps/desktop-shell
+        run: pnpm run test:a11y
+      - name: Upload accessibility artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-shell-a11y-${{ github.sha }}
+          path: |
+            apps/desktop-shell/playwright-report
+            apps/desktop-shell/test-results
+          if-no-files-found: warn
+
   perf-bench:
     name: Performance benchmarks
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ glyphd
 # Track the Go command sources even though the glyphd binary is ignored.
 !cmd/
 !cmd/glyphd/
+
+# Frontend test artifacts
+apps/desktop-shell/playwright-report/
+apps/desktop-shell/test-results/
 !cmd/glyphd/**
 !cmd/glyphctl/
 !cmd/glyphctl/**

--- a/apps/desktop-shell/package.json
+++ b/apps/desktop-shell/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
-    "format": "prettier --write \"src/**/*.{ts,tsx,css}\""
+    "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
+    "test:a11y": "vite build && playwright test"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
@@ -32,6 +33,8 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.2",
+    "@playwright/test": "^1.56.0",
     "@tanstack/router-plugin": "^1.132.50",
     "@tauri-apps/cli": "^1.5.9",
     "@types/node": "^20.11.19",

--- a/apps/desktop-shell/playwright.config.ts
+++ b/apps/desktop-shell/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000
+  },
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure'
+  },
+  webServer: {
+    command: 'pnpm preview -- --host 127.0.0.1 --port 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ]
+});

--- a/apps/desktop-shell/pnpm-lock.yaml
+++ b/apps/desktop-shell/pnpm-lock.yaml
@@ -63,6 +63,12 @@ importers:
         specifier: ^3.22.4
         version: 3.25.76
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.10.2
+        version: 4.10.2(playwright-core@1.56.0)
+      '@playwright/test':
+        specifier: ^1.56.0
+        version: 1.56.0
       '@tanstack/router-plugin':
         specifier: ^1.132.50
         version: 1.132.51(@tanstack/react-router@1.132.47(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.20(@types/node@20.19.19))
@@ -117,6 +123,11 @@ packages:
 
   '@antfu/utils@9.3.0':
     resolution: {integrity: sha512-9hFT4RauhcUzqOE4f1+frMKLZrgNog5b06I7VmZQV1BkvwvqrbC8EBZf3L1eEL2AKb6rNKjER0sEvJiSP1FXEA==}
+
+  '@axe-core/playwright@4.10.2':
+    resolution: {integrity: sha512-6/b5BJjG6hDaRNtgzLIfKr5DfwyiLHO4+ByTLB0cJgWSM8Ll7KqtdblIS6bEkwSF642/Ex91vNqIl3GLXGlceg==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -630,6 +641,11 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@playwright/test@1.56.0':
+    resolution: {integrity: sha512-Tzh95Twig7hUwwNe381/K3PggZBZblKUe2wv25oIpzWLr6Z0m4KgV1ZVIjnR6GM9ANEqjZD7XsZEa6JL/7YEgg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -1117,6 +1133,10 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  axe-core@4.10.3:
+    resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
+    engines: {node: '>=4'}
+
   babel-dead-code-elimination@1.0.10:
     resolution: {integrity: sha512-DV5bdJZTzZ0zn0DC24v3jD7Mnidh6xhKa4GfKCbq3sfW8kaWhDdZjP3i81geA8T33tdYqWKw4D3fVv0CwEgKVA==}
 
@@ -1479,6 +1499,11 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1751,6 +1776,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.56.0:
+    resolution: {integrity: sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.56.0:
+    resolution: {integrity: sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -2219,6 +2254,11 @@ snapshots:
 
   '@antfu/utils@9.3.0': {}
 
+  '@axe-core/playwright@4.10.2(playwright-core@1.56.0)':
+    dependencies:
+      axe-core: 4.10.3
+      playwright-core: 1.56.0
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
@@ -2655,6 +2695,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.56.0':
+    dependencies:
+      playwright: 1.56.0
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.26)(react@18.3.1)':
     dependencies:
@@ -3168,6 +3212,8 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  axe-core@4.10.3: {}
+
   babel-dead-code-elimination@1.0.10:
     dependencies:
       '@babel/core': 7.28.4
@@ -3586,6 +3632,9 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3832,6 +3881,14 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.7
       pathe: 2.0.3
+
+  playwright-core@1.56.0: {}
+
+  playwright@1.56.0:
+    dependencies:
+      playwright-core: 1.56.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   points-on-curve@0.2.0: {}
 

--- a/apps/desktop-shell/tests/a11y.spec.ts
+++ b/apps/desktop-shell/tests/a11y.spec.ts
@@ -1,0 +1,69 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+type RouteTarget = {
+  name: string;
+  path: string;
+  readySelector: string;
+};
+
+const ROUTES: RouteTarget[] = [
+  {
+    name: 'Operations overview',
+    path: '/',
+    readySelector: 'h1:has-text("Operations overview")'
+  },
+  {
+    name: 'Runs',
+    path: '/runs',
+    readySelector: 'h1:has-text("Runs")'
+  },
+  {
+    name: 'Flows',
+    path: '/flows',
+    readySelector: 'h1:has-text("Flow timeline")'
+  },
+  {
+    name: 'Cases',
+    path: '/cases',
+    readySelector: 'main'
+  }
+];
+
+const SERIOUS_IMPACTS = new Set(['serious', 'critical']);
+
+test.describe('Accessibility regressions', () => {
+  for (const route of ROUTES) {
+    test(`should not introduce critical issues on ${route.name}`, async ({ page }, testInfo) => {
+      await page.goto(route.path, { waitUntil: 'domcontentloaded' });
+      await page.waitForSelector(route.readySelector, { state: 'visible' });
+
+      const analysis = await new AxeBuilder({ page })
+        .include('main')
+        .analyze();
+
+      const seriousViolations = analysis.violations.filter((violation) =>
+        SERIOUS_IMPACTS.has(violation.impact ?? '')
+      );
+
+      const summary = analysis.violations
+        .map((violation) => `${violation.impact ?? 'unknown'}: ${violation.id} → ${violation.help}`)
+        .join('\n');
+
+      await testInfo.attach('axe-report', {
+        body: Buffer.from(JSON.stringify(analysis, null, 2)),
+        contentType: 'application/json'
+      });
+
+      if (summary) {
+        await testInfo.attach('axe-summary.txt', {
+          body: Buffer.from(summary),
+          contentType: 'text/plain'
+        });
+      }
+
+      expect.soft(analysis.violations.length, 'Accessibility violations detected').toBe(0);
+      expect(seriousViolations, 'Critical accessibility regressions detected').toEqual([]);
+    });
+  }
+});

--- a/apps/desktop-shell/tests/color-vision.spec.ts
+++ b/apps/desktop-shell/tests/color-vision.spec.ts
@@ -1,0 +1,99 @@
+import { test } from '@playwright/test';
+
+const COLOR_DEFICIENCIES = [
+  'deuteranopia',
+  'protanopia',
+  'tritanopia'
+] as const;
+
+const FILTER_MATRICES: Record<(typeof COLOR_DEFICIENCIES)[number], string> = {
+  deuteranopia: '0.367322 0.860646 -0.227968 0 0 0.280085 0.672501 0.047413 0 0 -0.011820 0.042940 0.968881 0 0 0 0 0 1 0',
+  protanopia: '0.152286 1.052583 -0.204868 0 0 0.114503 0.786281 0.099216 0 0 -0.003882 -0.048116 1.051998 0 0 0 0 0 1 0',
+  tritanopia: '1.255528 -0.076749 -0.178779 0 0 -0.078411 0.930809 0.147602 0 0 0.004733 -0.048130 1.043397 0 0 0 0 0 1 0'
+};
+
+type RouteTarget = {
+  name: string;
+  slug: string;
+  path: string;
+  readySelector: string;
+};
+
+const ROUTES: RouteTarget[] = [
+  {
+    name: 'Operations overview',
+    slug: 'dashboard',
+    path: '/',
+    readySelector: 'h1:has-text("Operations overview")'
+  },
+  {
+    name: 'Runs',
+    slug: 'runs',
+    path: '/runs',
+    readySelector: 'h1:has-text("Runs")'
+  },
+  {
+    name: 'Flows',
+    slug: 'flows',
+    path: '/flows',
+    readySelector: 'h1:has-text("Flow timeline")'
+  }
+];
+
+async function applyFilter(page: Parameters<typeof test>[0]['page'], filterId: string, matrix: string) {
+  await page.evaluate(([id, values]) => {
+    let svg = document.getElementById('vision-filter-root') as SVGSVGElement | null;
+    if (!svg) {
+      svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('id', 'vision-filter-root');
+      svg.setAttribute('aria-hidden', 'true');
+      svg.setAttribute('focusable', 'false');
+      svg.style.position = 'absolute';
+      svg.style.width = '0';
+      svg.style.height = '0';
+      const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+      svg.appendChild(defs);
+      document.body.prepend(svg);
+    }
+
+    const defs = svg.querySelector('defs')!;
+    let filter = defs.querySelector(`#${id}`) as SVGFilterElement | null;
+    if (!filter) {
+      filter = document.createElementNS('http://www.w3.org/2000/svg', 'filter');
+      filter.setAttribute('id', id);
+      defs.appendChild(filter);
+    }
+
+    let matrixElement = filter.querySelector('feColorMatrix');
+    if (!matrixElement) {
+      matrixElement = document.createElementNS('http://www.w3.org/2000/svg', 'feColorMatrix');
+      matrixElement.setAttribute('type', 'matrix');
+      filter.appendChild(matrixElement);
+    }
+
+    matrixElement.setAttribute('values', values);
+    document.documentElement.style.filter = `url(#${id})`;
+  }, [filterId, matrix]);
+}
+
+test.describe('Color vision regressions', () => {
+  for (const route of ROUTES) {
+    test(`captures colorblind previews for ${route.name}`, async ({ page }, testInfo) => {
+      await page.goto(route.path, { waitUntil: 'domcontentloaded' });
+      await page.waitForSelector(route.readySelector, { state: 'visible' });
+
+      for (const deficiency of COLOR_DEFICIENCIES) {
+        await applyFilter(page, `vision-${route.slug}-${deficiency}`, FILTER_MATRICES[deficiency]);
+        const screenshot = await page.screenshot({ fullPage: true });
+        await testInfo.attach(`${route.slug}-${deficiency}.png`, {
+          body: screenshot,
+          contentType: 'image/png'
+        });
+      }
+
+      await page.evaluate(() => {
+        document.documentElement.style.filter = 'none';
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add Playwright- and axe-core-powered accessibility regression coverage for key desktop-shell routes and color vision captures
- wire up project tooling for Playwright with scripts, configuration, and dependency updates
- extend CI with a dedicated web accessibility workflow and ignore generated Playwright artifacts

## Testing
- pnpm run test:a11y

------
https://chatgpt.com/codex/tasks/task_e_68e7c170a8f0832a8b490676563e5bc2