### PR TITLE
docs: update README branding to 0xgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
-# Glyph
+# 0xgen
 
 <!-- version-badge -->[![Release](https://img.shields.io/badge/release-v0.0.0--dev-blue)](https://github.com/RowanDark/Glyph/releases/latest)<!-- /version-badge --> [![Build status](https://github.com/RowanDark/Glyph/actions/workflows/ci.yml/badge.svg)](https://github.com/RowanDark/Glyph/actions/workflows/ci.yml) [![Docs](https://img.shields.io/badge/docs-material-blue)](https://rowandark.github.io/Glyph/) [![Plugin count](https://img.shields.io/endpoint?url=https://rowandark.github.io/Glyph/api/plugin-stats.json&cacheSeconds=3600)](https://rowandark.github.io/Glyph/plugins/catalog/)
 
-Glyph is an automation toolkit for orchestrating red-team and detection workflows.
-It coordinates plugins such as Galdr (HTTP rewriting proxy), Excavator (Playwright
-crawler), Seer (secret/PII detector), Ranker, and Scribe to turn raw telemetry into
-ranked findings and human-readable reports.
+0xgen — Generation Zero: AI-driven offensive security.
 
 The badges above highlight the most recent Glyph release, continuous-integration
 status, documentation portal, and the live plugin catalog size published from the


### PR DESCRIPTION
## Summary
- rename the README title heading to reference 0xgen
- refresh the tagline to the new 0xgen branding while leaving badges intact

## Testing
- python -m markdown README.md > /tmp/README.html

------
https://chatgpt.com/codex/tasks/task_e_68ec2ffda0cc832abed84bda1885527c