### PR TITLE
Fix Glyph branding regex

### DIFF
--- a/scripts/ci/check_glyph_branding.sh
+++ b/scripts/ci/check_glyph_branding.sh
@@ -47,7 +47,7 @@ for file in "${changed_files[@]}"; do
     continue
   fi
 
-  if matches=$(rg -n --ignore-case '\\bGlyph\\b' --color=never "$file"); then
+  if matches=$(rg -n --ignore-case '\bGlyph\b' --color=never "$file"); then
     if (( violations == 0 )); then
       echo "Forbidden legacy 'Glyph' references detected:"
     fi


### PR DESCRIPTION
## Summary
- ensure the Glyph branding guard passes the intended `\bGlyph\b` pattern to ripgrep so word boundaries are respected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7cbb1d660832ab8997843f77b422d