### PR TITLE
Update packaging references to 0xgen tap

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -8,10 +8,10 @@
 
 ### macOS (Homebrew)
 
-Las personas usuarias de macOS pueden instalar el binario precompilado `0xgenctl` mediante Homebrew utilizando el [tap RowanDark/homebrew-glyph](https://github.com/RowanDark/homebrew-glyph):
+Las personas usuarias de macOS pueden instalar el binario precompilado `0xgenctl` mediante Homebrew utilizando el [tap RowanDark/homebrew-0xgen](https://github.com/RowanDark/homebrew-0xgen):
 
 ```bash
-brew install rowandark/glyph/0xgenctl
+brew install rowandark/0xgen/0xgen
 ```
 
 ### Linux (Debian/Ubuntu)
@@ -64,7 +64,7 @@ C:\Tools\0xgen\0xgenctl.exe --version
 Agrega este repositorio como un bucket de Scoop e instala el manifiesto publicado:
 
 ```powershell
-scoop bucket add glyph https://github.com/RowanDark/0xgen
+scoop bucket add 0xgen https://github.com/RowanDark/0xgen
 scoop install 0xgenctl
 0xgenctl --version
 ```

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ docs build pipeline.
 ### macOS (Homebrew)
 
 macOS users can install the prebuilt `0xgenctl` binary via Homebrew using the
-[RowanDark/homebrew-glyph tap](https://github.com/RowanDark/homebrew-glyph):
+[RowanDark/homebrew-0xgen tap](https://github.com/RowanDark/homebrew-0xgen):
 
 ```bash
-brew install rowandark/glyph/0xgenctl
+brew install rowandark/0xgen/0xgen
 ```
 
 ### Linux (Debian/Ubuntu)
@@ -80,7 +80,7 @@ C:\Tools\0xgen\0xgenctl.exe --version
 Add this repository as a Scoop bucket and install the published manifest:
 
 ```powershell
-scoop bucket add glyph https://github.com/RowanDark/0xgen
+scoop bucket add 0xgen https://github.com/RowanDark/0xgen
 scoop install 0xgenctl
 0xgenctl --version
 ```

--- a/docs/en/cli/windows.md
+++ b/docs/en/cli/windows.md
@@ -59,7 +59,7 @@ If you prefer package managers, add the 0xgen bucket to Scoop and install the
 manifest published from this repository:
 
 ```powershell
-scoop bucket add glyph https://github.com/RowanDark/0xgen
+scoop bucket add 0xgen https://github.com/RowanDark/0xgen
 scoop install 0xgenctl
 0xgenctl --version
 ```

--- a/docs/en/dev-guide/index.md
+++ b/docs/en/dev-guide/index.md
@@ -61,9 +61,9 @@ you debug the plugin in real time.
 3. Execute `scripts/build_release.sh` to produce signed archives and checksums.
 4. Follow the prompts in `scripts/update-brew-formula.sh` if the Homebrew tap
    needs a new version. The script keeps the
-   [`RowanDark/homebrew-glyph`](https://github.com/RowanDark/homebrew-glyph)
-   formula in sync and the `bump-homebrew` workflow opens a pull request with the
-   changes.
+   [`RowanDark/homebrew-0xgen`](https://github.com/RowanDark/homebrew-0xgen)
+   `0xgen` formula in sync and the `bump-homebrew` workflow opens a pull request
+   with the changes.
 5. Build and sign the update manifests as described in the
    [updater guide](../dev/updater.md), then stage delta packages for macOS,
    Windows, and Linux.

--- a/docs/en/versions/v1.0/dev-guide/index.md
+++ b/docs/en/versions/v1.0/dev-guide/index.md
@@ -61,9 +61,9 @@ you debug the plugin in real time.
 3. Execute `scripts/build_release.sh` to produce signed archives and checksums.
 4. Follow the prompts in `scripts/update-brew-formula.sh` if the Homebrew tap
    needs a new version. The script keeps the
-   [`RowanDark/homebrew-glyph`](https://github.com/RowanDark/homebrew-glyph)
-   formula in sync and the `bump-homebrew` workflow opens a pull request with the
-   changes.
+   [`RowanDark/homebrew-0xgen`](https://github.com/RowanDark/homebrew-0xgen)
+   `0xgen` formula in sync and the `bump-homebrew` workflow opens a pull request
+   with the changes.
 5. Run `scripts/snapshot_docs.py vX.Y.Z --latest` to archive the documentation
    into `docs/en/versions/` and update the version selector manifest.
 6. Push a Git tag (for example `v1.2.3`) to trigger the release workflows and

--- a/docs/en/versions/v2.0/dev-guide/index.md
+++ b/docs/en/versions/v2.0/dev-guide/index.md
@@ -61,9 +61,9 @@ you debug the plugin in real time.
 3. Execute `scripts/build_release.sh` to produce signed archives and checksums.
 4. Follow the prompts in `scripts/update-brew-formula.sh` if the Homebrew tap
    needs a new version. The script keeps the
-   [`RowanDark/homebrew-glyph`](https://github.com/RowanDark/homebrew-glyph)
-   formula in sync and the `bump-homebrew` workflow opens a pull request with the
-   changes.
+   [`RowanDark/homebrew-0xgen`](https://github.com/RowanDark/homebrew-0xgen)
+   `0xgen` formula in sync and the `bump-homebrew` workflow opens a pull request
+   with the changes.
 5. Run `scripts/snapshot_docs.py vX.Y.Z --latest` to archive the documentation
    into `docs/en/versions/` and update the version selector manifest.
 6. Push a Git tag (for example `v1.2.3`) to trigger the release workflows and

--- a/packaging/homebrew/Aliases/0xgen
+++ b/packaging/homebrew/Aliases/0xgen
@@ -1,1 +1,1 @@
-../Formula/oxgenctl.rb
+../Formula/0xgen.rb

--- a/packaging/homebrew/Aliases/0xgenctl
+++ b/packaging/homebrew/Aliases/0xgenctl
@@ -1,1 +1,1 @@
-../Formula/oxgenctl.rb
+../Formula/0xgen.rb

--- a/packaging/homebrew/Formula/0xgen.rb
+++ b/packaging/homebrew/Formula/0xgen.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Oxgenctl < Formula
+class Oxgen < Formula
   desc "Automation toolkit for orchestrating red-team and detection workflows"
   homepage "https://github.com/RowanDark/0xgen"
   url "https://github.com/RowanDark/0xgen/archive/6cdf809882689869dfb340dc2d68c709675443b6.tar.gz"

--- a/scripts/update-brew-formula.sh
+++ b/scripts/update-brew-formula.sh
@@ -26,7 +26,7 @@ if [[ -z "${VERSION}" ]]; then
         exit 1
 fi
 
-TAP_REPO="RowanDark/homebrew-glyph"
+TAP_REPO="RowanDark/homebrew-0xgen"
 RELEASE_OWNER="RowanDark"
 RELEASE_REPO="0xgen"
 
@@ -69,7 +69,7 @@ gh repo clone "${TAP_REPO}" "${TAP_CLONE_DIR}" >/dev/null 2>&1 || gh repo clone 
 
 pushd "${TAP_CLONE_DIR}" >/dev/null
 
-BRANCH="bump-0xgenctl-${TAG}"
+BRANCH="bump-0xgen-${TAG}"
 DEFAULT_BRANCH="$(git symbolic-ref --short refs/remotes/origin/HEAD | cut -d/ -f2)"
 
 git config user.name "github-actions[bot]"
@@ -80,8 +80,8 @@ git pull --ff-only origin "${DEFAULT_BRANCH}" >/dev/null
 git checkout -B "${BRANCH}" "${DEFAULT_BRANCH}"
 
 mkdir -p Formula Aliases
-cat >Formula/oxgenctl.rb <<FORMULA
-class Oxgenctl < Formula
+cat >Formula/0xgen.rb <<FORMULA
+class Oxgen < Formula
   desc "Automation toolkit for orchestrating red-team and detection workflows"
   homepage "https://github.com/${RELEASE_OWNER}/${RELEASE_REPO}"
   version "${VERSION}"
@@ -113,11 +113,11 @@ end
 FORMULA
 
 cat >Aliases/0xgenctl <<'ALIAS'
-../Formula/oxgenctl.rb
+../Formula/0xgen.rb
 ALIAS
 
 cat >Aliases/0xgen <<'ALIAS'
-../Formula/oxgenctl.rb
+../Formula/0xgen.rb
 ALIAS
 
 if git diff --quiet; then
@@ -126,8 +126,8 @@ if git diff --quiet; then
         exit 0
 fi
 
-git add Formula/oxgenctl.rb Aliases/0xgenctl Aliases/0xgen
-git commit -m "Update 0xgenctl to ${TAG}" >/dev/null
+git add Formula/0xgen.rb Aliases/0xgenctl Aliases/0xgen
+git commit -m "Update 0xgen to ${TAG}" >/dev/null
 
 git push --set-upstream origin "${BRANCH}" --force-with-lease >/dev/null
 
@@ -136,7 +136,7 @@ if [[ -n "$(gh pr list --repo "${TAP_REPO}" --state open --head "${BRANCH}" --js
 else
         gh pr create \
                 --repo "${TAP_REPO}" \
-                --title "Update 0xgenctl to ${TAG}" \
+                --title "Update 0xgen to ${TAG}" \
                 --body "Automated update for ${TAG}." \
                 --head "${BRANCH}" \
                 --base "${DEFAULT_BRANCH}"


### PR DESCRIPTION
## Summary
- rename the Homebrew formula to 0xgen and point aliases at the new file
- update the release automation script to target RowanDark/homebrew-0xgen
- refresh README and docs to use the new Homebrew tap and Scoop bucket commands

## Testing
- not run (documentation and packaging updates only)


------
https://chatgpt.com/codex/tasks/task_e_68f8ef297bd8832a8d49ed8d431b776f