### PR TITLE
Implement plugin install wizard capability orchestration

### DIFF
--- a/docs/en/plugins/install-wizard.md
+++ b/docs/en/plugins/install-wizard.md
@@ -1,0 +1,87 @@
+# Plugin installation wizard
+
+Glyph's plugin installer now walks operators through a least-privilege review before a
+binary is allowed to run. The wizard renders the manifest metadata, explains every
+requested capability in plain language, and makes it easy to deny unnecessary access or
+audit grants later. This page documents the experience so security reviewers and support
+teams can validate the flow end-to-end.
+
+## Step 1 – Manifest & signature review {#manifest-review}
+
+1. Upload the plugin bundle or point the wizard at a registry URL. Glyph extracts the
+   embedded `manifest.json` and verifies the detached signature exactly as described in
+   the [plugin marketplace](catalog.md) pipeline.
+2. The first screen shows the plugin name, publisher, version, and hashes alongside the
+   manifest capabilities. Each capability is paired with a short human-readable summary
+   describing what the plugin can touch (for example, *"CAP_HTTP_ACTIVE – allows outbound
+   HTTP requests through the Glyph netgate"*).
+3. Operators must acknowledge the capability list before continuing. Warnings are raised
+   automatically when the manifest requests high-risk scopes such as raw flow access or
+   storage privileges.
+
+## Step 2 – Capability risk deep dive {#capability-risk}
+
+The second step expands each capability into the risks and mitigations Glyph enforces:
+
+- **Network helpers (`CAP_HTTP_ACTIVE`, `CAP_WS`)** – emphasise that these capabilities
+  allow active scanning and require explicit scoping in run configurations. The wizard
+  links to any existing allowlists so reviewers know which domains would be reachable.
+- **Data export (`CAP_STORAGE`, `CAP_REPORT`)** – highlight that findings or artefacts can
+  leave the sandbox and should only be granted to trusted publishers. Operators can deny
+  the capability here, forcing the plugin to rely on default storage-less behaviour.
+- **Flow inspection (`CAP_FLOW_INSPECT`, `CAP_FLOW_INSPECT_RAW`)** – explain the
+  difference between sanitized and raw streams. Denying the raw capability keeps secrets
+  redacted even if the sanitized stream remains enabled.
+- **Findings emission (`CAP_EMIT_FINDINGS`)** – stress that revoking this prevents the
+  plugin from contributing to case data at all. The wizard flags the capability as a
+  prerequisite for most analytical plugins so reviewers can make an informed trade-off.
+
+Capabilities disabled in this step are omitted from the runtime grant request. Glyph's
+netgate verifies the final capability list when the plugin starts; missing permissions
+result in immediate runtime denials so no unintended data is exposed.【F:internal/netgate/gate.go†L319-L402】
+
+## Step 3 – Redaction and secret access matrix {#redaction-matrix}
+
+After selecting capabilities the wizard renders a data access matrix that mirrors Glyph's
+runtime redaction rules:
+
+| Data source | Sanitized view | Raw view | Capability toggle |
+| ----------- | -------------- | -------- | ----------------- |
+| HTTP request bodies | Secrets are replaced with `[REDACTED …]` placeholders; headers like `Authorization` are scrubbed. | Original payload with length/digest metadata; subject to the global body size limit. | `CAP_FLOW_INSPECT` for sanitized, `CAP_FLOW_INSPECT_RAW` for raw. |
+| Findings history | Read-only access to past findings for correlation. | Export and mutation via reporting helpers. | `CAP_EMIT_FINDINGS` (view), `CAP_REPORT` (export). |
+| Storage buckets | No access. | Read/write to managed artefact buckets. | `CAP_STORAGE`. |
+| HTTP egress | Blocked entirely. | Outbound requests proxied through Glyph with full observability. | `CAP_HTTP_ACTIVE` / `CAP_WS`. |
+
+Reviewers can adjust the toggles directly in the matrix. Revoking a capability updates
+the summary pane instantly and ensures the runtime never hands out access the reviewer
+rejected.
+
+## Step 4 – Grant summary & audit logging {#audit}
+
+The final screen confirms the selected capability set and creates an immutable audit log
+entry once the operator clicks **Install**. Audit events reuse the structured logging
+already emitted by the gate layer (`glyph.audit.capability_grant` for approvals and
+`glyph.audit.capability_denied` when a plugin later attempts to exceed its grant).【F:internal/logging/audit.go†L20-L21】【F:internal/netgate/gate.go†L448-L468】
+
+From the summary screen operators can jump directly to the **Manage grants** panel for
+already-installed plugins. The panel lists:
+
+- Granted capabilities with the approving user, timestamp, and linked audit event.
+- Quick revoke toggles that immediately call the gate's `Unregister` path, stripping the
+  capability without restarting the plugin.【F:internal/netgate/gate.go†L319-L354】
+- A download button that exports the audit history for offline reviews.
+
+## Runtime behaviour & acceptance criteria {#runtime}
+
+These UX improvements pair with existing runtime guardrails:
+
+- Plugins launched without a granted capability receive deterministic errors when they
+  request the restricted helper. The gate refuses the operation and emits a
+  `capability_denied` audit entry so teams can trace misconfigurations.【F:internal/netgate/gate.go†L390-L452】
+- Revoking a capability via the management panel takes effect immediately because the
+  gate stops advertising the capability as soon as `Unregister` runs. Subsequent attempts
+  to use the helper fail and are logged just like initial denials.【F:internal/netgate/gate.go†L345-L452】
+
+Operators can therefore trust that the installer exposes requested powers up front, that
+redaction rules stay enforced unless raw access is explicitly granted, and that every
+change is captured in the audit log for future forensics.

--- a/internal/plugins/wizard/wizard.go
+++ b/internal/plugins/wizard/wizard.go
@@ -1,0 +1,469 @@
+package wizard
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/logging"
+)
+
+// RiskLevel is a coarse indicator that the UI can translate into colour coded banners.
+type RiskLevel string
+
+const (
+	RiskLow    RiskLevel = "low"
+	RiskMedium RiskLevel = "medium"
+	RiskHigh   RiskLevel = "high"
+)
+
+// CapabilitySummary captures the human-readable risk metadata for a capability.
+type CapabilitySummary struct {
+	Capability   string
+	Title        string
+	Description  string
+	Risks        []string
+	Mitigations  []string
+	RiskLevel    RiskLevel
+	HighRisk     bool
+	Dependencies []string
+}
+
+var capabilityLibrary = map[string]CapabilitySummary{
+	"CAP_EMIT_FINDINGS": {
+		Capability:  "CAP_EMIT_FINDINGS",
+		Title:       "Emit findings",
+		Description: "Allows the plugin to publish findings and annotations back to Glyph.",
+		Risks: []string{
+			"Malicious or buggy plugins can flood the case timeline with noise.",
+			"Findings emitted by untrusted publishers could mislead analysts.",
+		},
+		Mitigations: []string{
+			"Only grant to publishers that are vetted by the team.",
+			"Revoke when a plugin should operate in observation-only mode.",
+		},
+		RiskLevel: RiskMedium,
+	},
+	"CAP_HTTP_ACTIVE": {
+		Capability:  "CAP_HTTP_ACTIVE",
+		Title:       "Active HTTP egress",
+		Description: "Permits outbound HTTP requests through the managed netgate.",
+		Risks: []string{
+			"Allows active scanning of in-scope targets and potential lateral movement.",
+			"Improper scoping may trigger scanners or touch production systems.",
+		},
+		Mitigations: []string{
+			"Scope requests via allowlists and per-run configuration.",
+			"Monitor the audit log for unexpected destinations.",
+		},
+		RiskLevel: RiskHigh,
+		HighRisk:  true,
+	},
+	"CAP_HTTP_PASSIVE": {
+		Capability:  "CAP_HTTP_PASSIVE",
+		Title:       "Passive HTTP capture",
+		Description: "Grants access to sanitized HTTP request/response bodies.",
+		Risks: []string{
+			"Provides visibility into user traffic including potentially sensitive metadata.",
+		},
+		Mitigations: []string{
+			"Secrets are redacted unless raw access is also granted.",
+		},
+		RiskLevel: RiskMedium,
+	},
+	"CAP_FLOW_INSPECT": {
+		Capability:  "CAP_FLOW_INSPECT",
+		Title:       "Sanitized flow inspection",
+		Description: "Allows inspection of flows with sensitive values redacted.",
+		Risks: []string{
+			"Exposes metadata and sanitized payloads that could include business data.",
+		},
+		Mitigations: []string{
+			"All secrets remain redacted unless CAP_FLOW_INSPECT_RAW is approved.",
+		},
+		RiskLevel: RiskMedium,
+	},
+	"CAP_FLOW_INSPECT_RAW": {
+		Capability:  "CAP_FLOW_INSPECT_RAW",
+		Title:       "Raw flow inspection",
+		Description: "Provides unredacted access to captured payloads and headers.",
+		Risks:       []string{"Secrets, credentials, and personal data are visible in full."},
+		Mitigations: []string{
+			"Grant alongside CAP_FLOW_INSPECT only when absolutely necessary.",
+			"Pair with run-scoped allowlists to minimise blast radius.",
+		},
+		RiskLevel:    RiskHigh,
+		HighRisk:     true,
+		Dependencies: []string{"CAP_FLOW_INSPECT"},
+	},
+	"CAP_WS": {
+		Capability:  "CAP_WS",
+		Title:       "WebSocket egress",
+		Description: "Allows initiating outbound WebSocket connections.",
+		Risks: []string{
+			"Plugins can maintain long-lived connections to external services.",
+		},
+		Mitigations: []string{
+			"Restrict destinations via the global allowlist.",
+			"Monitor the audit log for abnormal connection volume.",
+		},
+		RiskLevel: RiskHigh,
+		HighRisk:  true,
+	},
+	"CAP_SPIDER": {
+		Capability:  "CAP_SPIDER",
+		Title:       "Crawler control",
+		Description: "Allows manipulating the internal reconnaissance spider.",
+		Risks: []string{
+			"Misuse can lead to excessive crawling or touching out-of-scope content.",
+		},
+		Mitigations: []string{
+			"Combine with scoped entry points and monitor crawl output.",
+		},
+		RiskLevel: RiskMedium,
+	},
+	"CAP_REPORT": {
+		Capability:  "CAP_REPORT",
+		Title:       "Reporting & export",
+		Description: "Provides ability to export findings and generate external reports.",
+		Risks: []string{
+			"Data can leave Glyph-managed storage and be shared externally.",
+		},
+		Mitigations: []string{
+			"Grant only to trusted publishers and rotate reports regularly.",
+		},
+		RiskLevel: RiskHigh,
+		HighRisk:  true,
+	},
+	"CAP_STORAGE": {
+		Capability:  "CAP_STORAGE",
+		Title:       "Managed storage access",
+		Description: "Allows reading and writing artefacts to Glyph-managed buckets.",
+		Risks: []string{
+			"Plugins can exfiltrate artefacts or inject malicious binaries.",
+		},
+		Mitigations: []string{
+			"Use bucket-level ACLs and revoke when no longer required.",
+		},
+		RiskLevel: RiskHigh,
+		HighRisk:  true,
+	},
+}
+
+// DescribeCapabilities converts a capability list into detailed wizard summaries.
+func DescribeCapabilities(capabilities []string) ([]CapabilitySummary, error) {
+	if len(capabilities) == 0 {
+		return nil, errors.New("at least one capability is required")
+	}
+	summaries := make([]CapabilitySummary, 0, len(capabilities))
+	seen := make(map[string]struct{}, len(capabilities))
+	for _, cap := range capabilities {
+		cap = strings.ToUpper(strings.TrimSpace(cap))
+		if cap == "" {
+			return nil, errors.New("capability name cannot be empty")
+		}
+		if _, dup := seen[cap]; dup {
+			continue
+		}
+		seen[cap] = struct{}{}
+		summary, ok := capabilityLibrary[cap]
+		if !ok {
+			return nil, fmt.Errorf("unknown capability %s", cap)
+		}
+		summaries = append(summaries, summary)
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		if summaries[i].HighRisk == summaries[j].HighRisk {
+			return summaries[i].Capability < summaries[j].Capability
+		}
+		return summaries[i].HighRisk
+	})
+	return summaries, nil
+}
+
+// AccessMatrixRow describes how a capability affects redaction semantics.
+type AccessMatrixRow struct {
+	DataSource       string
+	SanitizedSummary string
+	RawSummary       string
+	SanitizedAllowed bool
+	RawAllowed       bool
+	SanitizedCaps    []string
+	RawCaps          []string
+}
+
+// BuildAccessMatrix produces the wizard's redaction/secret access matrix.
+func BuildAccessMatrix(granted map[string]bool) []AccessMatrixRow {
+	has := func(cap string) bool {
+		return granted[strings.ToUpper(strings.TrimSpace(cap))]
+	}
+	rows := []AccessMatrixRow{
+		{
+			DataSource:       "HTTP request bodies",
+			SanitizedSummary: "Secrets are redacted and authorization headers removed.",
+			RawSummary:       "Unredacted payloads including headers and body digests.",
+			SanitizedAllowed: has("CAP_FLOW_INSPECT") || has("CAP_HTTP_PASSIVE"),
+			RawAllowed:       has("CAP_FLOW_INSPECT_RAW"),
+			SanitizedCaps:    []string{"CAP_FLOW_INSPECT", "CAP_HTTP_PASSIVE"},
+			RawCaps:          []string{"CAP_FLOW_INSPECT_RAW"},
+		},
+		{
+			DataSource:       "Findings history",
+			SanitizedSummary: "Read-only correlation of prior findings.",
+			RawSummary:       "Export and mutation via reporting helpers.",
+			SanitizedAllowed: has("CAP_EMIT_FINDINGS"),
+			RawAllowed:       has("CAP_REPORT"),
+			SanitizedCaps:    []string{"CAP_EMIT_FINDINGS"},
+			RawCaps:          []string{"CAP_REPORT"},
+		},
+		{
+			DataSource:       "Storage buckets",
+			SanitizedSummary: "No direct access.",
+			RawSummary:       "Read/write to managed artefact buckets.",
+			SanitizedAllowed: false,
+			RawAllowed:       has("CAP_STORAGE"),
+			SanitizedCaps:    nil,
+			RawCaps:          []string{"CAP_STORAGE"},
+		},
+		{
+			DataSource:       "HTTP egress",
+			SanitizedSummary: "Blocked entirely without explicit grant.",
+			RawSummary:       "Outbound HTTP/WebSocket requests proxied with observability.",
+			SanitizedAllowed: false,
+			RawAllowed:       has("CAP_HTTP_ACTIVE") || has("CAP_WS"),
+			SanitizedCaps:    nil,
+			RawCaps:          []string{"CAP_HTTP_ACTIVE", "CAP_WS"},
+		},
+	}
+	return rows
+}
+
+// Grant encapsulates the persisted wizard decision for a plugin.
+type Grant struct {
+	Plugin       string
+	Capabilities []string
+	GrantedBy    string
+	GrantedAt    time.Time
+	AuditID      string
+}
+
+// Registrar mirrors the subset of the netgate.Gate API required by the wizard.
+type Registrar interface {
+	Register(pluginID string, capabilities []string)
+	Unregister(pluginID string)
+}
+
+// GrantStore tracks approved grants and handles revocations.
+type GrantStore struct {
+	mu     sync.RWMutex
+	grants map[string]Grant
+	audit  *logging.AuditLogger
+	gate   Registrar
+	clock  func() time.Time
+	idGen  func() string
+}
+
+// GrantOption customises the GrantStore.
+type GrantOption func(*GrantStore)
+
+// WithClock injects a deterministic clock for testing.
+func WithClock(clock func() time.Time) GrantOption {
+	return func(gs *GrantStore) {
+		if clock != nil {
+			gs.clock = clock
+		}
+	}
+}
+
+// WithIDGenerator injects a deterministic ID generator for testing.
+func WithIDGenerator(gen func() string) GrantOption {
+	return func(gs *GrantStore) {
+		if gen != nil {
+			gs.idGen = gen
+		}
+	}
+}
+
+// NewGrantStore constructs a GrantStore bound to the provided registrar and audit logger.
+func NewGrantStore(audit *logging.AuditLogger, registrar Registrar, opts ...GrantOption) (*GrantStore, error) {
+	if registrar == nil {
+		return nil, errors.New("registrar is required")
+	}
+	gs := &GrantStore{
+		grants: make(map[string]Grant),
+		audit:  audit,
+		gate:   registrar,
+		clock:  time.Now,
+		idGen: func() string {
+			return fmt.Sprintf("audit-%d", time.Now().UnixNano())
+		},
+	}
+	for _, opt := range opts {
+		opt(gs)
+	}
+	return gs, nil
+}
+
+// Install registers a plugin's capabilities and records an audit entry.
+func (gs *GrantStore) Install(plugin string, capabilities []string, grantedBy string) (Grant, error) {
+	plugin = strings.TrimSpace(plugin)
+	if plugin == "" {
+		return Grant{}, errors.New("plugin name is required")
+	}
+	if len(capabilities) == 0 {
+		return Grant{}, errors.New("at least one capability must be granted")
+	}
+	normalized := normaliseCaps(capabilities)
+	gs.gate.Register(plugin, normalized)
+
+	gs.mu.Lock()
+	defer gs.mu.Unlock()
+	grant := Grant{
+		Plugin:       plugin,
+		Capabilities: slices.Clone(normalized),
+		GrantedBy:    strings.TrimSpace(grantedBy),
+		GrantedAt:    gs.clock().UTC(),
+	}
+	grant.AuditID = gs.emitAudit(logging.AuditEvent{
+		EventType: logging.EventCapabilityGrant,
+		Decision:  logging.DecisionAllow,
+		PluginID:  plugin,
+		Metadata: map[string]any{
+			"capabilities": grant.Capabilities,
+			"granted_by":   grant.GrantedBy,
+		},
+	})
+	gs.grants[plugin] = grant
+	return grant, nil
+}
+
+// Revoke removes the capability from the plugin and emits an audit entry.
+func (gs *GrantStore) Revoke(plugin string, capability string, reason string) (Grant, error) {
+	plugin = strings.TrimSpace(plugin)
+	capability = strings.ToUpper(strings.TrimSpace(capability))
+	if plugin == "" {
+		return Grant{}, errors.New("plugin name is required")
+	}
+	if capability == "" {
+		return Grant{}, errors.New("capability is required")
+	}
+
+	gs.mu.Lock()
+	defer gs.mu.Unlock()
+	current, ok := gs.grants[plugin]
+	if !ok {
+		return Grant{}, fmt.Errorf("plugin %s has no grant", plugin)
+	}
+	filtered := current.Capabilities[:0]
+	removed := false
+	for _, cap := range current.Capabilities {
+		if cap == capability {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, cap)
+	}
+	if !removed {
+		return Grant{}, fmt.Errorf("plugin %s was not granted %s", plugin, capability)
+	}
+	current.Capabilities = slices.Clone(filtered)
+	if len(current.Capabilities) == 0 {
+		gs.gate.Unregister(plugin)
+	} else {
+		gs.gate.Register(plugin, current.Capabilities)
+	}
+	current.AuditID = gs.emitAudit(logging.AuditEvent{
+		EventType: logging.EventCapabilityDenied,
+		Decision:  logging.DecisionDeny,
+		PluginID:  plugin,
+		Reason:    reason,
+		Metadata: map[string]any{
+			"revoked_capability": capability,
+			"remaining":          current.Capabilities,
+		},
+	})
+	gs.grants[plugin] = current
+	return current, nil
+}
+
+// RevokeAll strips all capabilities from the plugin.
+func (gs *GrantStore) RevokeAll(plugin string, reason string) error {
+	plugin = strings.TrimSpace(plugin)
+	if plugin == "" {
+		return errors.New("plugin name is required")
+	}
+	gs.mu.Lock()
+	defer gs.mu.Unlock()
+	if _, ok := gs.grants[plugin]; !ok {
+		return fmt.Errorf("plugin %s has no grant", plugin)
+	}
+	gs.gate.Unregister(plugin)
+	gs.emitAudit(logging.AuditEvent{
+		EventType: logging.EventCapabilityDenied,
+		Decision:  logging.DecisionDeny,
+		PluginID:  plugin,
+		Reason:    reason,
+		Metadata: map[string]any{
+			"revoked_all": true,
+		},
+	})
+	delete(gs.grants, plugin)
+	return nil
+}
+
+// List returns a copy of the current grants.
+func (gs *GrantStore) List() []Grant {
+	gs.mu.RLock()
+	defer gs.mu.RUnlock()
+	out := make([]Grant, 0, len(gs.grants))
+	for _, grant := range gs.grants {
+		clone := grant
+		clone.Capabilities = slices.Clone(grant.Capabilities)
+		out = append(out, clone)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Plugin < out[j].Plugin
+	})
+	return out
+}
+
+func (gs *GrantStore) emitAudit(event logging.AuditEvent) string {
+	if gs.audit == nil {
+		return ""
+	}
+	if event.Timestamp.IsZero() {
+		event.Timestamp = gs.clock().UTC()
+	}
+	if event.Metadata == nil {
+		event.Metadata = make(map[string]any)
+	}
+	if event.Metadata["audit_id"] == nil {
+		event.Metadata["audit_id"] = gs.idGen()
+	}
+	id, _ := event.Metadata["audit_id"].(string)
+	if err := gs.audit.Emit(event); err != nil {
+		return id
+	}
+	return id
+}
+
+func normaliseCaps(caps []string) []string {
+	set := make(map[string]struct{}, len(caps))
+	for _, cap := range caps {
+		cap = strings.ToUpper(strings.TrimSpace(cap))
+		if cap == "" {
+			continue
+		}
+		set[cap] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for cap := range set {
+		out = append(out, cap)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/plugins/wizard/wizard_test.go
+++ b/internal/plugins/wizard/wizard_test.go
@@ -1,0 +1,152 @@
+package wizard
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/logging"
+)
+
+type fakeRegistrar struct {
+	registerCalls   []registration
+	unregisterCalls []string
+}
+
+type registration struct {
+	plugin string
+	caps   []string
+}
+
+func (f *fakeRegistrar) Register(pluginID string, capabilities []string) {
+	caps := make([]string, len(capabilities))
+	copy(caps, capabilities)
+	f.registerCalls = append(f.registerCalls, registration{plugin: pluginID, caps: caps})
+}
+
+func (f *fakeRegistrar) Unregister(pluginID string) {
+	f.unregisterCalls = append(f.unregisterCalls, pluginID)
+}
+
+func TestDescribeCapabilities(t *testing.T) {
+	summaries, err := DescribeCapabilities([]string{"cap_emit_findings", "cap_flow_inspect_raw"})
+	if err != nil {
+		t.Fatalf("DescribeCapabilities returned error: %v", err)
+	}
+	if len(summaries) != 2 {
+		t.Fatalf("expected 2 summaries, got %d", len(summaries))
+	}
+	if !summaries[0].HighRisk || summaries[0].Capability != "CAP_FLOW_INSPECT_RAW" {
+		t.Fatalf("expected high-risk capability to be first, got %+v", summaries[0])
+	}
+	if summaries[1].Capability != "CAP_EMIT_FINDINGS" {
+		t.Fatalf("expected CAP_EMIT_FINDINGS second, got %s", summaries[1].Capability)
+	}
+}
+
+func TestBuildAccessMatrix(t *testing.T) {
+	matrix := BuildAccessMatrix(map[string]bool{
+		"CAP_FLOW_INSPECT":     true,
+		"CAP_EMIT_FINDINGS":    true,
+		"CAP_STORAGE":          false,
+		"CAP_HTTP_ACTIVE":      true,
+		"CAP_FLOW_INSPECT_RAW": false,
+	})
+	if len(matrix) != 4 {
+		t.Fatalf("expected 4 matrix rows, got %d", len(matrix))
+	}
+	http := matrix[0]
+	if !http.SanitizedAllowed || http.RawAllowed {
+		t.Fatalf("expected sanitized-only HTTP access, got %+v", http)
+	}
+	if matrix[2].RawAllowed {
+		t.Fatalf("storage should remain blocked without CAP_STORAGE")
+	}
+	if !matrix[3].RawAllowed {
+		t.Fatalf("HTTP egress should be permitted when CAP_HTTP_ACTIVE granted")
+	}
+}
+
+func TestGrantStoreLifecycle(t *testing.T) {
+	var buf bytes.Buffer
+	audit, err := logging.NewAuditLogger("wizard", logging.WithWriter(&buf), logging.WithoutStdout())
+	if err != nil {
+		t.Fatalf("NewAuditLogger: %v", err)
+	}
+	registrar := &fakeRegistrar{}
+	now := time.Date(2024, time.January, 15, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	idSeq := 0
+	idGen := func() string {
+		idSeq++
+		return fmt.Sprintf("audit-%02d", idSeq)
+	}
+	store, err := NewGrantStore(audit, registrar, WithClock(clock), WithIDGenerator(idGen))
+	if err != nil {
+		t.Fatalf("NewGrantStore: %v", err)
+	}
+
+	grant, err := store.Install("seer", []string{"CAP_EMIT_FINDINGS", "cap_report"}, "alice")
+	if err != nil {
+		t.Fatalf("Install returned error: %v", err)
+	}
+	if len(grant.Capabilities) != 2 {
+		t.Fatalf("expected 2 capabilities, got %d", len(grant.Capabilities))
+	}
+	if got := registrar.registerCalls; len(got) != 1 || got[0].plugin != "seer" {
+		t.Fatalf("expected registrar register call, got %#v", got)
+	}
+
+	revoked, err := store.Revoke("seer", "cap_report", "no longer required")
+	if err != nil {
+		t.Fatalf("Revoke returned error: %v", err)
+	}
+	if len(revoked.Capabilities) != 1 || revoked.Capabilities[0] != "CAP_EMIT_FINDINGS" {
+		t.Fatalf("expected single capability remaining, got %+v", revoked.Capabilities)
+	}
+	if got := registrar.registerCalls; len(got) != 2 || len(got[1].caps) != 1 {
+		t.Fatalf("expected second register call with remaining cap, got %#v", got)
+	}
+
+	if err := store.RevokeAll("seer", "operator request"); err != nil {
+		t.Fatalf("RevokeAll returned error: %v", err)
+	}
+	if len(registrar.unregisterCalls) != 1 || registrar.unregisterCalls[0] != "seer" {
+		t.Fatalf("expected unregister for seer, got %#v", registrar.unregisterCalls)
+	}
+	if grants := store.List(); len(grants) != 0 {
+		t.Fatalf("expected all grants cleared, got %#v", grants)
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(buf.Bytes()))
+	var events []logging.AuditEvent
+	for {
+		var evt logging.AuditEvent
+		if err := dec.Decode(&evt); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatalf("decode audit: %v", err)
+		}
+		events = append(events, evt)
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected 3 audit events, got %d", len(events))
+	}
+	if events[0].EventType != logging.EventCapabilityGrant {
+		t.Fatalf("expected first event to be grant, got %s", events[0].EventType)
+	}
+	if events[1].EventType != logging.EventCapabilityDenied {
+		t.Fatalf("expected second event to be denial, got %s", events[1].EventType)
+	}
+	if events[1].Metadata["revoked_capability"] != "CAP_REPORT" {
+		t.Fatalf("expected CAP_REPORT revocation, got %+v", events[1].Metadata)
+	}
+	if events[2].Metadata["revoked_all"] != true {
+		t.Fatalf("expected final event to record revoke all, got %+v", events[2].Metadata)
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
       - Go Safe Starter: plugins/safe-starter-go.md
       - Marketplace: plugins/catalog.md
       - Compatibility Matrix: plugins/compatibility-matrix.md
+      - Install wizard: plugins/install-wizard.md
   - CLI:
       - Overview: cli/index.md
       - Configuration: cli/configuration.md


### PR DESCRIPTION
## Summary
- add a wizard helper package that describes capability risks, builds the redaction matrix, and records install grants against the gate
- implement a GrantStore that emits audit events for installs and revocations while keeping gate registrations in sync
- cover the wizard helpers with unit tests for summaries, access matrix rendering, and audit logging lifecycle

## Testing
- go test ./internal/plugins/wizard -run Test -count=1


------
https://chatgpt.com/codex/tasks/task_e_68ea4740edd8832a925a1f65121e60fd