### PR TITLE
Add tracing instrumentation and exemplar dashboards

### DIFF
--- a/docs/en/observability/grafana-dashboard.json
+++ b/docs/en/observability/grafana-dashboard.json
@@ -1,80 +1,258 @@
 {
-  "title": "Glyph Telemetry",
-  "uid": "glyph-observability",
-  "tags": ["glyph", "observability"],
-  "timezone": "browser",
-  "schemaVersion": 39,
-  "version": 1,
-  "refresh": "30s",
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "iteration": 1740000000000,
+  "links": [],
   "panels": [
     {
-      "type": "stat",
-      "title": "Total RPC Requests",
-      "id": 1,
-      "datasource": "Prometheus",
-      "targets": [
-        {
-          "expr": "sum(glyph_rpc_requests_total)",
-          "legendFormat": "requests"
-        }
-      ]
-    },
-    {
-      "type": "timeseries",
-      "title": "RPC Error Rate",
-      "id": 2,
-      "datasource": "Prometheus",
-      "targets": [
-        {
-          "expr": "sum(rate(glyph_rpc_errors_total[5m]))",
-          "legendFormat": "errors"
-        }
-      ],
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
-          "unit": "ops"
-        }
-      }
-    },
-    {
-      "type": "timeseries",
-      "title": "Plugin Event Latency",
-      "id": 3,
-      "datasource": "Prometheus",
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.95, sum(rate(glyph_plugin_event_duration_seconds_bucket[5m])) by (le, plugin))",
-          "legendFormat": "{{plugin}} p95"
+          "color": { "mode": "palette-classic" },
+          "custom": { "exemplars": { "display": true } },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 50 },
+              { "color": "red", "value": 80 }
+            ]
+          }
         },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(glyph_plugin_event_duration_seconds_bucket[5m])) by (le, plugin))",
-          "legendFormat": "{{plugin}} p50"
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "max_over_time(glyph_plugin_queue_length{job=~\"$job\",plugin=~\"$plugin\"}[5m])",
+          "legendFormat": "{{plugin}}",
+          "range": true,
+          "refId": "A"
         }
-      ]
-    },
-    {
-      "type": "timeseries",
+      ],
       "title": "Plugin Queue Depth",
-      "id": 4,
-      "datasource": "Prometheus",
-      "targets": [
-        {
-          "expr": "glyph_plugin_queue_length",
-          "legendFormat": "{{plugin}}"
-        }
-      ]
+      "type": "timeSeries"
     },
     {
-      "type": "timeseries",
-      "title": "Active Plugin Connections",
-      "id": 5,
-      "datasource": "Prometheus",
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "exemplars": { "display": true } },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 2 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
       "targets": [
         {
-          "expr": "glyph_active_plugins",
-          "legendFormat": "active"
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(glyph_http_request_duration_seconds_bucket{job=~\"$job\",plugin=~\"$plugin\"}[5m])) by (le,plugin))",
+          "legendFormat": "{{plugin}}",
+          "range": true,
+          "refId": "A"
         }
-      ]
+      ],
+      "title": "HTTP Request Latency (P95)",
+      "type": "timeSeries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "exemplars": { "display": true } },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(glyph_flow_dispatch_seconds_bucket{job=~\"$job\",subscription=~\"$subscription\",variant=~\"$variant\"}[5m])) by (le,subscription,variant))",
+          "legendFormat": "{{subscription}} :: {{variant}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Flow Dispatch Latency (P95)",
+      "type": "timeSeries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "exemplars": { "display": true } },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(glyph_plugin_event_duration_seconds_bucket{job=~\"$job\",plugin=~\"$plugin\"}[5m])) by (le,plugin,event))",
+          "legendFormat": "{{plugin}} :: {{event}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Plugin Event Duration (P95)",
+      "type": "timeSeries"
+    },
+    {
+      "datasource": null,
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 16 },
+      "id": 5,
+      "options": {
+        "displayMode": "gradient",
+        "legend": { "displayMode": "table" },
+        "reduceOptions": { "calcs": ["mean"], "fields": "", "values": false },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (component,method) (rate(glyph_rpc_duration_seconds_sum{job=~\"$job\"}[5m]) / rate(glyph_rpc_duration_seconds_count{job=~\"$job\"}[5m]))",
+          "legendFormat": "{{component}} :: {{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RPC Handler Duration (avg over 5m)",
+      "type": "heatmap"
     }
-  ]
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["glyph"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "all", "value": ".*" },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "query": "label_values(glyph_rpc_requests_total, job)",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "all", "value": ".*" },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Plugin",
+        "multi": false,
+        "name": "plugin",
+        "query": "label_values(glyph_plugin_queue_length, plugin)",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "all", "value": ".*" },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Subscription",
+        "multi": false,
+        "name": "subscription",
+        "query": "label_values(glyph_flow_dispatch_seconds_bucket, subscription)",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "all", "value": ".*" },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Variant",
+        "multi": false,
+        "name": "variant",
+        "query": "label_values(glyph_flow_dispatch_seconds_bucket, variant)",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": { "refresh_intervals": ["10s", "30s", "1m", "5m"] },
+  "timezone": "",
+  "title": "Glyph Operations Overview",
+  "version": 2
 }

--- a/docs/en/versions/v1.0/observability/grafana-dashboard.json
+++ b/docs/en/versions/v1.0/observability/grafana-dashboard.json
@@ -1,80 +1,258 @@
 {
-  "title": "Glyph Telemetry",
-  "uid": "glyph-observability",
-  "tags": ["glyph", "observability"],
-  "timezone": "browser",
-  "schemaVersion": 39,
-  "version": 1,
-  "refresh": "30s",
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "iteration": 1740000000000,
+  "links": [],
   "panels": [
     {
-      "type": "stat",
-      "title": "Total RPC Requests",
-      "id": 1,
-      "datasource": "Prometheus",
-      "targets": [
-        {
-          "expr": "sum(glyph_rpc_requests_total)",
-          "legendFormat": "requests"
-        }
-      ]
-    },
-    {
-      "type": "timeseries",
-      "title": "RPC Error Rate",
-      "id": 2,
-      "datasource": "Prometheus",
-      "targets": [
-        {
-          "expr": "sum(rate(glyph_rpc_errors_total[5m]))",
-          "legendFormat": "errors"
-        }
-      ],
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
-          "unit": "ops"
-        }
-      }
-    },
-    {
-      "type": "timeseries",
-      "title": "Plugin Event Latency",
-      "id": 3,
-      "datasource": "Prometheus",
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.95, sum(rate(glyph_plugin_event_duration_seconds_bucket[5m])) by (le, plugin))",
-          "legendFormat": "{{plugin}} p95"
+          "color": { "mode": "palette-classic" },
+          "custom": { "exemplars": { "display": true } },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 50 },
+              { "color": "red", "value": 80 }
+            ]
+          }
         },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(glyph_plugin_event_duration_seconds_bucket[5m])) by (le, plugin))",
-          "legendFormat": "{{plugin}} p50"
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "max_over_time(glyph_plugin_queue_length{job=~\"$job\",plugin=~\"$plugin\"}[5m])",
+          "legendFormat": "{{plugin}}",
+          "range": true,
+          "refId": "A"
         }
-      ]
-    },
-    {
-      "type": "timeseries",
+      ],
       "title": "Plugin Queue Depth",
-      "id": 4,
-      "datasource": "Prometheus",
-      "targets": [
-        {
-          "expr": "glyph_plugin_queue_length",
-          "legendFormat": "{{plugin}}"
-        }
-      ]
+      "type": "timeSeries"
     },
     {
-      "type": "timeseries",
-      "title": "Active Plugin Connections",
-      "id": 5,
-      "datasource": "Prometheus",
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "exemplars": { "display": true } },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 2 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
       "targets": [
         {
-          "expr": "glyph_active_plugins",
-          "legendFormat": "active"
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(glyph_http_request_duration_seconds_bucket{job=~\"$job\",plugin=~\"$plugin\"}[5m])) by (le,plugin))",
+          "legendFormat": "{{plugin}}",
+          "range": true,
+          "refId": "A"
         }
-      ]
+      ],
+      "title": "HTTP Request Latency (P95)",
+      "type": "timeSeries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "exemplars": { "display": true } },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(glyph_flow_dispatch_seconds_bucket{job=~\"$job\",subscription=~\"$subscription\",variant=~\"$variant\"}[5m])) by (le,subscription,variant))",
+          "legendFormat": "{{subscription}} :: {{variant}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Flow Dispatch Latency (P95)",
+      "type": "timeSeries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "exemplars": { "display": true } },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(glyph_plugin_event_duration_seconds_bucket{job=~\"$job\",plugin=~\"$plugin\"}[5m])) by (le,plugin,event))",
+          "legendFormat": "{{plugin}} :: {{event}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Plugin Event Duration (P95)",
+      "type": "timeSeries"
+    },
+    {
+      "datasource": null,
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 16 },
+      "id": 5,
+      "options": {
+        "displayMode": "gradient",
+        "legend": { "displayMode": "table" },
+        "reduceOptions": { "calcs": ["mean"], "fields": "", "values": false },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (component,method) (rate(glyph_rpc_duration_seconds_sum{job=~\"$job\"}[5m]) / rate(glyph_rpc_duration_seconds_count{job=~\"$job\"}[5m]))",
+          "legendFormat": "{{component}} :: {{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RPC Handler Duration (avg over 5m)",
+      "type": "heatmap"
     }
-  ]
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["glyph"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "all", "value": ".*" },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "query": "label_values(glyph_rpc_requests_total, job)",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "all", "value": ".*" },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Plugin",
+        "multi": false,
+        "name": "plugin",
+        "query": "label_values(glyph_plugin_queue_length, plugin)",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "all", "value": ".*" },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Subscription",
+        "multi": false,
+        "name": "subscription",
+        "query": "label_values(glyph_flow_dispatch_seconds_bucket, subscription)",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "all", "value": ".*" },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Variant",
+        "multi": false,
+        "name": "variant",
+        "query": "label_values(glyph_flow_dispatch_seconds_bucket, variant)",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": { "refresh_intervals": ["10s", "30s", "1m", "5m"] },
+  "timezone": "",
+  "title": "Glyph Operations Overview",
+  "version": 2
 }

--- a/docs/en/versions/v2.0/observability/grafana-dashboard.json
+++ b/docs/en/versions/v2.0/observability/grafana-dashboard.json
@@ -1,80 +1,258 @@
 {
-  "title": "Glyph Telemetry",
-  "uid": "glyph-observability",
-  "tags": ["glyph", "observability"],
-  "timezone": "browser",
-  "schemaVersion": 39,
-  "version": 1,
-  "refresh": "30s",
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "iteration": 1740000000000,
+  "links": [],
   "panels": [
     {
-      "type": "stat",
-      "title": "Total RPC Requests",
-      "id": 1,
-      "datasource": "Prometheus",
-      "targets": [
-        {
-          "expr": "sum(glyph_rpc_requests_total)",
-          "legendFormat": "requests"
-        }
-      ]
-    },
-    {
-      "type": "timeseries",
-      "title": "RPC Error Rate",
-      "id": 2,
-      "datasource": "Prometheus",
-      "targets": [
-        {
-          "expr": "sum(rate(glyph_rpc_errors_total[5m]))",
-          "legendFormat": "errors"
-        }
-      ],
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
-          "unit": "ops"
-        }
-      }
-    },
-    {
-      "type": "timeseries",
-      "title": "Plugin Event Latency",
-      "id": 3,
-      "datasource": "Prometheus",
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.95, sum(rate(glyph_plugin_event_duration_seconds_bucket[5m])) by (le, plugin))",
-          "legendFormat": "{{plugin}} p95"
+          "color": { "mode": "palette-classic" },
+          "custom": { "exemplars": { "display": true } },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 50 },
+              { "color": "red", "value": 80 }
+            ]
+          }
         },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(glyph_plugin_event_duration_seconds_bucket[5m])) by (le, plugin))",
-          "legendFormat": "{{plugin}} p50"
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "max_over_time(glyph_plugin_queue_length{job=~\"$job\",plugin=~\"$plugin\"}[5m])",
+          "legendFormat": "{{plugin}}",
+          "range": true,
+          "refId": "A"
         }
-      ]
-    },
-    {
-      "type": "timeseries",
+      ],
       "title": "Plugin Queue Depth",
-      "id": 4,
-      "datasource": "Prometheus",
-      "targets": [
-        {
-          "expr": "glyph_plugin_queue_length",
-          "legendFormat": "{{plugin}}"
-        }
-      ]
+      "type": "timeSeries"
     },
     {
-      "type": "timeseries",
-      "title": "Active Plugin Connections",
-      "id": 5,
-      "datasource": "Prometheus",
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "exemplars": { "display": true } },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 2 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
       "targets": [
         {
-          "expr": "glyph_active_plugins",
-          "legendFormat": "active"
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(glyph_http_request_duration_seconds_bucket{job=~\"$job\",plugin=~\"$plugin\"}[5m])) by (le,plugin))",
+          "legendFormat": "{{plugin}}",
+          "range": true,
+          "refId": "A"
         }
-      ]
+      ],
+      "title": "HTTP Request Latency (P95)",
+      "type": "timeSeries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "exemplars": { "display": true } },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(glyph_flow_dispatch_seconds_bucket{job=~\"$job\",subscription=~\"$subscription\",variant=~\"$variant\"}[5m])) by (le,subscription,variant))",
+          "legendFormat": "{{subscription}} :: {{variant}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Flow Dispatch Latency (P95)",
+      "type": "timeSeries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "exemplars": { "display": true } },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(glyph_plugin_event_duration_seconds_bucket{job=~\"$job\",plugin=~\"$plugin\"}[5m])) by (le,plugin,event))",
+          "legendFormat": "{{plugin}} :: {{event}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Plugin Event Duration (P95)",
+      "type": "timeSeries"
+    },
+    {
+      "datasource": null,
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 16 },
+      "id": 5,
+      "options": {
+        "displayMode": "gradient",
+        "legend": { "displayMode": "table" },
+        "reduceOptions": { "calcs": ["mean"], "fields": "", "values": false },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (component,method) (rate(glyph_rpc_duration_seconds_sum{job=~\"$job\"}[5m]) / rate(glyph_rpc_duration_seconds_count{job=~\"$job\"}[5m]))",
+          "legendFormat": "{{component}} :: {{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RPC Handler Duration (avg over 5m)",
+      "type": "heatmap"
     }
-  ]
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["glyph"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "all", "value": ".*" },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "query": "label_values(glyph_rpc_requests_total, job)",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "all", "value": ".*" },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Plugin",
+        "multi": false,
+        "name": "plugin",
+        "query": "label_values(glyph_plugin_queue_length, plugin)",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "all", "value": ".*" },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Subscription",
+        "multi": false,
+        "name": "subscription",
+        "query": "label_values(glyph_flow_dispatch_seconds_bucket, subscription)",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "all", "value": ".*" },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Variant",
+        "multi": false,
+        "name": "variant",
+        "query": "label_values(glyph_flow_dispatch_seconds_bucket, variant)",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": { "refresh_intervals": ["10s", "30s", "1m", "5m"] },
+  "timezone": "",
+  "title": "Glyph Operations Overview",
+  "version": 2
 }

--- a/docs/observability/grafana-dashboard.json
+++ b/docs/observability/grafana-dashboard.json
@@ -18,8 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1680000000000,
+  "iteration": 1740000000000,
   "links": [],
   "panels": [
     {
@@ -27,6 +26,7 @@
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
+          "custom": { "exemplars": { "display": true } },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -62,6 +62,7 @@
       "datasource": null,
       "fieldConfig": {
         "defaults": {
+          "custom": { "exemplars": { "display": true } },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -84,19 +85,91 @@
         {
           "datasource": "Prometheus",
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(glyph_http_request_duration_seconds_bucket{job=~\"$job\",plugin=~\"$plugin\"}[5m])) by (le))",
-          "legendFormat": "95th percentile",
+          "expr": "histogram_quantile(0.95, sum(rate(glyph_http_request_duration_seconds_bucket{job=~\"$job\",plugin=~\"$plugin\"}[5m])) by (le,plugin))",
+          "legendFormat": "{{plugin}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "HTTP Request Latency (95th percentile)",
+      "title": "HTTP Request Latency (P95)",
       "type": "timeSeries"
     },
     {
       "datasource": null,
-      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "exemplars": { "display": true } },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
       "id": 3,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(glyph_flow_dispatch_seconds_bucket{job=~\"$job\",subscription=~\"$subscription\",variant=~\"$variant\"}[5m])) by (le,subscription,variant))",
+          "legendFormat": "{{subscription}} :: {{variant}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Flow Dispatch Latency (P95)",
+      "type": "timeSeries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "exemplars": { "display": true } },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(glyph_plugin_event_duration_seconds_bucket{job=~\"$job\",plugin=~\"$plugin\"}[5m])) by (le,plugin,event))",
+          "legendFormat": "{{plugin}} :: {{event}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Plugin Event Duration (P95)",
+      "type": "timeSeries"
+    },
+    {
+      "datasource": null,
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 16 },
+      "id": 5,
       "options": {
         "displayMode": "gradient",
         "legend": { "displayMode": "table" },
@@ -118,7 +191,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 37,
+  "schemaVersion": 39,
   "style": "dark",
   "tags": ["glyph"],
   "templating": {
@@ -148,6 +221,32 @@
         "refresh": 1,
         "regex": "",
         "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "all", "value": ".*" },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Subscription",
+        "multi": false,
+        "name": "subscription",
+        "query": "label_values(glyph_flow_dispatch_seconds_bucket, subscription)",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "all", "value": ".*" },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Variant",
+        "multi": false,
+        "name": "variant",
+        "query": "label_values(glyph_flow_dispatch_seconds_bucket, variant)",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
       }
     ]
   },
@@ -155,5 +254,5 @@
   "timepicker": { "refresh_intervals": ["10s", "30s", "1m", "5m"] },
   "timezone": "",
   "title": "Glyph Operations Overview",
-  "version": 1
+  "version": 2
 }

--- a/internal/replay/cases.go
+++ b/internal/replay/cases.go
@@ -1,40 +1,103 @@
 package replay
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/RowanDark/Glyph/internal/cases"
+	"github.com/RowanDark/Glyph/internal/observability/tracing"
 )
 
 // LoadCases reads cases from a JSON file.
 func LoadCases(path string) ([]cases.Case, error) {
+	return LoadCasesWithContext(context.Background(), path)
+}
+
+// LoadCasesWithContext reads cases from a JSON file using the provided context for tracing.
+func LoadCasesWithContext(ctx context.Context, path string) ([]cases.Case, error) {
+	_, span := tracing.StartSpan(ctx, "replay.load_cases", tracing.WithSpanKind(tracing.SpanKindInternal), tracing.WithAttributes(map[string]any{"glyph.replay.cases_path": strings.TrimSpace(path)}))
+	status := tracing.StatusOK
+	statusMsg := ""
+	defer func() {
+		if span != nil {
+			span.EndWithStatus(status, statusMsg)
+		}
+	}()
+
 	data, err := os.ReadFile(path)
 	if err != nil {
+		if span != nil {
+			span.RecordError(err)
+		}
+		status = tracing.StatusError
+		statusMsg = "read cases"
 		return nil, fmt.Errorf("read cases: %w", err)
 	}
 	var list []cases.Case
 	if err := json.Unmarshal(data, &list); err != nil {
+		if span != nil {
+			span.RecordError(err)
+		}
+		status = tracing.StatusError
+		statusMsg = "decode cases"
 		return nil, fmt.Errorf("decode cases: %w", err)
+	}
+	if span != nil {
+		span.SetAttribute("glyph.replay.case_count", len(list))
 	}
 	return list, nil
 }
 
 // WriteCases writes the provided cases to disk using deterministic encoding.
 func WriteCases(path string, list []cases.Case) error {
+	return WriteCasesWithContext(context.Background(), path, list)
+}
+
+// WriteCasesWithContext writes cases using the provided context for tracing.
+func WriteCasesWithContext(ctx context.Context, path string, list []cases.Case) error {
+	attrs := map[string]any{
+		"glyph.replay.cases_path": strings.TrimSpace(path),
+		"glyph.replay.case_count": len(list),
+	}
+	_, span := tracing.StartSpan(ctx, "replay.write_cases", tracing.WithSpanKind(tracing.SpanKindInternal), tracing.WithAttributes(attrs))
+	status := tracing.StatusOK
+	statusMsg := ""
+	defer func() {
+		if span != nil {
+			span.EndWithStatus(status, statusMsg)
+		}
+	}()
+
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
+		if span != nil {
+			span.RecordError(err)
+		}
+		status = tracing.StatusError
+		statusMsg = "create cases directory"
 		return fmt.Errorf("create cases directory: %w", err)
 	}
 	normalised := cloneAndSortCases(list)
 	data, err := json.MarshalIndent(normalised, "", "  ")
 	if err != nil {
+		if span != nil {
+			span.RecordError(err)
+		}
+		status = tracing.StatusError
+		statusMsg = "encode cases"
 		return fmt.Errorf("encode cases: %w", err)
 	}
 	if err := os.WriteFile(path, data, 0o644); err != nil {
+		if span != nil {
+			span.RecordError(err)
+		}
+		status = tracing.StatusError
+		statusMsg = "write cases"
 		return fmt.Errorf("write cases: %w", err)
 	}
 	return nil

--- a/internal/replay/flows.go
+++ b/internal/replay/flows.go
@@ -2,6 +2,7 @@ package replay
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/RowanDark/Glyph/internal/observability/tracing"
 )
 
 // FlowRecord captures a sanitized proxy flow suitable for replay.
@@ -26,8 +29,28 @@ type FlowRecord struct {
 
 // LoadFlows reads flow records from a JSONL file.
 func LoadFlows(path string) ([]FlowRecord, error) {
+	return LoadFlowsWithContext(context.Background(), path)
+}
+
+// LoadFlowsWithContext reads flow records from a JSONL file using the provided context for tracing.
+func LoadFlowsWithContext(ctx context.Context, path string) ([]FlowRecord, error) {
+	attrs := map[string]any{"glyph.replay.flows_path": strings.TrimSpace(path)}
+	_, span := tracing.StartSpan(ctx, "replay.load_flows", tracing.WithSpanKind(tracing.SpanKindInternal), tracing.WithAttributes(attrs))
+	status := tracing.StatusOK
+	statusMsg := ""
+	defer func() {
+		if span != nil {
+			span.EndWithStatus(status, statusMsg)
+		}
+	}()
+
 	file, err := os.Open(path)
 	if err != nil {
+		if span != nil {
+			span.RecordError(err)
+		}
+		status = tracing.StatusError
+		statusMsg = "open flows"
 		return nil, fmt.Errorf("open flows: %w", err)
 	}
 	defer file.Close()
@@ -41,11 +64,21 @@ func LoadFlows(path string) ([]FlowRecord, error) {
 		}
 		var record FlowRecord
 		if err := json.Unmarshal(line, &record); err != nil {
+			if span != nil {
+				span.RecordError(err)
+			}
+			status = tracing.StatusError
+			statusMsg = "decode flow record"
 			return nil, fmt.Errorf("decode flow record: %w", err)
 		}
 		records = append(records, record)
 	}
 	if err := scanner.Err(); err != nil {
+		if span != nil {
+			span.RecordError(err)
+		}
+		status = tracing.StatusError
+		statusMsg = "scan flows"
 		return nil, fmt.Errorf("scan flows: %w", err)
 	}
 	sort.SliceStable(records, func(i, j int) bool {
@@ -54,19 +87,56 @@ func LoadFlows(path string) ([]FlowRecord, error) {
 		}
 		return records[i].Sequence < records[j].Sequence
 	})
+	if span != nil {
+		span.SetAttribute("glyph.replay.flow_records", len(records))
+	}
 	return records, nil
 }
 
 // WriteFlows persists the provided flow records as JSONL.
 func WriteFlows(path string, flows []FlowRecord) error {
+	return WriteFlowsWithContext(context.Background(), path, flows)
+}
+
+// WriteFlowsWithContext persists flow records using the provided context for tracing.
+func WriteFlowsWithContext(ctx context.Context, path string, flows []FlowRecord) error {
+	attrs := map[string]any{
+		"glyph.replay.flows_path":   strings.TrimSpace(path),
+		"glyph.replay.flow_records": len(flows),
+	}
+	_, span := tracing.StartSpan(ctx, "replay.write_flows", tracing.WithSpanKind(tracing.SpanKindInternal), tracing.WithAttributes(attrs))
+	status := tracing.StatusOK
+	statusMsg := ""
+	defer func() {
+		if span != nil {
+			span.EndWithStatus(status, statusMsg)
+		}
+	}()
+
 	if strings.TrimSpace(path) == "" {
-		return errors.New("flow output path required")
+		err := errors.New("flow output path required")
+		if span != nil {
+			span.RecordError(err)
+		}
+		status = tracing.StatusError
+		statusMsg = "missing path"
+		return err
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		if span != nil {
+			span.RecordError(err)
+		}
+		status = tracing.StatusError
+		statusMsg = "create flow directory"
 		return fmt.Errorf("create flow directory: %w", err)
 	}
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 	if err != nil {
+		if span != nil {
+			span.RecordError(err)
+		}
+		status = tracing.StatusError
+		statusMsg = "open flow output"
 		return fmt.Errorf("open flow output: %w", err)
 	}
 	defer file.Close()
@@ -86,14 +156,37 @@ func WriteFlows(path string, flows []FlowRecord) error {
 	for _, record := range sorted {
 		data, err := json.Marshal(record)
 		if err != nil {
+			if span != nil {
+				span.RecordError(err)
+			}
+			status = tracing.StatusError
+			statusMsg = "encode flow record"
 			return fmt.Errorf("encode flow record: %w", err)
 		}
 		if _, err := writer.Write(data); err != nil {
+			if span != nil {
+				span.RecordError(err)
+			}
+			status = tracing.StatusError
+			statusMsg = "write flow record"
 			return fmt.Errorf("write flow record: %w", err)
 		}
 		if err := writer.WriteByte('\n'); err != nil {
+			if span != nil {
+				span.RecordError(err)
+			}
+			status = tracing.StatusError
+			statusMsg = "write newline"
 			return fmt.Errorf("write newline: %w", err)
 		}
 	}
-	return writer.Flush()
+	if err := writer.Flush(); err != nil {
+		if span != nil {
+			span.RecordError(err)
+		}
+		status = tracing.StatusError
+		statusMsg = "flush flow writer"
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- instrument the proxy capture path, plugin bus dispatch, runner, supervisor, and replay helpers with OpenTelemetry spans and error/status metadata
- extend observability metrics with context-aware exemplar support and propagate trace IDs into histograms
- refresh observability docs and Grafana dashboards to surface flow dispatch latency, plugin timings, and exemplar tooling guidance

## Testing
- GOMAXPROCS=4 go test ./... -p 2

------
https://chatgpt.com/codex/tasks/task_e_68ea2d2b0670832aa8f4c70813a2691c