### PR TITLE
Add scan safety guardrails for hydro CLI

### DIFF
--- a/cmd/hydro/main.go
+++ b/cmd/hydro/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+var (
+	aggressive   = flag.Bool("aggressive", false, "scan aggressively, potentially impacting targets")
+	recursive    = flag.Bool("recursive", false, "scan recursively, potentially impacting targets")
+	confirmLegal = flag.Bool("confirm-legal", false, "confirm you have legal authorization for destructive scans")
+)
+
+const safetyBanner = `⚠️  LEGAL NOTICE ⚠️
+You are enabling scan options that may be destructive.
+Ensure you have explicit authorization to test these systems and
+understand all applicable laws, contracts, and policies before proceeding.`
+
+func main() {
+	flag.Parse()
+
+	destructiveFlags := activeDestructiveFlags(*aggressive, *recursive)
+	if err := maybeWarnDestructive(os.Stderr, *confirmLegal, destructiveFlags); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(2)
+	}
+
+	fmt.Printf("hydro scan starting (aggressive=%t, recursive=%t)\n", *aggressive, *recursive)
+}
+
+func activeDestructiveFlags(aggressiveEnabled, recursiveEnabled bool) []string {
+	var result []string
+	if aggressiveEnabled {
+		result = append(result, "--aggressive")
+	}
+	if recursiveEnabled {
+		result = append(result, "--recursive")
+	}
+	return result
+}
+
+func maybeWarnDestructive(w io.Writer, confirmed bool, destructiveFlags []string) error {
+	if len(destructiveFlags) == 0 {
+		return nil
+	}
+
+	fmt.Fprintln(w, safetyBanner)
+	fmt.Fprintf(w, "Destructive options enabled: %s\n", strings.Join(destructiveFlags, ", "))
+	fmt.Fprintln(w)
+
+	if confirmed {
+		return nil
+	}
+
+	return fmt.Errorf("refusing to continue without --confirm-legal when %s is set", joinDestructiveFlags(destructiveFlags))
+}
+
+func joinDestructiveFlags(flags []string) string {
+	switch len(flags) {
+	case 0:
+		return ""
+	case 1:
+		return flags[0]
+	default:
+		return strings.Join(flags[:len(flags)-1], ", ") + " and " + flags[len(flags)-1]
+	}
+}

--- a/cmd/hydro/main_test.go
+++ b/cmd/hydro/main_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestActiveDestructiveFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		aggressive bool
+		recursive  bool
+		want       []string
+	}{
+		{name: "none", want: nil},
+		{name: "aggressive", aggressive: true, want: []string{"--aggressive"}},
+		{name: "recursive", recursive: true, want: []string{"--recursive"}},
+		{name: "both", aggressive: true, recursive: true, want: []string{"--aggressive", "--recursive"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := activeDestructiveFlags(tt.aggressive, tt.recursive)
+			if len(got) != len(tt.want) {
+				t.Fatalf("expected %d flags, got %d (%v)", len(tt.want), len(got), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("expected flag %q at index %d, got %q", tt.want[i], i, got[i])
+				}
+			}
+		})
+	}
+}
+
+func TestMaybeWarnDestructive_NoFlags(t *testing.T) {
+	var buf bytes.Buffer
+	if err := maybeWarnDestructive(&buf, false, nil); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output, got %q", buf.String())
+	}
+}
+
+func TestMaybeWarnDestructive_RequiresConfirmation(t *testing.T) {
+	var buf bytes.Buffer
+	err := maybeWarnDestructive(&buf, false, []string{"--aggressive", "--recursive"})
+	if err == nil {
+		t.Fatal("expected error when confirmation missing")
+	}
+	if !strings.Contains(err.Error(), "--aggressive and --recursive") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+	if out := buf.String(); !strings.Contains(out, "LEGAL NOTICE") || !strings.Contains(out, "Destructive options enabled") {
+		t.Fatalf("banner not printed, output: %q", out)
+	}
+}
+
+func TestMaybeWarnDestructive_WithConfirmation(t *testing.T) {
+	var buf bytes.Buffer
+	err := maybeWarnDestructive(&buf, true, []string{"--aggressive"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "LEGAL NOTICE") {
+		t.Fatalf("expected legal notice banner, got %q", out)
+	}
+}
+
+func TestJoinDestructiveFlags(t *testing.T) {
+	tests := []struct {
+		flags []string
+		want  string
+	}{
+		{nil, ""},
+		{[]string{"--aggressive"}, "--aggressive"},
+		{[]string{"--aggressive", "--recursive"}, "--aggressive and --recursive"},
+		{[]string{"one", "two", "three"}, "one, two and three"},
+	}
+
+	for _, tt := range tests {
+		if got := joinDestructiveFlags(tt.flags); got != tt.want {
+			t.Errorf("joinDestructiveFlags(%v) = %q, want %q", tt.flags, got, tt.want)
+		}
+	}
+}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,9 @@
+# Hydro Quickstart
+
+When running `hydro` with potentially destructive scan options you must explicitly acknowledge that you have permission to do so.
+
+```bash
+hydro --aggressive --confirm-legal
+```
+
+Both the `--aggressive` and `--recursive` flags display a legal reminder banner before execution. If you forget to include the `--confirm-legal` acknowledgement, hydro exits immediately with a non-zero status to keep you safe and compliant.


### PR DESCRIPTION
## Summary
- print the hydro legal banner and block execution through a reusable safety guard when destructive flags are active
- cover the new helper logic with unit tests for destructive flag detection and legal confirmation handling
- document the `--confirm-legal` acknowledgement in the hydro quickstart guide

## Testing
- go mod download
- go test ./cmd/hydro
- go build ./cmd/hydro


------
https://chatgpt.com/codex/tasks/task_e_68ed501cd204832aad6101da23d11719