### PR TITLE
chore: update desktop shell branding to 0xgen

### DIFF
--- a/apps/desktop-shell/src-tauri/tauri.conf.json
+++ b/apps/desktop-shell/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "package": {
-    "productName": "Glyph Desktop",
+    "productName": "0xgen",
     "version": "0.1.0"
   },
   "tauri": {
@@ -35,7 +35,7 @@
     },
     "windows": [
       {
-        "title": "Glyph Desktop",
+        "title": "0xgen",
         "width": 1200,
         "height": 800,
         "resizable": true,


### PR DESCRIPTION
## Summary
- update the Tauri configuration product name to 0xgen for the desktop shell
- set the default desktop window title to 0xgen

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ec348b35e4832a8ac57a3c909f085e