### PR TITLE
Add rebrand tracker documentation

### DIFF
--- a/docs/en/dev/rebrand-tracker.md
+++ b/docs/en/dev/rebrand-tracker.md
@@ -1,0 +1,19 @@
+# Rebrand tracker: Glyph → 0xgen (meta)
+
+> **Status:** Prep work
+
+Create label: `rebrand`
+
+## Checklist
+
+- [ ] 1 Docs surface rename (title/header only)
+- [ ] 2 README badges/links (no URLs changed)
+- [ ] 3 GUI window title/icon text only
+- [ ] 4 CLI banner + `--version` output text
+- [ ] 5 Config dir env vars (read new, fall back to old)
+- [ ] 6 Binary wrapper: `0xgenctl` → `glyphctl` (alias)
+- [ ] 7 Docs URLs: add redirects `/Glyph` → `/0xgen`
+- [ ] 8 `go.mod` module comment only (no path change)
+- [ ] 9 Homebrew formula name only (alias keeps glyph)
+- [ ] 10 CI job names & artifact names (no paths)
+- [ ] 11 Final: repository rename and module path migration

--- a/docs/es/dev/rebrand-tracker.md
+++ b/docs/es/dev/rebrand-tracker.md
@@ -1,0 +1,19 @@
+# Seguimiento de rebranding: Glyph → 0xgen (meta)
+
+> **Estado:** Trabajo de preparación
+
+Crear etiqueta: `rebrand`
+
+## Lista de comprobación
+
+- [ ] 1 Renombrar superficies de documentación (solo título/encabezado)
+- [ ] 2 Insignias/enlaces del README (sin cambiar URL)
+- [ ] 3 Título/icono de la ventana GUI solo texto
+- [ ] 4 Banner de la CLI y texto de la salida de `--version`
+- [ ] 5 Variables de entorno del directorio de configuración (leer nuevo, retrocompatibilidad con el anterior)
+- [ ] 6 Wrapper binario: `0xgenctl` → `glyphctl` (alias)
+- [ ] 7 URLs de la documentación: añadir redirecciones `/Glyph` → `/0xgen`
+- [ ] 8 Comentario del módulo en `go.mod` solamente (sin cambiar la ruta)
+- [ ] 9 Nombre de la fórmula de Homebrew solamente (el alias mantiene glyph)
+- [ ] 10 Nombres de trabajos y artefactos en CI (sin cambiar rutas)
+- [ ] 11 Final: renombrar repositorio y migrar la ruta del módulo

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - Updater channels & rollback: dev/updater.md
       - Windows & WSL interop: dev/windows-wsl.md
       - Running tests locally: dev/testing.md
+      - Rebrand tracker (meta): dev/rebrand-tracker.md
       - Accessibility modes: dev-guide/accessibility-modes.md
   - Security:
       - Overview: security/index.md
@@ -74,6 +75,7 @@ plugins:
           E2E Scenario Suite: Escenarios E2E
           Updater channels & rollback: Canales de actualización y reversión
           Running tests locally: Ejecución de pruebas en local
+          Rebrand tracker (meta): Seguimiento de rebranding (meta)
           Accessibility modes: Modos de accesibilidad
           Security: Seguridad
           Versions: Versiones


### PR DESCRIPTION
## Summary
- add an English and Spanish rebrand tracking checklist for the Glyph → 0xgen effort
- surface the tracker in the developer guide navigation and localize the entry name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ec2a8eaf80832abc799d7424aa5366