### PR TITLE
Loosen audit record schema for resend flow metadata

### DIFF
--- a/apps/desktop-shell/src/lib/ipc.ts
+++ b/apps/desktop-shell/src/lib/ipc.ts
@@ -258,14 +258,16 @@ const FlowPageSchema = z.object({
   nextCursor: z.string().optional().nullable()
 });
 
-const AuditRecordSchema = z.object({
-  entryId: z.string(),
-  signature: z.string(),
-  recordedAt: z.string().optional(),
-  actor: z.string().optional(),
-  action: z.string().optional(),
-  decision: z.string().optional()
-});
+const AuditRecordSchema = z
+  .object({
+    entryId: z.string().optional(),
+    signature: z.string().optional(),
+    recordedAt: z.string().optional(),
+    actor: z.string().optional(),
+    action: z.string().optional(),
+    decision: z.string().optional()
+  })
+  .passthrough();
 
 const ResendFlowMetadataSchema = z
   .object({


### PR DESCRIPTION
## Summary
- relax the audit record schema used in resend flow metadata so audit entries can omit or rename fields

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9181a803c832a8bac6a0f574d7894