### PR TITLE
Rebrand(6): add 0xgenctl shim that calls glyphctl

### DIFF
--- a/packaging/windows/glyphctl.wxs
+++ b/packaging/windows/glyphctl.wxs
@@ -46,6 +46,7 @@
     <ComponentGroup Id="GlyphComponents">
       <Component Id="GlyphExecutable" Guid="{2DFEEA0E-4FD0-4F71-83F2-5C2F11C278F7}" Directory="INSTALLFOLDER" Win64="yes">
         <File Id="GlyphExecutableFile" Source="$(var.PayloadDir)/glyphctl.exe" KeyPath="yes" />
+        <File Id="GlyphAliasFile" Source="$(var.PayloadDir)/0xgenctl.cmd" />
         <File Id="GlyphLicenseFile" Source="$(var.PayloadDir)/LICENSE.txt" />
         <File Id="GlyphReadmeFile" Source="$(var.PayloadDir)/README.txt" />
         <Environment Id="GlyphPath"

--- a/packaging/windows/winget/glyphctl.yaml
+++ b/packaging/windows/winget/glyphctl.yaml
@@ -13,9 +13,11 @@ Installers:
     InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
     Commands:
       - glyphctl
+      - 0xgenctl
   - Architecture: arm64
     InstallerType: portable
     InstallerUrl: https://github.com/RowanDark/Glyph/releases/download/v0.0.0/glyphctl_v0.0.0_windows_arm64.zip
     InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
     Commands:
       - glyphctl
+      - 0xgenctl

--- a/scoop/bucket/glyphctl.json
+++ b/scoop/bucket/glyphctl.json
@@ -14,7 +14,8 @@
     }
   },
   "bin": [
-    "glyphctl.exe"
+    "glyphctl.exe",
+    ["0xgenctl.cmd", "0xgenctl"]
   ],
   "checkver": {
     "github": "https://github.com/RowanDark/Glyph"

--- a/scripts/0xgenctl
+++ b/scripts/0xgenctl
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec glyphctl "$@"

--- a/scripts/0xgenctl.cmd
+++ b/scripts/0xgenctl.cmd
@@ -1,0 +1,2 @@
+@echo off
+"%~dp0glyphctl.exe" %*

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -38,6 +38,8 @@ for target in "${targets[@]}"; do
                 go build -ldflags "$LDFLAGS" -o "$BUILD_DIR/glyphctl" ./cmd/glyphctl
 
         cp "$ROOT_DIR/LICENSE" "$BUILD_DIR/"
+        cp "$ROOT_DIR/scripts/0xgenctl" "$BUILD_DIR/"
+        chmod +x "$BUILD_DIR/0xgenctl"
 
         (cd "$DIST_DIR" && tar -czf "$ARCHIVE_BASENAME.tar.gz" "$ARCHIVE_BASENAME")
         rm -rf "$BUILD_DIR"

--- a/scripts/build_windows_installer.ps1
+++ b/scripts/build_windows_installer.ps1
@@ -50,6 +50,7 @@ $tempDir = New-Item -ItemType Directory -Path (Join-Path -Path ([IO.Path]::GetTe
 try {
     $repoRoot = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath '..')).Path
     Copy-Item -Path $payloadExecutable -Destination (Join-Path -Path $tempDir -ChildPath 'glyphctl.exe')
+    Copy-Item -Path (Join-Path -Path $repoRoot -ChildPath 'scripts/0xgenctl.cmd') -Destination (Join-Path -Path $tempDir -ChildPath '0xgenctl.cmd')
     Copy-Item -Path (Join-Path -Path $repoRoot -ChildPath 'README.md') -Destination (Join-Path -Path $tempDir -ChildPath 'README.txt')
     Copy-Item -Path (Join-Path -Path $repoRoot -ChildPath 'LICENSE') -Destination (Join-Path -Path $tempDir -ChildPath 'LICENSE.txt')
 

--- a/scripts/build_windows_installer.sh
+++ b/scripts/build_windows_installer.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 if [[ $# -ne 4 ]]; then
   cat >&2 <<'EOF'
 Usage: build_windows_installer.sh <tag> <arch> <payload_dir> <output_dir>
@@ -63,8 +65,9 @@ trap 'rm -rf "$stage"' EXIT
 mkdir -p "$output_dir"
 
 cp "$payload_dir/glyphctl.exe" "$stage/glyphctl.exe"
-cp README.md "$stage/README.txt"
-cp LICENSE "$stage/LICENSE.txt"
+cp "$ROOT_DIR/scripts/0xgenctl.cmd" "$stage/0xgenctl.cmd"
+cp "$ROOT_DIR/README.md" "$stage/README.txt"
+cp "$ROOT_DIR/LICENSE" "$stage/LICENSE.txt"
 
 wixl \
   -DVersion="$msi_version" \


### PR DESCRIPTION
## Summary
- add cross-platform 0xgenctl wrapper scripts that forward to glyphctl
- package the alias in release archives, Windows installer payloads, Scoop, and winget metadata so both command names remain available

## Testing
- go test ./...
- PATH="$(pwd):$PATH" ./scripts/0xgenctl --help >/tmp/0xgenctl_help.txt

------
https://chatgpt.com/codex/tasks/task_e_68ec3ae11cac832aa1037673d80b754d