### PR TITLE
Rebrand glyphctl banner and version output

### DIFF
--- a/cmd/glyphctl/main.go
+++ b/cmd/glyphctl/main.go
@@ -6,6 +6,20 @@ import (
 	"os"
 )
 
+const productName = "0xgen"
+const cliBanner = productName + " CLI (glyphctl)"
+
+func init() {
+	defaultUsage := flag.Usage
+	flag.Usage = func() {
+		fmt.Fprintln(flag.CommandLine.Output(), cliBanner)
+		fmt.Fprintln(flag.CommandLine.Output())
+		if defaultUsage != nil {
+			defaultUsage()
+		}
+	}
+}
+
 func main() {
 	// Parse global flags (including --manifest-validate) once.
 	flag.Parse()
@@ -41,22 +55,22 @@ func main() {
 		os.Exit(runConfig(args[1:]))
 	case "scope":
 		os.Exit(runScope(args[1:]))
-        case "plugin":
-                if len(args) < 2 {
-                        fmt.Fprintln(os.Stderr, "plugin subcommand required")
-                        os.Exit(2)
-                }
-                switch args[1] {
-                case "run":
-                        os.Exit(runPluginRun(args[2:]))
-                case "verify":
-                        os.Exit(runPluginVerify(args[2:]))
-                case "registry":
-                        os.Exit(runPluginRegistry(args[2:]))
-                default:
-                        fmt.Fprintf(os.Stderr, "unknown plugin subcommand: %s\n", args[1])
-                        os.Exit(2)
-                }
+	case "plugin":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "plugin subcommand required")
+			os.Exit(2)
+		}
+		switch args[1] {
+		case "run":
+			os.Exit(runPluginRun(args[2:]))
+		case "verify":
+			os.Exit(runPluginVerify(args[2:]))
+		case "registry":
+			os.Exit(runPluginRegistry(args[2:]))
+		default:
+			fmt.Fprintf(os.Stderr, "unknown plugin subcommand: %s\n", args[1])
+			os.Exit(2)
+		}
 	case "raider":
 		os.Exit(runRaider(args[1:]))
 	case "history":
@@ -76,58 +90,58 @@ func main() {
 			fmt.Fprintln(os.Stderr, "repeater subcommand required")
 			os.Exit(2)
 		}
-                switch args[1] {
-                case "send":
-                        os.Exit(runRepeaterSend(args[2:]))
-                default:
-                        fmt.Fprintf(os.Stderr, "unknown repeater subcommand: %s\n", args[1])
-                        os.Exit(2)
-                }
-        case "serve":
-                if len(args) < 2 {
-                        fmt.Fprintln(os.Stderr, "serve subcommand required")
-                        os.Exit(2)
-                }
-                switch args[1] {
-                case "ui":
-                        os.Exit(runServeUI(args[2:]))
-                default:
-                        fmt.Fprintf(os.Stderr, "unknown serve subcommand: %s\n", args[1])
-                        os.Exit(2)
-                }
-        case "replay":
-                os.Exit(runReplay(args[1:]))
-        case "version":
-                os.Exit(runVersion(args[1:]))
-        case "self-update":
-                os.Exit(runSelfUpdate(args[1:]))
-        case "proxy":
-                if len(args) < 2 {
-                        fmt.Fprintln(os.Stderr, "proxy subcommand required")
-                        os.Exit(2)
-                }
-                switch args[1] {
-                case "trust":
-                        os.Exit(runProxyTrust(args[2:]))
-                default:
-                        fmt.Fprintf(os.Stderr, "unknown proxy subcommand: %s\n", args[1])
-                        os.Exit(2)
-                }
-        case "wsl":
-                if len(args) < 2 {
-                        fmt.Fprintln(os.Stderr, "wsl subcommand required")
-                        os.Exit(2)
-                }
-                switch args[1] {
-                case "path":
-                        os.Exit(runWSLPath(args[2:]))
-                default:
-                        fmt.Fprintf(os.Stderr, "unknown wsl subcommand: %s\n", args[1])
-                        os.Exit(2)
-                }
-        default:
-                fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
-                flag.Usage()
-                os.Exit(2)
-        }
+		switch args[1] {
+		case "send":
+			os.Exit(runRepeaterSend(args[2:]))
+		default:
+			fmt.Fprintf(os.Stderr, "unknown repeater subcommand: %s\n", args[1])
+			os.Exit(2)
+		}
+	case "serve":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "serve subcommand required")
+			os.Exit(2)
+		}
+		switch args[1] {
+		case "ui":
+			os.Exit(runServeUI(args[2:]))
+		default:
+			fmt.Fprintf(os.Stderr, "unknown serve subcommand: %s\n", args[1])
+			os.Exit(2)
+		}
+	case "replay":
+		os.Exit(runReplay(args[1:]))
+	case "version":
+		os.Exit(runVersion(args[1:]))
+	case "self-update":
+		os.Exit(runSelfUpdate(args[1:]))
+	case "proxy":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "proxy subcommand required")
+			os.Exit(2)
+		}
+		switch args[1] {
+		case "trust":
+			os.Exit(runProxyTrust(args[2:]))
+		default:
+			fmt.Fprintf(os.Stderr, "unknown proxy subcommand: %s\n", args[1])
+			os.Exit(2)
+		}
+	case "wsl":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "wsl subcommand required")
+			os.Exit(2)
+		}
+		switch args[1] {
+		case "path":
+			os.Exit(runWSLPath(args[2:]))
+		default:
+			fmt.Fprintf(os.Stderr, "unknown wsl subcommand: %s\n", args[1])
+			os.Exit(2)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
+		flag.Usage()
+		os.Exit(2)
+	}
 }

--- a/cmd/glyphctl/version.go
+++ b/cmd/glyphctl/version.go
@@ -8,6 +8,10 @@ import (
 
 var version = "dev"
 
+func versionString() string {
+	return fmt.Sprintf("%s %s", productName, version)
+}
+
 func runVersion(args []string) int {
 	fs := flag.NewFlagSet("version", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
@@ -18,6 +22,6 @@ func runVersion(args []string) int {
 		fmt.Fprintln(os.Stderr, "version takes no arguments")
 		return 2
 	}
-	fmt.Println(version)
+	fmt.Println(versionString())
 	return 0
 }

--- a/cmd/glyphctl/version_flag.go
+++ b/cmd/glyphctl/version_flag.go
@@ -14,6 +14,6 @@ func maybePrintVersion() bool {
 	if !*showVersion {
 		return false
 	}
-	fmt.Println(version)
+	fmt.Println(versionString())
 	return true
 }


### PR DESCRIPTION
## Summary
- Prefix the glyphctl usage banner with the 0xgen product name.
- Include the 0xgen label in version output for both the version subcommand and --version flag.

## Testing
- go build ./cmd/glyphctl && ./glyphctl --version | grep 0xgen
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ec35c85630832aaf3c1f8d56ebc9e4