### PR TITLE
Docs: remove legacy Glyph branding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Removed all `GLYPH_*` environment-variable fallbacks across binaries, plugins, and tooling; only `0XGEN_*` configuration is now recognised.
 - Replaced glyph-prefixed observability metrics and desktop shell aliases with `oxg_*` series.
-- Dropped acceptance and emission of legacy `X-Glyph-*` proxy headers in favour of the canonical `X-0xgen-*` family, updating E2E coverage accordingly.
+- Dropped acceptance and emission of proxy headers branded for the legacy name in favour of the canonical `X-0xgen-*` family, updating E2E coverage accordingly.
 - Rotated the plugin signing key and refreshed detached signatures for all bundled plugins to reflect the rebrand.
 
 ## v0.1.0-alpha

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to Glyph
+# Contributing to 0xgen
 
-Thanks for helping shape Glyph! To keep the project healthy and reproducible, please follow these guidelines before opening a pull request.
+Thanks for helping shape 0xgen! To keep the project healthy and reproducible, please follow these guidelines before opening a pull request.
 
 ## Development environment
 
 - Install Go 1.21+, Node.js 18+, and the Amass binary if you plan to exercise OSINT Well locally.
 - `go install golang.org/x/tools/cmd/goimports@latest` helps keep imports tidy.
-- Set `0XGEN_OUT` if you want Glyph services to write artefacts outside of `/out`.
+- Set `0XGEN_OUT` if you want 0xgen services to write artefacts outside of `/out`.
 
 ## Working on changes
 

--- a/PLUGIN_GUIDE.md
+++ b/PLUGIN_GUIDE.md
@@ -1,6 +1,6 @@
 # Plugin Security Guide
 
-This guide summarizes the expectations for Glyph plugins and provides practical
+This guide summarizes the expectations for 0xgen plugins and provides practical
 patterns to keep new integrations safe.
 
 ## Design principles
@@ -89,6 +89,6 @@ sandbox and avoid `sudo`, host mounts, or direct Docker API access.
 
 ## Further reading
 
-* [Glyph threat model](THREAT_MODEL.md)
+* [0xgen threat model](THREAT_MODEL.md)
 * [Security policy](SECURITY.md)
 * [SDK documentation](docs/sdk/README.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-We take the security of Glyph deployments seriously. Responsible disclosure
+We take the security of 0xgen deployments seriously. Responsible disclosure
 helps the community remediate issues quickly and protect operators who rely on
 the toolkit.
 
@@ -25,7 +25,7 @@ flags in the release notes.
 
 Please include the following details to help us triage your report:
 
-* A description of the vulnerability and the affected Glyph components.
+* A description of the vulnerability and the affected 0xgen components.
 * Steps to reproduce the issue, including configuration snippets or sample
   inputs.
 * Any suggested mitigations or potential impact.
@@ -51,7 +51,7 @@ ships them.
 
 ## Scope
 
-The policy covers the Glyph core (`0xgend`, `0xgenctl`), bundled plugins, SDKs,
+The policy covers the 0xgen core (`0xgend`, `0xgenctl`), bundled plugins, SDKs,
 and example tooling. Third-party plugins or forks maintained outside this
 repository are out of scope.
 

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -1,13 +1,13 @@
-# Glyph Threat Model
+# 0xgen Threat Model
 
 This document summarizes the security assumptions, major attack surfaces, and the
-controls that Glyph relies on today. It is intended to help contributors reason
+controls that 0xgen relies on today. It is intended to help contributors reason
 about changes, plugin authors understand the runtime expectations, and auditors
 navigate the project.
 
 ## High-level assumptions
 
-* Glyph deployments run inside trusted infrastructure managed by the operator.
+* 0xgen deployments run inside trusted infrastructure managed by the operator.
   We assume the host OS, container runtime, and CI pipelines are hardened and
   patched.
 * Secrets such as API tokens, webhook credentials, or private keys are supplied
@@ -16,7 +16,7 @@ navigate the project.
   subprocesses) and should treat any data originating from remote systems as
   hostile until validated.
 * Network egress from plugins is tightly controlled. When external connectivity
-  is required, it should be routed through the Glyph broker APIs or other
+  is required, it should be routed through the 0xgen broker APIs or other
   audited proxies.
 
 ## Threat scenarios
@@ -66,7 +66,7 @@ compromise the orchestrator host.
 
 ### Man-in-the-middle (MITM)
 
-Interception of network traffic between Glyph components could allow tampering
+Interception of network traffic between 0xgen components could allow tampering
 with findings or plugin coordination.
 
 * **Controls**: internal communication uses mutual TLS, and the orchestrator
@@ -90,7 +90,7 @@ requests to internal services or leaking local files.
 * Operators must monitor plugin logs and metrics to detect abuse.
 * Sandboxing relies on container runtime hardening; a kernel exploit can bypass
   isolation until patched.
-* Glyph assumes the network perimeter enforces egress filtering. Lack of
+* 0xgen assumes the network perimeter enforces egress filtering. Lack of
   filtering increases the blast radius of plugin compromise.
 
 ## Reporting

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -6,7 +6,6 @@ telemetry into ranked findings and human-readable reports. This site consolidate
 operational and contributor documentation that previously lived in scattered Markdown
 files.
 
-_History note: 0xgen was formerly named Glyph._
 
 Use the navigation sidebar to explore:
 

--- a/specs/finding.md
+++ b/specs/finding.md
@@ -1,6 +1,6 @@
 # Findings Schema
 
-Glyph persists plugin findings as JSON Lines files under `/out`. Each entry in
+0xgen persists plugin findings as JSON Lines files under `/out`. Each entry in
 `findings.jsonl` must comply with the schema below so downstream tooling can
 parse findings deterministically. The canonical JSON Schema lives at
 `plugins/findings.schema.json` and the `0xgenctl findings validate` command can
@@ -52,7 +52,7 @@ check an exported log against it.
   "version": "0.2",
   "id": "01HZXK4QAZ3ZKAB1Y7P5Z9Q4C4",
   "plugin": "demo",
-  "type": "glyph.demo.start",
+  "type": "oxg.demo.start",
   "message": "Sample finding emitted during startup",
   "target": "demo://self-test",
   "severity": "low",


### PR DESCRIPTION
## Summary
- replace the remaining Glyph mentions across contributor and security documentation with 0xgen branding
- update the threat model and findings schema examples to align with the 0xgen name
- remove the "formerly Glyph" history note from the English documentation index

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa5c495f8c832aa4e714c7e1d625be