### PR TITLE
Rebrand HTML report outputs to 0xgen

### DIFF
--- a/examples/quickstart/report.html
+++ b/examples/quickstart/report.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Glyph Findings Report</title>
+  <title>0xgen Findings Report</title>
   <style>:root {
  color-scheme: light dark;
  --bg-color: #f8fafc;
@@ -324,7 +324,7 @@ pre {
 <body>
   <header class="header">
     <div>
-      <h1>Glyph Findings Report</h1>
+      <h1>0xgen Findings Report</h1>
       <p class="meta">Generated at 2025-10-02T00:42:12Z (UTC)</p>
       <p class="meta">Reporting window: All findings through 2025-10-02T00:42:12Z (UTC)</p>
       <p class="meta">Total findings: 7</p>

--- a/internal/reporter/html.go
+++ b/internal/reporter/html.go
@@ -397,11 +397,17 @@ const htmlAppScript = `(function () {
     filteredCases: [],
   };
 
+  const aliasMap = [
+    ["oxg-style", "glyph-style"],
+    ["oxg-data", "glyph-data"],
+    ["oxg-app", "glyph-app"],
+  ];
+
   document.addEventListener("DOMContentLoaded", init);
 
   async function init() {
     await verifyIntegrity();
-    const dataElement = document.getElementById("glyph-data");
+    const dataElement = getElementByIds("oxg-data", "glyph-data");
     if (!dataElement) {
       console.error("dataset element missing");
       return;
@@ -425,9 +431,8 @@ const htmlAppScript = `(function () {
     if (!window.crypto || !window.crypto.subtle) {
       return;
     }
-    const elements = ["glyph-style", "glyph-data", "glyph-app"];
-    for (const id of elements) {
-      const el = document.getElementById(id);
+    for (const ids of aliasMap) {
+      const el = getElementByIds(...ids);
       if (!el) {
         continue;
       }
@@ -444,16 +449,26 @@ const htmlAppScript = `(function () {
       if (actual !== expected) {
         console.error(
           "integrity mismatch for " +
-            id +
+            (el.id || ids[0]) +
             ": expected " +
             expected +
             ", got " +
             actual,
         );
-        showIntegrityWarning(id);
+        showIntegrityWarning(el.id || ids[0]);
         break;
       }
     }
+  }
+
+  function getElementByIds(...ids) {
+    for (const id of ids) {
+      const el = document.getElementById(id);
+      if (el) {
+        return el;
+      }
+    }
+    return null;
   }
 
   function showIntegrityWarning(source) {
@@ -914,17 +929,17 @@ func RenderHTML(list []findings.Finding, opts ReportOptions) (string, error) {
 
 	var b strings.Builder
 	b.WriteString("<!doctype html>\n")
-	b.WriteString("<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n<title>Glyph Findings Report</title>\n")
-	b.WriteString(fmt.Sprintf("<style id=\"glyph-style\" data-integrity=\"sha256-%s\">\n%s\n</style>\n", styleDigest, htmlStyles))
+	b.WriteString("<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n<title>0xgen Findings Report</title>\n")
+	b.WriteString(fmt.Sprintf("<style id=\"oxg-style\" data-integrity=\"sha256-%s\">\n%s\n</style>\n", styleDigest, htmlStyles))
 	b.WriteString("</head>\n<body>\n")
-	b.WriteString("<header class=\"header\">\n<h1>Glyph Findings Report</h1>\n<p class=\"meta\">Generated at <span id=\"generatedAt\">(pending)</span></p>\n<div class=\"meta\">Window: <span id=\"windowStart\">(pending)</span> → <span id=\"windowEnd\">(pending)</span></div>\n</header>\n")
-	b.WriteString("<main>\n<div id=\"integrityWarning\" class=\"banner\" hidden>Integrity check failed for <code>unknown</code>. Refresh or regenerate this report to continue.</div>\n")
+	b.WriteString("<header class=\"header\">\n<h1>0xgen Findings Report</h1>\n<p class=\"meta\">Generated at <span id=\"generatedAt\">(pending)</span></p>\n<div class=\"meta\">Window: <span id=\"windowStart\">(pending)</span> → <span id=\"windowEnd\">(pending)</span></div>\n</header>\n")
+	b.WriteString("<main id=\"oxg-report-root\">\n<div id=\"integrityWarning\" class=\"banner\" hidden>Integrity check failed for <code>unknown</code>. Refresh or regenerate this report to continue.</div>\n")
 	b.WriteString("<section class=\"controls\">\n<div class=\"search\"><input id=\"searchInput\" type=\"search\" placeholder=\"Search findings, assets, or evidence\" aria-label=\"Search\"></div>\n<div class=\"severity-chips\" id=\"severityFilters\"></div>\n<button type=\"button\" id=\"resetFilters\">Reset filters</button>\n</section>\n")
 	b.WriteString("<section class=\"stats-grid\">\n<div class=\"stat-card\"><span class=\"label\">Cases in view</span><span class=\"value\" id=\"filteredCases\">0</span><span class=\"hint\">of <span id=\"totalCases\">0</span> total</span></div>\n<div class=\"stat-card\"><span class=\"label\">Findings analysed</span><span class=\"value\" id=\"totalFindings\">0</span><span class=\"hint\" id=\"sbomInfo\" hidden></span></div>\n<div class=\"stat-card\"><span class=\"label\">Critical / High / Medium</span><span class=\"value\"><span id=\"filtered-crit\">0</span> / <span id=\"filtered-high\">0</span> / <span id=\"filtered-med\">0</span></span><span class=\"hint\">Low <span id=\"filtered-low\">0</span> • Informational <span id=\"filtered-info\">0</span></span></div>\n</section>\n")
 	b.WriteString("<section class=\"panel\">\n<h2>Cases</h2>\n<div class=\"case-list\" id=\"caseList\"></div>\n</section>\n")
-	b.WriteString("<section class=\"panel\">\n<h2>Source Findings</h2>\n<table class=\"findings-table\" id=\"findingsTable\"><thead><tr><th>Severity</th><th>Plugin</th><th>Target</th><th>Message</th><th>Detected</th></tr></thead><tbody></tbody></table>\n</section>\n</main>\n")
-	b.WriteString(fmt.Sprintf("<script type=\"application/json\" id=\"glyph-data\" data-integrity=\"sha256-%s\">%s</script>\n", dataDigest, datasetEscaped))
-	b.WriteString(fmt.Sprintf("<script id=\"glyph-app\" data-integrity=\"sha256-%s\">\n%s\n</script>\n", scriptDigest, htmlAppScript))
+	b.WriteString("<section class=\"panel\">\n<h2>Source Findings</h2>\n<table class=\"findings-table\" id=\"findingsTable\"><thead><tr><th>Severity</th><th>Plugin</th><th>Target</th><th>Message</th><th>Detected</th></tr></thead><tbody></tbody></table>\n</section>\n</main>\n<div id=\"glyph-report-root\" style=\"display:none\"></div>\n")
+	b.WriteString(fmt.Sprintf("<script type=\"application/json\" id=\"oxg-data\" data-integrity=\"sha256-%s\">%s</script>\n", dataDigest, datasetEscaped))
+	b.WriteString(fmt.Sprintf("<script id=\"oxg-app\" data-integrity=\"sha256-%s\">\n%s\n</script>\n", scriptDigest, htmlAppScript))
 	b.WriteString("</body>\n</html>\n")
 
 	return b.String(), nil

--- a/internal/reporter/md.go
+++ b/internal/reporter/md.go
@@ -13,9 +13,11 @@ import (
 )
 
 const (
-	defaultOutputDir = "/out"
-	findingsFilename = "findings.jsonl"
-	reportFilename   = "report.md"
+	defaultOutputDir   = "/out"
+	findingsFilename   = "findings.jsonl"
+	reportFilename     = "report.md"
+	htmlReportFilename = "0xgen_report.html"
+	jsonReportFilename = "0xgen_report.json"
 	// DefaultTopTargets controls how many targets appear in summary tables.
 	DefaultTopTargets     = 10
 	defaultTopPlugins     = 5
@@ -28,6 +30,10 @@ var (
 	DefaultFindingsPath = filepath.Join(defaultOutputDir, findingsFilename)
 	// DefaultReportPath is the default markdown summary written for CAP_REPORT consumers.
 	DefaultReportPath = filepath.Join(defaultOutputDir, reportFilename)
+	// DefaultHTMLReportPath is where the interactive HTML report is written when no --out flag is provided.
+	DefaultHTMLReportPath = filepath.Join(defaultOutputDir, htmlReportFilename)
+	// DefaultJSONReportPath is where the JSON bundle is written when no --out flag is provided.
+	DefaultJSONReportPath = filepath.Join(defaultOutputDir, jsonReportFilename)
 )
 
 func init() {
@@ -35,6 +41,8 @@ func init() {
 		if custom := strings.TrimSpace(val); custom != "" {
 			DefaultFindingsPath = filepath.Join(custom, findingsFilename)
 			DefaultReportPath = filepath.Join(custom, reportFilename)
+			DefaultHTMLReportPath = filepath.Join(custom, htmlReportFilename)
+			DefaultJSONReportPath = filepath.Join(custom, jsonReportFilename)
 		}
 	}
 }

--- a/internal/reporter/testdata/report_since_24h.html.golden
+++ b/internal/reporter/testdata/report_since_24h.html.golden
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Glyph Findings Report</title>
-<style id="glyph-style" data-integrity="sha256-hLFlCIoG7TyWRiIxB0nMRAua83WOjocLAnmWfpUvShs=">
+<title>0xgen Findings Report</title>
+<style id="oxg-style" data-integrity="sha256-hLFlCIoG7TyWRiIxB0nMRAua83WOjocLAnmWfpUvShs=">
 :root {
  color-scheme: light dark;
  --bg: #0f172a;
@@ -378,11 +378,11 @@ main {
 </head>
 <body>
 <header class="header">
-<h1>Glyph Findings Report</h1>
+<h1>0xgen Findings Report</h1>
 <p class="meta">Generated at <span id="generatedAt">(pending)</span></p>
 <div class="meta">Window: <span id="windowStart">(pending)</span> → <span id="windowEnd">(pending)</span></div>
 </header>
-<main>
+<main id="oxg-report-root">
 <div id="integrityWarning" class="banner" hidden>Integrity check failed for <code>unknown</code>. Refresh or regenerate this report to continue.</div>
 <section class="controls">
 <div class="search"><input id="searchInput" type="search" placeholder="Search findings, assets, or evidence" aria-label="Search"></div>
@@ -403,7 +403,8 @@ main {
 <table class="findings-table" id="findingsTable"><thead><tr><th>Severity</th><th>Plugin</th><th>Target</th><th>Message</th><th>Detected</th></tr></thead><tbody></tbody></table>
 </section>
 </main>
-<script type="application/json" id="glyph-data" data-integrity="sha256-DsM6sIJ6GrWeE/o1R3oicnxNPB5I88qv1HxvEhmINXQ=">{
+<div id="glyph-report-root" style="display:none"></div>
+<script type="application/json" id="oxg-data" data-integrity="sha256-DsM6sIJ6GrWeE/o1R3oicnxNPB5I88qv1HxvEhmINXQ=">{
   "schema_version": "1.0",
   "generated_at": "2024-02-10T12:00:00Z",
   "findings_count": 2,
@@ -600,7 +601,7 @@ main {
   }
 }
 </script>
-<script id="glyph-app" data-integrity="sha256-Nuudq9Et0qllGWpYcpEkvLs2h48iGO+U2e1C9VS+230=">
+<script id="oxg-app" data-integrity="sha256-A87w6+ht78oM0oKinRe0sZlBh1WUX8mJZ9iIHkEXCwE=">
 (function () {
   const severityOrder = [
     { id: "crit", label: "Critical" },
@@ -617,11 +618,17 @@ main {
     filteredCases: [],
   };
 
+  const aliasMap = [
+    ["oxg-style", "glyph-style"],
+    ["oxg-data", "glyph-data"],
+    ["oxg-app", "glyph-app"],
+  ];
+
   document.addEventListener("DOMContentLoaded", init);
 
   async function init() {
     await verifyIntegrity();
-    const dataElement = document.getElementById("glyph-data");
+    const dataElement = getElementByIds("oxg-data", "glyph-data");
     if (!dataElement) {
       console.error("dataset element missing");
       return;
@@ -645,9 +652,8 @@ main {
     if (!window.crypto || !window.crypto.subtle) {
       return;
     }
-    const elements = ["glyph-style", "glyph-data", "glyph-app"];
-    for (const id of elements) {
-      const el = document.getElementById(id);
+    for (const ids of aliasMap) {
+      const el = getElementByIds(...ids);
       if (!el) {
         continue;
       }
@@ -664,16 +670,26 @@ main {
       if (actual !== expected) {
         console.error(
           "integrity mismatch for " +
-            id +
+            (el.id || ids[0]) +
             ": expected " +
             expected +
             ", got " +
             actual,
         );
-        showIntegrityWarning(id);
+        showIntegrityWarning(el.id || ids[0]);
         break;
       }
     }
+  }
+
+  function getElementByIds(...ids) {
+    for (const id of ids) {
+      const el = document.getElementById(id);
+      if (el) {
+        return el;
+      }
+    }
+    return null;
   }
 
   function showIntegrityWarning(source) {


### PR DESCRIPTION
## Summary
- update the interactive HTML report to display the new 0xgen branding while keeping legacy glyph IDs as aliases
- add default HTML/JSON report filenames that use the 0xgen prefix when no --out flag is supplied
- refresh fixtures and quickstart sample assets to reflect the new report title and element IDs

## Testing
- go test ./internal/reporter ./cmd/glyphctl -count=1 *(hangs, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68f78aa812a0832a9c9e7447dca2b968