### PR TITLE
Support 0XGEN environment variables

### DIFF
--- a/cmd/glyphctl/plugin_run.go
+++ b/cmd/glyphctl/plugin_run.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/RowanDark/0xgen/internal/env"
 	"github.com/RowanDark/0xgen/internal/plugins"
 	"github.com/RowanDark/0xgen/internal/plugins/integrity"
 	"github.com/RowanDark/0xgen/internal/plugins/runner"
@@ -102,18 +103,25 @@ func runPluginRun(args []string) int {
 	if limits.WallTime <= 0 {
 		limits.WallTime = 5 * time.Second
 	}
-	env := map[string]string{}
-	if val := os.Getenv("GLYPH_OUT"); strings.TrimSpace(val) != "" {
-		env["GLYPH_OUT"] = val
+	envVars := map[string]string{}
+	if val, ok := env.Lookup("0XGEN_OUT", "GLYPH_OUT"); ok {
+		if trimmed := strings.TrimSpace(val); trimmed != "" {
+			envVars["0XGEN_OUT"] = trimmed
+			envVars["GLYPH_OUT"] = trimmed
+		}
 	}
-	if val := os.Getenv("GLYPH_E2E_SMOKE"); strings.TrimSpace(val) != "" {
-		env["GLYPH_E2E_SMOKE"] = val
+	if val, ok := env.Lookup("0XGEN_E2E_SMOKE", "GLYPH_E2E_SMOKE"); ok {
+		if trimmed := strings.TrimSpace(val); trimmed != "" {
+			envVars["0XGEN_E2E_SMOKE"] = trimmed
+			envVars["GLYPH_E2E_SMOKE"] = trimmed
+		}
 	}
-	env["GLYPH_CAPABILITY_TOKEN"] = capToken
+	envVars["0XGEN_CAPABILITY_TOKEN"] = capToken
+	envVars["GLYPH_CAPABILITY_TOKEN"] = capToken
 	config := runner.Config{
 		Binary: binaryPath,
 		Args:   []string{"--server", *server, "--token", *token},
-		Env:    env,
+		Env:    envVars,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
 		Limits: limits,

--- a/cmd/glyphctl/replay.go
+++ b/cmd/glyphctl/replay.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/RowanDark/0xgen/internal/cases"
+	"github.com/RowanDark/0xgen/internal/env"
 	"github.com/RowanDark/0xgen/internal/replay"
 	"github.com/RowanDark/0xgen/internal/reporter"
 )
@@ -39,9 +40,12 @@ func runReplay(args []string) int {
 
 	dest := strings.TrimSpace(*outDir)
 	if dest == "" {
-		if env := strings.TrimSpace(os.Getenv("GLYPH_OUT")); env != "" {
-			dest = filepath.Join(env, "replay")
-		} else {
+		if val, ok := env.Lookup("0XGEN_OUT", "GLYPH_OUT"); ok {
+			if trimmed := strings.TrimSpace(val); trimmed != "" {
+				dest = filepath.Join(trimmed, "replay")
+			}
+		}
+		if dest == "" {
 			cwd, err := os.Getwd()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "determine working directory: %v\n", err)

--- a/cmd/glyphctl/self_update.go
+++ b/cmd/glyphctl/self_update.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/RowanDark/0xgen/internal/env"
 	"github.com/RowanDark/0xgen/internal/updater"
 )
 
@@ -56,7 +57,10 @@ func runSelfUpdate(args []string) int {
 		persist = false
 	}
 
-	baseURL := strings.TrimSpace(os.Getenv("GLYPH_UPDATER_BASE_URL"))
+	baseURL := ""
+	if val, ok := env.Lookup("0XGEN_UPDATER_BASE_URL", "GLYPH_UPDATER_BASE_URL"); ok {
+		baseURL = strings.TrimSpace(val)
+	}
 	client := &updater.Client{
 		Store:          store,
 		BaseURL:        baseURL,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/RowanDark/0xgen/internal/env"
 )
 
 // Config captures the Glyph configuration resolved from defaults, optional files,
@@ -53,7 +55,9 @@ func Default() Config {
 //  2. ~/.0xgen/config.toml (TOML)
 //  3. ~/.glyph/config.toml (TOML, legacy)
 //
-// Environment variables prefixed with GLYPH_ have the highest precedence.
+// Environment variables prefixed with 0XGEN_ have the highest precedence.
+// Legacy GLYPH_ variables remain supported for one release and emit a warning
+// when used.
 func Load() (Config, error) {
 	cfg := Default()
 
@@ -189,39 +193,59 @@ func applyFileConfig(cfg *Config, data []byte, format string) error {
 }
 
 func applyEnvOverrides(cfg *Config) {
-	if val := strings.TrimSpace(os.Getenv("GLYPH_SERVER")); val != "" {
-		cfg.ServerAddr = val
-	}
-	if val := strings.TrimSpace(os.Getenv("GLYPH_AUTH_TOKEN")); val != "" {
-		cfg.AuthToken = val
-	}
-	if val := strings.TrimSpace(os.Getenv("GLYPH_OUT")); val != "" {
-		cfg.OutputDir = val
-	}
-	if val := strings.TrimSpace(os.Getenv("GLYPH_PROXY_ENABLE")); val != "" {
-		if parsed, err := strconv.ParseBool(val); err == nil {
-			cfg.Proxy.Enable = parsed
+	if val, ok := env.Lookup("0XGEN_SERVER", "GLYPH_SERVER"); ok {
+		if trimmed := strings.TrimSpace(val); trimmed != "" {
+			cfg.ServerAddr = trimmed
 		}
 	}
-	if val := strings.TrimSpace(os.Getenv("GLYPH_ENABLE_PROXY")); val != "" {
-		if parsed, err := strconv.ParseBool(val); err == nil {
-			cfg.Proxy.Enable = parsed
+	if val, ok := env.Lookup("0XGEN_AUTH_TOKEN", "GLYPH_AUTH_TOKEN"); ok {
+		if trimmed := strings.TrimSpace(val); trimmed != "" {
+			cfg.AuthToken = trimmed
 		}
 	}
-	if val := strings.TrimSpace(os.Getenv("GLYPH_PROXY_ADDR")); val != "" {
-		cfg.Proxy.Addr = val
+	if val, ok := env.Lookup("0XGEN_OUT", "GLYPH_OUT"); ok {
+		if trimmed := strings.TrimSpace(val); trimmed != "" {
+			cfg.OutputDir = trimmed
+		}
 	}
-	if val := strings.TrimSpace(os.Getenv("GLYPH_PROXY_RULES")); val != "" {
-		cfg.Proxy.RulesPath = val
+	if val, ok := env.Lookup("0XGEN_PROXY_ENABLE", "GLYPH_PROXY_ENABLE"); ok {
+		if trimmed := strings.TrimSpace(val); trimmed != "" {
+			if parsed, err := strconv.ParseBool(trimmed); err == nil {
+				cfg.Proxy.Enable = parsed
+			}
+		}
 	}
-	if val := strings.TrimSpace(os.Getenv("GLYPH_PROXY_HISTORY")); val != "" {
-		cfg.Proxy.HistoryPath = val
+	if val, ok := env.Lookup("0XGEN_ENABLE_PROXY", "GLYPH_ENABLE_PROXY"); ok {
+		if trimmed := strings.TrimSpace(val); trimmed != "" {
+			if parsed, err := strconv.ParseBool(trimmed); err == nil {
+				cfg.Proxy.Enable = parsed
+			}
+		}
 	}
-	if val := strings.TrimSpace(os.Getenv("GLYPH_PROXY_CA_CERT")); val != "" {
-		cfg.Proxy.CACertPath = val
+	if val, ok := env.Lookup("0XGEN_PROXY_ADDR", "GLYPH_PROXY_ADDR"); ok {
+		if trimmed := strings.TrimSpace(val); trimmed != "" {
+			cfg.Proxy.Addr = trimmed
+		}
 	}
-	if val := strings.TrimSpace(os.Getenv("GLYPH_PROXY_CA_KEY")); val != "" {
-		cfg.Proxy.CAKeyPath = val
+	if val, ok := env.Lookup("0XGEN_PROXY_RULES", "GLYPH_PROXY_RULES"); ok {
+		if trimmed := strings.TrimSpace(val); trimmed != "" {
+			cfg.Proxy.RulesPath = trimmed
+		}
+	}
+	if val, ok := env.Lookup("0XGEN_PROXY_HISTORY", "GLYPH_PROXY_HISTORY"); ok {
+		if trimmed := strings.TrimSpace(val); trimmed != "" {
+			cfg.Proxy.HistoryPath = trimmed
+		}
+	}
+	if val, ok := env.Lookup("0XGEN_PROXY_CA_CERT", "GLYPH_PROXY_CA_CERT"); ok {
+		if trimmed := strings.TrimSpace(val); trimmed != "" {
+			cfg.Proxy.CACertPath = trimmed
+		}
+	}
+	if val, ok := env.Lookup("0XGEN_PROXY_CA_KEY", "GLYPH_PROXY_CA_KEY"); ok {
+		if trimmed := strings.TrimSpace(val); trimmed != "" {
+			cfg.Proxy.CAKeyPath = trimmed
+		}
 	}
 }
 

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,0 +1,59 @@
+package env
+
+import (
+	"log"
+	"os"
+	"sync"
+)
+
+var (
+	warnLogger func(format string, args ...any) = log.Printf
+	warnMu     sync.Mutex
+	warnedKeys sync.Map
+)
+
+// Lookup returns the value of newKey if it exists. When the legacy oldKey is
+// present it is returned instead and a deprecation warning is logged once.
+func Lookup(newKey, oldKey string) (string, bool) {
+	if v, ok := os.LookupEnv(newKey); ok {
+		return v, true
+	}
+	if v, ok := os.LookupEnv(oldKey); ok {
+		logDeprecated(oldKey, newKey)
+		return v, true
+	}
+	return "", false
+}
+
+func logDeprecated(oldKey, newKey string) {
+	onceIface, _ := warnedKeys.LoadOrStore(oldKey, &sync.Once{})
+	once := onceIface.(*sync.Once)
+	once.Do(func() {
+		warnMu.Lock()
+		logger := warnLogger
+		warnMu.Unlock()
+		logger("%s is deprecated; use %s", oldKey, newKey)
+	})
+}
+
+// ResetWarningsForTesting clears the cached once guards so tests can verify
+// warning behaviour deterministically.
+func ResetWarningsForTesting() {
+	warnMu.Lock()
+	warnedKeys = sync.Map{}
+	warnMu.Unlock()
+}
+
+// SetWarnLoggerForTesting swaps the logger used for warnings. The returned
+// function restores the previous logger and should be deferred in tests.
+func SetWarnLoggerForTesting(fn func(format string, args ...any)) (restore func()) {
+	warnMu.Lock()
+	previous := warnLogger
+	warnLogger = fn
+	warnMu.Unlock()
+	return func() {
+		warnMu.Lock()
+		warnLogger = previous
+		warnMu.Unlock()
+	}
+}

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,0 +1,66 @@
+package env
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestLookupPrefersNewKey(t *testing.T) {
+	ResetWarningsForTesting()
+	restore := SetWarnLoggerForTesting(func(string, ...any) {})
+	defer restore()
+
+	t.Setenv("0XGEN_HOME", "/modern")
+	t.Setenv("GLYPH_HOME", "/legacy")
+
+	val, ok := Lookup("0XGEN_HOME", "GLYPH_HOME")
+	if !ok {
+		t.Fatalf("expected lookup to succeed")
+	}
+	if val != "/modern" {
+		t.Fatalf("expected new key to win, got %s", val)
+	}
+}
+
+func TestLookupWarnsOnLegacyKeyOnce(t *testing.T) {
+	ResetWarningsForTesting()
+
+	var buf bytes.Buffer
+	restore := SetWarnLoggerForTesting(func(format string, args ...any) {
+		buf.WriteString(strings.TrimSpace(fmt.Sprintf(format, args...)))
+	})
+	defer restore()
+
+	t.Setenv("GLYPH_HOME", "/legacy")
+
+	if _, ok := Lookup("0XGEN_HOME", "GLYPH_HOME"); !ok {
+		t.Fatalf("expected lookup to succeed")
+	}
+	if _, ok := Lookup("0XGEN_HOME", "GLYPH_HOME"); !ok {
+		t.Fatalf("expected second lookup to succeed")
+	}
+
+	output := buf.String()
+	if output != "GLYPH_HOME is deprecated; use 0XGEN_HOME" {
+		t.Fatalf("unexpected warning format: %q", output)
+	}
+}
+
+func TestLookupReturnsLegacyValue(t *testing.T) {
+	ResetWarningsForTesting()
+	restore := SetWarnLoggerForTesting(func(string, ...any) {})
+	defer restore()
+
+	want := "/legacy"
+	t.Setenv("GLYPH_OUT", want)
+
+	got, ok := Lookup("0XGEN_OUT", "GLYPH_OUT")
+	if !ok {
+		t.Fatalf("expected lookup to succeed")
+	}
+	if got != want {
+		t.Fatalf("expected %s, got %s", want, got)
+	}
+}

--- a/internal/exporter/config.go
+++ b/internal/exporter/config.go
@@ -1,9 +1,10 @@
 package exporter
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/RowanDark/0xgen/internal/env"
 )
 
 const (
@@ -35,9 +36,11 @@ var (
 )
 
 func init() {
-	base := strings.TrimSpace(os.Getenv("GLYPH_OUT"))
-	if base == "" {
-		base = defaultOutputDir
+	base := defaultOutputDir
+	if val, ok := env.Lookup("0XGEN_OUT", "GLYPH_OUT"); ok {
+		if trimmed := strings.TrimSpace(val); trimmed != "" {
+			base = trimmed
+		}
 	}
 
 	DefaultSARIFPath = filepath.Join(base, sarifFilename)

--- a/internal/findings/writer.go
+++ b/internal/findings/writer.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/RowanDark/0xgen/internal/env"
 )
 
 const (
@@ -23,8 +25,10 @@ const (
 var DefaultFindingsPath = filepath.Join(defaultOutputDir, defaultFilename)
 
 func init() {
-	if custom := strings.TrimSpace(os.Getenv("GLYPH_OUT")); custom != "" {
-		DefaultFindingsPath = filepath.Join(custom, defaultFilename)
+	if val, ok := env.Lookup("0XGEN_OUT", "GLYPH_OUT"); ok {
+		if custom := strings.TrimSpace(val); custom != "" {
+			DefaultFindingsPath = filepath.Join(custom, defaultFilename)
+		}
 	}
 }
 
@@ -80,10 +84,12 @@ func (w *Writer) Path() string {
 // NewWriter constructs a writer targeting the provided path.
 func NewWriter(path string, opts ...WriterOption) *Writer {
 	if strings.TrimSpace(path) == "" {
-		custom := strings.TrimSpace(os.Getenv("GLYPH_OUT"))
-		if custom != "" {
-			path = filepath.Join(custom, defaultFilename)
-		} else {
+		if val, ok := env.Lookup("0XGEN_OUT", "GLYPH_OUT"); ok {
+			if custom := strings.TrimSpace(val); custom != "" {
+				path = filepath.Join(custom, defaultFilename)
+			}
+		}
+		if strings.TrimSpace(path) == "" {
 			path = DefaultFindingsPath
 		}
 	}
@@ -229,5 +235,8 @@ func (w *Writer) rotateIfNeeded(next int64) error {
 }
 
 func syncWritesEnabled() bool {
-	return os.Getenv("GLYPH_SYNC_WRITES") == "1"
+	if val, ok := env.Lookup("0XGEN_SYNC_WRITES", "GLYPH_SYNC_WRITES"); ok {
+		return strings.TrimSpace(val) == "1"
+	}
+	return false
 }

--- a/internal/history/search.go
+++ b/internal/history/search.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/RowanDark/0xgen/internal/env"
 	"github.com/RowanDark/0xgen/internal/proxy"
 )
 
@@ -41,9 +42,11 @@ type Index struct {
 
 // DefaultPath returns the default location of the proxy history log, honouring GLYPH_OUT.
 func DefaultPath() string {
-	dir := strings.TrimSpace(os.Getenv("GLYPH_OUT"))
-	if dir == "" {
-		dir = "/out"
+	dir := "/out"
+	if val, ok := env.Lookup("0XGEN_OUT", "GLYPH_OUT"); ok {
+		if trimmed := strings.TrimSpace(val); trimmed != "" {
+			dir = trimmed
+		}
 	}
 	return filepath.Join(dir, defaultHistoryFilename)
 }

--- a/internal/netgate/gate.go
+++ b/internal/netgate/gate.go
@@ -12,12 +12,12 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/RowanDark/0xgen/internal/env"
 	"github.com/RowanDark/0xgen/internal/logging"
 	"github.com/RowanDark/0xgen/internal/netgate/fingerprint"
 	obsmetrics "github.com/RowanDark/0xgen/internal/observability/metrics"
@@ -28,8 +28,10 @@ const (
 	capHTTPActive  = "CAP_HTTP_ACTIVE"
 	capHTTPPassive = "CAP_HTTP_PASSIVE"
 
-	envTimeout = "GLYPH_NET_TIMEOUT"
-	envBudget  = "GLYPH_NET_BUDGET"
+	envTimeout    = "GLYPH_NET_TIMEOUT"
+	envBudget     = "GLYPH_NET_BUDGET"
+	envTimeoutNew = "0XGEN_NET_TIMEOUT"
+	envBudgetNew  = "0XGEN_NET_BUDGET"
 
 	defaultTimeout = 5 * time.Second
 	defaultBudget  = 50
@@ -236,14 +238,18 @@ func WithAuditLogger(logger *logging.AuditLogger) Option {
 
 func loadConfigFromEnv() Config {
 	cfg := Config{Timeout: defaultTimeout, RequestBudget: defaultBudget, Retry: defaultRetryConfig()}
-	if raw := strings.TrimSpace(os.Getenv(envTimeout)); raw != "" {
-		if dur, err := time.ParseDuration(raw); err == nil {
-			cfg.Timeout = dur
+	if raw, ok := env.Lookup(envTimeoutNew, envTimeout); ok {
+		if trimmed := strings.TrimSpace(raw); trimmed != "" {
+			if dur, err := time.ParseDuration(trimmed); err == nil {
+				cfg.Timeout = dur
+			}
 		}
 	}
-	if raw := strings.TrimSpace(os.Getenv(envBudget)); raw != "" {
-		if v, err := strconv.Atoi(raw); err == nil {
-			cfg.RequestBudget = v
+	if raw, ok := env.Lookup(envBudgetNew, envBudget); ok {
+		if trimmed := strings.TrimSpace(raw); trimmed != "" {
+			if v, err := strconv.Atoi(trimmed); err == nil {
+				cfg.RequestBudget = v
+			}
 		}
 	}
 	return cfg

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -26,6 +26,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/RowanDark/0xgen/internal/env"
 	"github.com/RowanDark/0xgen/internal/flows"
 	obsmetrics "github.com/RowanDark/0xgen/internal/observability/metrics"
 	"github.com/RowanDark/0xgen/internal/observability/tracing"
@@ -231,8 +232,10 @@ func defaultTransport() http.RoundTripper {
 }
 
 func defaultOutputDir() string {
-	if custom := strings.TrimSpace(os.Getenv("GLYPH_OUT")); custom != "" {
-		return custom
+	if val, ok := env.Lookup("0XGEN_OUT", "GLYPH_OUT"); ok {
+		if custom := strings.TrimSpace(val); custom != "" {
+			return custom
+		}
 	}
 	return "/out"
 }

--- a/internal/ranker/ranker.go
+++ b/internal/ranker/ranker.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/RowanDark/0xgen/internal/env"
 	"github.com/RowanDark/0xgen/internal/findings"
 )
 
@@ -38,8 +39,10 @@ const (
 var DefaultOutputPath = filepath.Join(defaultOutputDir, rankedFilename)
 
 func init() {
-	if custom := strings.TrimSpace(os.Getenv("GLYPH_OUT")); custom != "" {
-		DefaultOutputPath = filepath.Join(custom, rankedFilename)
+	if val, ok := env.Lookup("0XGEN_OUT", "GLYPH_OUT"); ok {
+		if custom := strings.TrimSpace(val); custom != "" {
+			DefaultOutputPath = filepath.Join(custom, rankedFilename)
+		}
 	}
 }
 

--- a/internal/reporter/md.go
+++ b/internal/reporter/md.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/RowanDark/0xgen/internal/env"
 	"github.com/RowanDark/0xgen/internal/findings"
 )
 
@@ -30,9 +31,11 @@ var (
 )
 
 func init() {
-	if custom := strings.TrimSpace(os.Getenv("GLYPH_OUT")); custom != "" {
-		DefaultFindingsPath = filepath.Join(custom, findingsFilename)
-		DefaultReportPath = filepath.Join(custom, reportFilename)
+	if val, ok := env.Lookup("0XGEN_OUT", "GLYPH_OUT"); ok {
+		if custom := strings.TrimSpace(val); custom != "" {
+			DefaultFindingsPath = filepath.Join(custom, findingsFilename)
+			DefaultReportPath = filepath.Join(custom, reportFilename)
+		}
 	}
 }
 

--- a/internal/updater/config.go
+++ b/internal/updater/config.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/RowanDark/0xgen/internal/env"
 )
 
 const (
@@ -50,8 +52,10 @@ type Store struct {
 func DefaultConfigDir() (string, error) {
 	// Honour GLYPH_UPDATER_CONFIG_DIR if present so tests can override the
 	// location without polluting the real user config.
-	if override := strings.TrimSpace(os.Getenv("GLYPH_UPDATER_CONFIG_DIR")); override != "" {
-		return override, nil
+	if override, ok := env.Lookup("0XGEN_UPDATER_CONFIG_DIR", "GLYPH_UPDATER_CONFIG_DIR"); ok {
+		if trimmed := strings.TrimSpace(override); trimmed != "" {
+			return trimmed, nil
+		}
 	}
 	dir, err := os.UserConfigDir()
 	if err != nil {


### PR DESCRIPTION
## Summary
- add an internal env helper that prefers 0XGEN_* variables and warns once when using GLYPH_ fallbacks
- update glyphctl, glyphd, and related packages to read 0XGEN_* vars while still honouring legacy names
- extend tests to cover new environment precedence and deprecation warnings

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ef8df2c820832a85350ed9e8efecf0