### PR TITLE
proxy: emit X-0xgen headers with legacy support

### DIFF
--- a/cmd/glyphd/main.go
+++ b/cmd/glyphd/main.go
@@ -62,6 +62,7 @@ func main() {
 	maxBodyKB := flag.Int("max-body-kb", 128, "maximum raw body kilobytes to include in flow events (-1 disables raw bodies)")
 	proxyFlowSeed := flag.Int64("proxy-flow-seed", 0, "seed used to deterministically order flow identifiers (default random)")
 	proxyFlowLog := flag.String("proxy-flow-log", "", "path to write sanitized flow transcripts for replay (defaults next to proxy history)")
+	proxyEmitLegacy := flag.Bool("proxy-emit-legacy-headers", false, "emit deprecated X-Glyph-* headers alongside X-0xgen-* responses")
 	scopePolicy := flag.String("scope-policy", "", "path to YAML scope policy used to suppress out-of-scope flows")
 	fingerprintRotate := flag.Bool("fingerprint-rotate", false, "enable rotating JA3/JA4 fingerprints per host")
 	pluginDir := flag.String("plugins-dir", "plugins", "path to plugin directory")
@@ -109,11 +110,12 @@ func main() {
 			CACertPath:  *proxyCACert,
 			CAKeyPath:   *proxyCAKey,
 			Flow: proxy.FlowCaptureConfig{
-				Enabled:      *proxyFlowEnabled,
-				SampleRate:   sampleRate,
-				MaxBodyBytes: maxBodyBytes,
-				Seed:         *proxyFlowSeed,
-				LogPath:      strings.TrimSpace(*proxyFlowLog),
+				Enabled:           *proxyFlowEnabled,
+				SampleRate:        sampleRate,
+				MaxBodyBytes:      maxBodyBytes,
+				Seed:              *proxyFlowSeed,
+				LogPath:           strings.TrimSpace(*proxyFlowLog),
+				EmitLegacyHeaders: *proxyEmitLegacy,
 			},
 		},
 		enableProxy:       *enableProxy,

--- a/internal/e2e/galdr_h2_ws_test.go
+++ b/internal/e2e/galdr_h2_ws_test.go
@@ -44,7 +44,7 @@ func TestGaldrProxyHTTP2HeaderRewrite(t *testing.T) {
 	pool := x509PoolFromCert(cert)
 
 	tempDir := t.TempDir()
-	rulesPath := writeTempFile(t, tempDir, "rules.json", `[{"name":"h2-rewrite","match":{"url_contains":"/"},"response":{"add_headers":{"X-Glyph":"on"},"remove_headers":["Server"]}}]`)
+	rulesPath := writeTempFile(t, tempDir, "rules.json", `[{"name":"h2-rewrite","match":{"url_contains":"/"},"response":{"add_headers":{"X-0xgen":"on"},"remove_headers":["Server"]}}]`)
 
 	cfg := proxy.Config{
 		Addr:        "127.0.0.1:0",
@@ -101,8 +101,11 @@ func TestGaldrProxyHTTP2HeaderRewrite(t *testing.T) {
 	defer resp.Body.Close()
 	_, _ = io.ReadAll(resp.Body)
 
-	if resp.Header.Get("X-Glyph") != "on" {
-		t.Fatalf("expected rewritten header, got %q", resp.Header.Get("X-Glyph"))
+	if resp.Header.Get("X-0xgen") != "on" {
+		t.Fatalf("expected rewritten header, got %q", resp.Header.Get("X-0xgen"))
+	}
+	if legacy := resp.Header.Get("X-Glyph"); legacy != "" {
+		t.Fatalf("expected legacy header to be absent, got %q", legacy)
 	}
 	if resp.Header.Get("Server") != "" {
 		t.Fatalf("expected server header stripped, got %q", resp.Header.Get("Server"))

--- a/internal/e2e/galdr_proxy_test.go
+++ b/internal/e2e/galdr_proxy_test.go
@@ -41,7 +41,7 @@ func TestGaldrProxyHeaderRewriteAndHistory(t *testing.T) {
 	caCertPath := filepath.Join(tempDir, "proxy_ca.pem")
 	caKeyPath := filepath.Join(tempDir, "proxy_ca.key")
 
-	rules := `[{"name":"rewrite","match":{"url_contains":"/"},"response":{"add_headers":{"X-Glyph":"on"},"remove_headers":["Server"]}}]`
+	rules := `[{"name":"rewrite","match":{"url_contains":"/"},"response":{"add_headers":{"X-0xgen":"on"},"remove_headers":["Server"]}}]`
 	if err := os.WriteFile(rulesPath, []byte(rules), 0o644); err != nil {
 		t.Fatalf("write rules: %v", err)
 	}
@@ -113,8 +113,11 @@ func TestGaldrProxyHeaderRewriteAndHistory(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
-	if got := resp.Header.Get("X-Glyph"); got != "on" {
-		t.Fatalf("expected X-Glyph header, got %q\nbody: %s", got, string(body))
+	if got := resp.Header.Get("X-0xgen"); got != "on" {
+		t.Fatalf("expected X-0xgen header, got %q\nbody: %s", got, string(body))
+	}
+	if legacy := resp.Header.Get("X-Glyph"); legacy != "" {
+		t.Fatalf("expected legacy header to be absent, got %q", legacy)
 	}
 	if got := resp.Header.Get("Server"); got != "" {
 		t.Fatalf("expected Server header stripped, got %q", got)
@@ -154,8 +157,11 @@ func TestGaldrProxyHeaderRewriteAndHistory(t *testing.T) {
 	if entry.Timestamp.IsZero() {
 		t.Fatalf("history timestamp missing: %+v", entry)
 	}
-	if headers := entry.ResponseHeaders["X-Glyph"]; len(headers) == 0 || headers[0] != "on" {
+	if headers := entry.ResponseHeaders["X-0xgen"]; len(headers) == 0 || headers[0] != "on" {
 		t.Fatalf("history missing rewritten header: %+v", entry.ResponseHeaders)
+	}
+	if _, exists := entry.ResponseHeaders["X-Glyph"]; exists {
+		t.Fatalf("history should not record legacy header: %+v", entry.ResponseHeaders)
 	}
 	if _, exists := entry.ResponseHeaders["Server"]; exists {
 		t.Fatalf("history should not record stripped server header: %+v", entry.ResponseHeaders)

--- a/internal/updater/manifest.go
+++ b/internal/updater/manifest.go
@@ -156,7 +156,7 @@ func download(ctx context.Context, client *http.Client, targetURL, channel strin
 	}
 	req.Header.Set("User-Agent", fmt.Sprintf("glyphctl/%s (%s/%s)", runtime.Version(), runtime.GOOS, runtime.GOARCH))
 	if channel != "" {
-		req.Header.Set("X-Glyph-Update-Channel", channel)
+		req.Header.Set("X-0xgen-Update-Channel", channel)
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/plugins/galdr-proxy/README.md
+++ b/plugins/galdr-proxy/README.md
@@ -27,7 +27,7 @@ Key files are written beneath `/out` by default:
 | CA private key | `/out/galdr_proxy_ca.key` | Used to mint leaf certificates for intercepted hosts |
 | History log | `/out/proxy_history.jsonl` | JSONL file containing every intercepted request/response |
 
-Use `--proxy-addr`, `--proxy-rules`, `--proxy-history`, `--proxy-ca-cert`, and `--proxy-ca-key` to override the defaults. For a quick-start ruleset, copy `examples/rules.example.json` into your output directory and point `--proxy-rules` at the copied file. The example injects an `X-Glyph: on` response header, strips the upstream `Server` banner, and rewrites the content-security policy so you can immediately verify changes in a browser.
+Use `--proxy-addr`, `--proxy-rules`, `--proxy-history`, `--proxy-ca-cert`, and `--proxy-ca-key` to override the defaults. For a quick-start ruleset, copy `examples/rules.example.json` into your output directory and point `--proxy-rules` at the copied file. The example injects an `X-0xgen: on` response header, strips the upstream `Server` banner, and rewrites the content-security policy so you can immediately verify changes in a browser.
 
 ### Install the Galdr CA
 
@@ -107,7 +107,7 @@ glyphctl repeater send \
 Example entry:
 
 ```json
-{"timestamp":"2024-01-01T12:00:00Z","client_ip":"127.0.0.1","protocol":"http","method":"GET","url":"https://example.com/demo","status_code":200,"latency_ms":42,"request_size_bytes":128,"response_size_bytes":512,"request_headers":{"X-Glyph":["on"]},"response_headers":{"X-Glyph-Proxy":["active"]},"matched_rules":["demo-rule"]}
+{"timestamp":"2024-01-01T12:00:00Z","client_ip":"127.0.0.1","protocol":"http","method":"GET","url":"https://example.com/demo","status_code":200,"latency_ms":42,"request_size_bytes":128,"response_size_bytes":512,"request_headers":{"X-0xgen":["on"]},"response_headers":{"X-0xgen-Proxy":["active"]},"matched_rules":["demo-rule"]}
 ```
 
 ### WebSocket traffic

--- a/plugins/galdr-proxy/examples/rules.example.json
+++ b/plugins/galdr-proxy/examples/rules.example.json
@@ -4,7 +4,7 @@
     "match": {"url_contains": "/"},
     "response": {
       "add_headers": {
-        "X-Glyph": "on",
+        "X-0xgen": "on",
         "Content-Security-Policy": "default-src 'self'; script-src 'self' https://glyph.dev"
       },
       "remove_headers": ["Server"]


### PR DESCRIPTION
## Summary
- rename Galdr proxy headers to the X-0xgen- prefix and keep history/sanitized streams in sync
- accept legacy X-Glyph-* names, warn when encountered, and add a flag to emit both families during transition
- update end-to-end tests, examples, and updater headers to exercise the new defaults

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68efa500794c832a8a32c6f3e57f4d22