### PR TITLE
Fix docs workflow canonical prefix and badge

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -134,15 +134,32 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
+      - name: Assert canonical site prefix
+        run: |
+          expected="https://rowandark.github.io/0xgen/"
+          actual="${{ steps.deployment.outputs.page_url }}"
+          if [ "${actual%/}/" != "$expected" ]; then
+            echo "::error ::Unexpected page URL '$actual' (expected '$expected')."
+            exit 1
+          fi
+
   smoke:
     needs: deploy
     runs-on: ubuntu-latest
     steps:
       - name: Check published pages
         env:
-          BASE_URL: ${{ needs.deploy.outputs.page_url }}
+          PUBLISHED_URL: ${{ needs.deploy.outputs.page_url }}
+          CANONICAL_URL: https://rowandark.github.io/0xgen/
         run: |
-          url="${BASE_URL%/}"
-          for p in "" "quickstart/" "cli/" "plugins/" "security/"; do
-            curl -fSL "${url}/${p}" >/dev/null
+          published="${PUBLISHED_URL%/}/"
+          canonical="$CANONICAL_URL"
+          if [ "$published" != "$canonical" ]; then
+            echo "::error ::Unexpected published URL '$published' (expected '$canonical')."
+            exit 1
+          fi
+
+          base="${canonical%/}"
+          for path in "" "quickstart/" "cli/" "plugins/" "security/"; do
+            curl -fSL "${base}/${path}" >/dev/null
           done

--- a/README.es.md
+++ b/README.es.md
@@ -1,6 +1,6 @@
 # 0xgen
 
-[![Documentación](https://img.shields.io/badge/docs-material-blue)](https://rowandark.github.io/0xgen/)
+[![Estado de la documentación](https://github.com/RowanDark/0xgen/actions/workflows/docs.yml/badge.svg?branch=main)](https://rowandark.github.io/0xgen/)
 
 0xgen es un conjunto de herramientas de automatización para orquestar flujos de trabajo de red teaming y detección. Coordina complementos como Galdr (proxy de reescritura HTTP), Excavator (rastreador Playwright), Seer (detector de secretos/PII), Ranker y Scribe para convertir telemetría sin procesar en hallazgos priorizados e informes legibles para humanos.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 0xgen
 
-<!-- version-badge -->[![Release](https://img.shields.io/badge/release-v0.0.0--dev-blue)](https://github.com/RowanDark/0xgen/releases/latest)<!-- /version-badge --> [![Build status](https://github.com/RowanDark/0xgen/actions/workflows/ci.yml/badge.svg)](https://github.com/RowanDark/0xgen/actions/workflows/ci.yml) [![Docs](https://img.shields.io/badge/docs-material-blue)](https://rowandark.github.io/0xgen/) [![Plugin count](https://img.shields.io/endpoint?url=https://rowandark.github.io/0xgen/api/plugin-stats.json&cacheSeconds=3600)](https://rowandark.github.io/0xgen/plugins/catalog/)
+<!-- version-badge -->[![Release](https://img.shields.io/badge/release-v0.0.0--dev-blue)](https://github.com/RowanDark/0xgen/releases/latest)<!-- /version-badge --> [![Build status](https://github.com/RowanDark/0xgen/actions/workflows/ci.yml/badge.svg)](https://github.com/RowanDark/0xgen/actions/workflows/ci.yml) [![Docs status](https://github.com/RowanDark/0xgen/actions/workflows/docs.yml/badge.svg?branch=main)](https://rowandark.github.io/0xgen/) [![Plugin count](https://img.shields.io/endpoint?url=https://rowandark.github.io/0xgen/api/plugin-stats.json&cacheSeconds=3600)](https://rowandark.github.io/0xgen/plugins/catalog/)
 
 0xgen — Generation Zero: AI-driven offensive security.
 


### PR DESCRIPTION
## Summary
- assert the GitHub Pages deployment resolves to https://rowandark.github.io/0xgen/ and reuse that canonical URL for smoke testing
- refresh the documentation badges in the English and Spanish READMEs to show the docs workflow status while linking to the published site

## Testing
- not run (CI will cover)


------
https://chatgpt.com/codex/tasks/task_e_68fa1aa28ce0832a85753202f7753cc8