### PR TITLE
Rebrand docs title to 0xgen

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,6 +1,6 @@
-# Welcome to Glyph
+# Welcome to 0xgen
 
-Glyph is an automation toolkit for orchestrating red-team and detection workflows. It
+0xgen is an automation toolkit for orchestrating red-team and detection workflows. It
 coordinates plugins such as Galdr, Excavator, Seer, Ranker, and Scribe to turn raw
 telemetry into ranked findings and human-readable reports. This site consolidates the
 operational and contributor documentation that previously lived in scattered Markdown

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Glyph Documentation
+site_name: 0xgen Documentation
 site_description: Documentation for the Glyph red-team and detection automation toolkit.
 site_url: https://rowandark.github.io/Glyph/
 repo_url: https://github.com/RowanDark/Glyph


### PR DESCRIPTION
## Summary
- rename the MkDocs site title to "0xgen Documentation"
- update the English docs landing page heading and opening sentence to use the 0xgen name

## Testing
- `mkdocs build --strict` *(fails: Config value 'plugins': Plugin 'git-revision-date-localized' option 'format' is unrecognised in the existing configuration)*
- `python -m http.server 8000` & `curl -I http://127.0.0.1:8000/`

------
https://chatgpt.com/codex/tasks/task_e_68ec2d0cbfa0832a8fb47ca083fbca6d