### PR TITLE
Resolve glyphctl path in 0xgenctl shim

### DIFF
--- a/scripts/0xgenctl
+++ b/scripts/0xgenctl
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-exec glyphctl "$@"
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+exec "$SCRIPT_DIR/glyphctl" "$@"


### PR DESCRIPTION
## Summary
- resolve the glyphctl executable relative to the shim so it works when invoked from its directory

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ec422a2e40832aa0d9e9272508b57d