### PR TITLE
feat: add GUI metrics panel and health chips

### DIFF
--- a/apps/desktop-shell/src/components/metrics-panel.tsx
+++ b/apps/desktop-shell/src/components/metrics-panel.tsx
@@ -1,0 +1,282 @@
+import { createPortal } from 'react-dom';
+import { useMemo, type ReactNode } from 'react';
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts';
+import { X, ExternalLink } from 'lucide-react';
+
+import { Button } from './ui/button';
+import { cn } from '../lib/utils';
+import { useMetrics } from '../providers/metrics-provider';
+
+function formatTime(value: number) {
+  return new Date(value).toLocaleTimeString();
+}
+
+function formatRate(value: number) {
+  return `${value.toFixed(2)} req/s`;
+}
+
+function ChartFallback({ message }: { message: string }) {
+  return (
+    <div className="flex h-52 items-center justify-center rounded-lg border border-dashed border-border text-sm text-muted-foreground">
+      {message}
+    </div>
+  );
+}
+
+function ChartCard({
+  title,
+  description,
+  className,
+  children
+}: {
+  title: string;
+  description?: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className={cn('flex flex-col gap-3 rounded-xl border border-border bg-muted/10 p-4', className)}>
+      <header className="space-y-1">
+        <h3 className="text-base font-semibold text-foreground">{title}</h3>
+        {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+      </header>
+      {children}
+    </section>
+  );
+}
+
+export function MetricsPanel({ open, onOpenChange }: { open: boolean; onOpenChange: (next: boolean) => void }) {
+  const { history, latest } = useMetrics();
+
+  const rpsSeries = useMemo(() => {
+    if (history.length < 2) {
+      return [];
+    }
+    const points = [] as { time: number; rate: number }[];
+    for (let index = 1; index < history.length; index += 1) {
+      const current = history[index];
+      const previous = history[index - 1];
+      const deltaCount = current.eventsTotal - previous.eventsTotal;
+      const deltaTime = (current.timestamp - previous.timestamp) / 1000;
+      if (deltaCount < 0 || deltaTime <= 0) {
+        continue;
+      }
+      const rate = deltaCount / deltaTime;
+      points.push({ time: current.timestamp, rate: Math.max(0, rate) });
+    }
+    return points;
+  }, [history]);
+
+  const queueSeries = useMemo(
+    () => history.map((entry) => ({ time: entry.timestamp, depth: entry.queueDepth })),
+    [history]
+  );
+
+  const dropSeries = useMemo(() => {
+    if (history.length < 2) {
+      return [];
+    }
+    const points = [] as { time: number; drops: number }[];
+    for (let index = 1; index < history.length; index += 1) {
+      const current = history[index];
+      const previous = history[index - 1];
+      const delta = current.queueDrops - previous.queueDrops;
+      const deltaTime = (current.timestamp - previous.timestamp) / 1000;
+      if (delta < 0 || deltaTime <= 0) {
+        continue;
+      }
+      points.push({ time: current.timestamp, drops: Math.max(0, delta / deltaTime) });
+    }
+    return points;
+  }, [history]);
+
+  const latencyBuckets = useMemo(
+    () =>
+      (latest?.latencyBuckets ?? []).map((bucket) => ({
+        upperBoundMs: bucket.upperBoundMs,
+        label: `${Math.round(bucket.upperBoundMs)} ms`,
+        count: bucket.count
+      })),
+    [latest?.latencyBuckets]
+  );
+
+  const pluginErrors = useMemo(
+    () =>
+      (latest?.pluginErrors ?? []).map((item) => ({
+        plugin: item.plugin,
+        errors: item.errors
+      })),
+    [latest?.pluginErrors]
+  );
+
+  const lastUpdated = latest ? new Date(latest.timestamp).toLocaleTimeString() : null;
+
+  if (!open) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 p-4 backdrop-blur">
+      <div className="relative flex w-full max-w-6xl flex-col gap-4 overflow-hidden rounded-3xl border border-border bg-card p-6 shadow-2xl">
+        <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-foreground">Operations metrics</h2>
+            <p className="text-sm text-muted-foreground">
+              Live Prometheus readings from the Glyph daemon.
+              {lastUpdated ? ` Last updated at ${lastUpdated}.` : null}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <a
+              href="/metrics"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1 text-sm font-medium text-primary transition hover:border-primary hover:bg-primary/10"
+            >
+              <ExternalLink className="h-4 w-4" aria-hidden />
+              Raw metrics
+            </a>
+            <Button variant="ghost" size="icon" onClick={() => onOpenChange(false)} aria-label="Close metrics panel">
+              <X className="h-5 w-5" />
+            </Button>
+          </div>
+        </header>
+        <div className="grid gap-4 md:grid-cols-2">
+          <ChartCard title="Requests per second" description="Computed from plugin event throughput">
+            {rpsSeries.length === 0 ? (
+              <ChartFallback message="Awaiting enough samples to chart request rate" />
+            ) : (
+              <div className="h-52">
+                <ResponsiveContainer width="100%" height="100%">
+                  <AreaChart data={rpsSeries} margin={{ top: 16, right: 24, left: 0, bottom: 0 }}>
+                    <defs>
+                      <linearGradient id="rpsGradient" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor="#6366f1" stopOpacity={0.35} />
+                        <stop offset="95%" stopColor="#6366f1" stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.1} />
+                    <XAxis
+                      dataKey="time"
+                      type="number"
+                      tickFormatter={formatTime}
+                      domain={[rpsSeries[0]?.time ?? 'dataMin', rpsSeries[rpsSeries.length - 1]?.time ?? 'dataMax']}
+                    />
+                    <YAxis tickFormatter={(value) => value.toFixed(1)} width={60} />
+                    <Tooltip
+                      labelFormatter={formatTime}
+                      formatter={(value: number) => [formatRate(value), 'RPS']}
+                    />
+                    <Area type="monotone" dataKey="rate" stroke="#6366f1" strokeWidth={2} fill="url(#rpsGradient)" />
+                  </AreaChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </ChartCard>
+          <ChartCard title="Queue depth" description="Pending messages across all plugins">
+            {queueSeries.length === 0 ? (
+              <ChartFallback message="No queue depth samples yet" />
+            ) : (
+              <div className="h-52">
+                <ResponsiveContainer width="100%" height="100%">
+                  <AreaChart data={queueSeries} margin={{ top: 16, right: 24, left: 0, bottom: 0 }}>
+                    <defs>
+                      <linearGradient id="queueGradient" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor="#22c55e" stopOpacity={0.35} />
+                        <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.1} />
+                    <XAxis dataKey="time" type="number" tickFormatter={formatTime} />
+                    <YAxis width={60} allowDecimals={false} />
+                    <Tooltip
+                      labelFormatter={formatTime}
+                      formatter={(value: number) => [`${value.toFixed(0)} messages`, 'Queue depth']}
+                    />
+                    <Area type="monotone" dataKey="depth" stroke="#22c55e" strokeWidth={2} fill="url(#queueGradient)" />
+                  </AreaChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </ChartCard>
+          <ChartCard title="Queue drops" description="Rate of discarded events per second">
+            {dropSeries.length === 0 ? (
+              <ChartFallback message="No drop activity observed" />
+            ) : (
+              <div className="h-52">
+                <ResponsiveContainer width="100%" height="100%">
+                  <AreaChart data={dropSeries} margin={{ top: 16, right: 24, left: 0, bottom: 0 }}>
+                    <defs>
+                      <linearGradient id="dropGradient" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor="#f97316" stopOpacity={0.35} />
+                        <stop offset="95%" stopColor="#f97316" stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.1} />
+                    <XAxis dataKey="time" type="number" tickFormatter={formatTime} />
+                    <YAxis width={60} tickFormatter={(value) => value.toFixed(2)} />
+                    <Tooltip
+                      labelFormatter={formatTime}
+                      formatter={(value: number) => [`${value.toFixed(2)} /s`, 'Drops']}
+                    />
+                    <Area type="monotone" dataKey="drops" stroke="#f97316" strokeWidth={2} fill="url(#dropGradient)" />
+                  </AreaChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </ChartCard>
+          <ChartCard title="Plugin errors" description="Total error counters by plugin">
+            {pluginErrors.length === 0 ? (
+              <ChartFallback message="No plugin errors reported" />
+            ) : (
+              <div className="h-52">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={pluginErrors} margin={{ top: 16, right: 24, left: 0, bottom: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.1} />
+                    <XAxis dataKey="plugin" tick={{ fontSize: 12 }} interval={0} angle={-20} height={60} textAnchor="end" />
+                    <YAxis allowDecimals={false} width={60} />
+                    <Tooltip formatter={(value: number) => [`${value.toFixed(0)}`, 'Errors']} />
+                    <Bar dataKey="errors" fill="#ef4444" radius={[4, 4, 0, 0]} />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </ChartCard>
+        </div>
+        <ChartCard title="Latency histogram" description="Distribution of plugin processing duration">
+          {latencyBuckets.length === 0 ? (
+            <ChartFallback message="Latency histogram unavailable" />
+          ) : (
+            <div className="h-64">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={latencyBuckets} margin={{ top: 16, right: 24, left: 0, bottom: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.1} />
+                  <XAxis dataKey="label" />
+                  <YAxis allowDecimals={false} width={60} />
+                  <Tooltip
+                    formatter={(value: number, _name, payload) => [
+                      `${value.toFixed(0)} events`,
+                      `≤ ${payload?.payload?.label ?? ''}`
+                    ]}
+                  />
+                  <Bar dataKey="count" fill="#0ea5e9" radius={[4, 4, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </ChartCard>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/apps/desktop-shell/src/lib/ipc.ts
+++ b/apps/desktop-shell/src/lib/ipc.ts
@@ -51,11 +51,25 @@ export type StartRunPayload = {
   };
 };
 
+const LatencyBucketSchema = z.object({
+  upperBoundMs: z.number(),
+  count: z.number()
+});
+
+const PluginErrorSchema = z.object({
+  plugin: z.string(),
+  errors: z.number()
+});
+
 const DashboardMetricsSchema = z.object({
   failures: z.number(),
   queueDepth: z.number(),
   avgLatencyMs: z.number(),
-  casesFound: z.number()
+  casesFound: z.number(),
+  eventsTotal: z.number(),
+  queueDrops: z.number(),
+  latencyBuckets: z.array(LatencyBucketSchema).optional().default([]),
+  pluginErrors: z.array(PluginErrorSchema).optional().default([])
 });
 
 const ManifestDnsRecordSchema = z.object({
@@ -308,6 +322,8 @@ const ScopeDryRunResponseSchema = z.object({
 });
 
 export type Run = z.infer<typeof RunSchema>;
+export type LatencyBucket = z.infer<typeof LatencyBucketSchema>;
+export type PluginErrorTotal = z.infer<typeof PluginErrorSchema>;
 export type DashboardMetrics = z.infer<typeof DashboardMetricsSchema>;
 export type FlowEvent = z.infer<typeof FlowEventSchema>;
 export type FlowPage = z.infer<typeof FlowPageSchema>;

--- a/apps/desktop-shell/src/main.tsx
+++ b/apps/desktop-shell/src/main.tsx
@@ -9,6 +9,7 @@ import { Toaster } from './providers/toaster';
 import { ThemeProvider, bootstrapTheme } from './providers/theme-provider';
 import { ArtifactProvider } from './providers/artifact-provider';
 import { CommandCenterProvider } from './providers/command-center';
+import { MetricsProvider } from './providers/metrics-provider';
 
 bootstrapTheme();
 
@@ -23,10 +24,12 @@ ReactDOM.createRoot(rootElement).render(
     <ThemeProvider>
       <AppErrorBoundary>
         <ArtifactProvider>
-          <CommandCenterProvider>
-            <Toaster />
-            <RouterProvider router={router} />
-          </CommandCenterProvider>
+          <MetricsProvider>
+            <CommandCenterProvider>
+              <Toaster />
+              <RouterProvider router={router} />
+            </CommandCenterProvider>
+          </MetricsProvider>
         </ArtifactProvider>
       </AppErrorBoundary>
     </ThemeProvider>

--- a/apps/desktop-shell/src/providers/metrics-provider.tsx
+++ b/apps/desktop-shell/src/providers/metrics-provider.tsx
@@ -1,0 +1,135 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+
+import { fetchMetrics, type DashboardMetrics } from '../lib/ipc';
+import { useArtifact } from './artifact-provider';
+
+const HISTORY_LIMIT = 60;
+
+type MetricSnapshot = DashboardMetrics & { timestamp: number };
+
+type MetricsContextValue = {
+  history: MetricSnapshot[];
+  latest: MetricSnapshot | null;
+  loading: boolean;
+  error: Error | null;
+  refresh: () => Promise<void>;
+};
+
+const MetricsContext = createContext<MetricsContextValue | undefined>(undefined);
+
+export function MetricsProvider({ children }: { children: React.ReactNode }) {
+  const { status } = useArtifact();
+  const offlineMode = Boolean(status?.loaded);
+  const [history, setHistory] = useState<MetricSnapshot[]>([]);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(false);
+  const inFlightRef = useRef(false);
+
+  const appendSnapshot = useCallback((metrics: DashboardMetrics) => {
+    setHistory((previous) => {
+      const timestamp = Date.now();
+      const nextEntry: MetricSnapshot = { timestamp, ...metrics };
+      const last = previous[previous.length - 1];
+      if (
+        last &&
+        last.eventsTotal === nextEntry.eventsTotal &&
+        last.queueDepth === nextEntry.queueDepth &&
+        timestamp - last.timestamp < 500
+      ) {
+        return previous;
+      }
+      const next = [...previous.slice(-(HISTORY_LIMIT - 1)), nextEntry];
+      return next;
+    });
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (offlineMode || inFlightRef.current) {
+      return;
+    }
+    inFlightRef.current = true;
+    setLoading(true);
+    try {
+      const snapshot = await fetchMetrics();
+      appendSnapshot(snapshot);
+      setError(null);
+    } catch (rawError) {
+      const nextError = rawError instanceof Error ? rawError : new Error(String(rawError));
+      setError(nextError);
+      throw nextError;
+    } finally {
+      inFlightRef.current = false;
+      setLoading(false);
+    }
+  }, [appendSnapshot, offlineMode]);
+
+  useEffect(() => {
+    if (!offlineMode) {
+      return;
+    }
+    if (status?.metrics) {
+      setHistory([{ timestamp: Date.now(), ...status.metrics }]);
+    } else {
+      setHistory([]);
+    }
+    setError(null);
+  }, [offlineMode, status?.metrics]);
+
+  useEffect(() => {
+    if (offlineMode) {
+      return;
+    }
+    setHistory([]);
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        await refresh();
+      } catch (pollError) {
+        if (cancelled) {
+          return;
+        }
+        console.error('Failed to fetch metrics', pollError);
+      }
+    };
+
+    void poll();
+    const interval = window.setInterval(poll, 15_000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [offlineMode, refresh]);
+
+  const value = useMemo<MetricsContextValue>(
+    () => ({
+      history,
+      latest: history.length > 0 ? history[history.length - 1] : null,
+      loading,
+      error,
+      refresh
+    }),
+    [history, loading, error, refresh]
+  );
+
+  return <MetricsContext.Provider value={value}>{children}</MetricsContext.Provider>;
+}
+
+export function useMetrics() {
+  const context = useContext(MetricsContext);
+  if (!context) {
+    throw new Error('useMetrics must be used within a MetricsProvider');
+  }
+  return context;
+}
+
+export type { MetricSnapshot };

--- a/apps/desktop-shell/src/routes/__root.tsx
+++ b/apps/desktop-shell/src/routes/__root.tsx
@@ -1,15 +1,17 @@
 import { Link, Outlet, createRootRoute, useNavigate, useRouterState } from '@tanstack/react-router';
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
-import { Menu, Play, RefreshCw, Archive, Command as CommandIcon } from 'lucide-react';
+import { Activity, Menu, Play, RefreshCw, Archive, Command as CommandIcon } from 'lucide-react';
 import { open } from '@tauri-apps/api/dialog';
 import { toast } from 'sonner';
 
 import { Button } from '../components/ui/button';
 import { cn } from '../lib/utils';
 import { ThemeSwitcher } from '../components/theme-switcher';
+import { MetricsPanel } from '../components/metrics-panel';
 import { openArtifact } from '../lib/ipc';
 import { useArtifact } from '../providers/artifact-provider';
 import { useCommandCenter } from '../providers/command-center';
+import { useMetrics, type MetricSnapshot } from '../providers/metrics-provider';
 
 const Devtools = lazy(() => import('../screens/devtools'));
 
@@ -23,12 +25,52 @@ const navigation = [
   { to: '/scope', label: 'Scope' }
 ];
 
-function Header() {
+type HealthTone = 'ok' | 'warn' | 'danger' | 'neutral';
+
+const toneStyles: Record<HealthTone, string> = {
+  ok: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-500 hover:border-emerald-500 hover:bg-emerald-500/20',
+  warn: 'border-amber-500/40 bg-amber-500/10 text-amber-500 hover:border-amber-500 hover:bg-amber-500/20',
+  danger: 'border-red-500/40 bg-red-500/10 text-red-500 hover:border-red-500 hover:bg-red-500/20',
+  neutral: 'border-border bg-muted/60 text-muted-foreground hover:border-primary/40 hover:text-foreground'
+};
+
+function HealthChip({
+  label,
+  value,
+  tone,
+  onClick,
+  disabled
+}: {
+  label: string;
+  value: string;
+  tone: HealthTone;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        'inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+        toneStyles[tone],
+        disabled ? 'cursor-not-allowed opacity-60' : undefined
+      )}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      <span className="uppercase tracking-wide text-[0.65rem] font-medium">{label}</span>
+      <span>{value}</span>
+    </button>
+  );
+}
+
+function Header({ onOpenMetrics }: { onOpenMetrics: () => void }) {
   const { status, setStatusFromOpen } = useArtifact();
   const location = useRouterState({ select: (state) => state.location.pathname });
   const navigate = useNavigate();
   const { registerCommand, openPalette } = useCommandCenter();
   const offlineMode = Boolean(status?.loaded);
+  const { history: metricsHistory, latest: latestMetrics } = useMetrics();
   const initialIndex = useMemo(() => {
     const exactMatch = navigation.findIndex((item) => location === item.to);
     if (exactMatch >= 0) {
@@ -40,6 +82,62 @@ function Header() {
   }, [location]);
   const [focusedIndex, setFocusedIndex] = useState(() => (initialIndex >= 0 ? initialIndex : 0));
   const linkRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+  const previousMetrics = metricsHistory.length > 1 ? metricsHistory[metricsHistory.length - 2] : null;
+
+  const computeRate = (
+    current: MetricSnapshot | null,
+    previous: MetricSnapshot | null,
+    field: 'eventsTotal' | 'queueDrops'
+  ) => {
+    if (!current || !previous) {
+      return 0;
+    }
+    const delta = current[field] - previous[field];
+    const deltaTime = (current.timestamp - previous.timestamp) / 1000;
+    if (delta <= 0 || deltaTime <= 0) {
+      return 0;
+    }
+    return delta / deltaTime;
+  };
+
+  const requestRate = computeRate(latestMetrics, previousMetrics, 'eventsTotal');
+  const dropRate = computeRate(latestMetrics, previousMetrics, 'queueDrops');
+  const queueDepth = latestMetrics?.queueDepth ?? 0;
+  const pluginErrors = latestMetrics?.pluginErrors ?? [];
+  const totalPluginErrors = pluginErrors.reduce((sum, item) => sum + item.errors, 0);
+  const metricsAvailable = Boolean(latestMetrics);
+
+  const rpsTone: HealthTone = metricsAvailable
+    ? requestRate <= 0.01
+      ? 'warn'
+      : 'ok'
+    : 'neutral';
+  const queueTone: HealthTone = metricsAvailable
+    ? queueDepth >= 25
+      ? 'danger'
+      : queueDepth >= 10
+        ? 'warn'
+        : 'ok'
+    : 'neutral';
+  const dropTone: HealthTone = metricsAvailable
+    ? dropRate >= 1
+      ? 'danger'
+      : dropRate > 0
+        ? 'warn'
+        : 'ok'
+    : 'neutral';
+  const errorTone: HealthTone = metricsAvailable
+    ? totalPluginErrors >= 10
+      ? 'danger'
+      : totalPluginErrors > 0
+        ? 'warn'
+        : 'ok'
+    : 'neutral';
+
+  const rpsDisplay = metricsAvailable && requestRate > 0 ? `${requestRate.toFixed(1)} /s` : '—';
+  const queueDisplay = metricsAvailable ? Math.round(queueDepth).toString() : '—';
+  const dropDisplay = metricsAvailable && dropRate > 0 ? `${dropRate.toFixed(2)} /s` : '—';
+  const errorDisplay = metricsAvailable ? Math.round(totalPluginErrors).toString() : '—';
 
   useEffect(() => {
     if (initialIndex >= 0) {
@@ -154,7 +252,23 @@ function Header() {
           </Link>
         ))}
       </nav>
+      <div className="hidden flex-wrap items-center gap-2 xl:flex">
+        <HealthChip label="RPS" value={rpsDisplay} tone={rpsTone} onClick={onOpenMetrics} />
+        <HealthChip label="QUEUE" value={queueDisplay} tone={queueTone} onClick={onOpenMetrics} />
+        <HealthChip label="DROPS" value={dropDisplay} tone={dropTone} onClick={onOpenMetrics} />
+        <HealthChip label="ERRORS" value={errorDisplay} tone={errorTone} onClick={onOpenMetrics} />
+      </div>
       <div className="flex items-center gap-3">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="xl:hidden"
+          onClick={onOpenMetrics}
+          title="Open metrics panel"
+        >
+          <Activity className="h-4 w-4" />
+        </Button>
         <Button
           type="button"
           variant="ghost"
@@ -191,12 +305,14 @@ function Header() {
 }
 
 function RootComponent() {
+  const [metricsOpen, setMetricsOpen] = useState(false);
+
   return (
     <div className="flex h-full flex-col">
       <a href="#main-content" className="skip-link">
         Skip to main content
       </a>
-      <Header />
+      <Header onOpenMetrics={() => setMetricsOpen(true)} />
       <main id="main-content" tabIndex={-1} className="flex-1 overflow-y-auto bg-background">
         <Suspense
           fallback={
@@ -209,6 +325,7 @@ function RootComponent() {
           <Outlet />
         </Suspense>
       </main>
+      <MetricsPanel open={metricsOpen} onOpenChange={setMetricsOpen} />
       {__DEVTOOLS_ENABLED__ && (
         <Suspense fallback={null}>
           <Devtools />


### PR DESCRIPTION
## Summary
- add a shared metrics provider with history polling and expose new Prometheus fields in the desktop shell backend
- render an on-demand metrics panel with auto-updating RPS, latency, queue, drop, and plugin error charts plus a raw /metrics link
- surface live health chips in the navbar that reflect queue, drop, error, and throughput status

## Testing
- pnpm -C apps/desktop-shell build

------
https://chatgpt.com/codex/tasks/task_e_68e7e633992c832aac5ac5405419fdad