### PR TITLE
Remove legacy Glyph branding from CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Windows plugin smoke test
         if: matrix.os == 'windows-latest'
-        run: go test ./internal/e2e -run TestGlyphctlSmoke -count=1
+        run: go test ./internal/e2e -run TestCliSmoke -count=1
 
       - name: Generate sample HTML report
         if: matrix.os == 'ubuntu-latest'
@@ -101,7 +101,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: 0xgen-glyph-report-html
+          name: 0xgen-report-html
           path: report.html
           if-no-files-found: error
 
@@ -205,8 +205,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          data_volume="$(docker volume create glyph-ci-data)"
-          out_volume="$(docker volume create glyph-ci-out)"
+          data_volume="$(docker volume create 0xgen-ci-data)"
+          out_volume="$(docker volume create 0xgen-ci-out)"
 
           cleanup() {
             docker volume rm -f "$data_volume" "$out_volume" >/dev/null 2>&1 || true
@@ -223,7 +223,7 @@ jobs:
             --cpus="1.0"
             --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m
             --tmpfs /home/nonroot/.cache:rw,noexec,nosuid,nodev,size=64m
-            --mount "type=volume,src=${data_volume},dst=/home/nonroot/.glyph"
+            --mount "type=volume,src=${data_volume},dst=/home/nonroot/.0xgen"
           )
 
           docker run "${common_flags[@]}" \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
             --no-robots \
             --timeout=10 \
             --threads=8 \
-            --user-agent "GlyphDocsLinkChecker/1.0" \
+            --user-agent "0xgenDocsLinkChecker/1.0" \
             --ignore-url "^mailto:" \
             --ignore-url "^tel:" \
             --ignore-url "^javascript:" \

--- a/.github/workflows/homebrew-smoke.yml
+++ b/.github/workflows/homebrew-smoke.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Install 0xgenctl from tap
         run: |
           set -euxo pipefail
-          brew tap rowandark/glyph
-          brew install glyph
+          brew tap rowandark/0xgen
+          brew install 0xgen
           0xgenctl --version

--- a/.github/workflows/packaging-smoke.yml
+++ b/.github/workflows/packaging-smoke.yml
@@ -108,11 +108,11 @@ jobs:
           Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
           iwr -useb get.scoop.sh | iex
 
-      - name: Add Glyph bucket and install 0xgenctl
+      - name: Add 0xgen bucket and install 0xgenctl
         if: steps.manifest.outputs.placeholder == 'false'
         shell: pwsh
         run: |
-          scoop bucket add glyph https://github.com/${{ github.repository }}
+          scoop bucket add 0xgen https://github.com/${{ github.repository }}
           scoop install 0xgenctl
           0xgenctl --version
 
@@ -154,7 +154,7 @@ jobs:
         run: |
           $msi = "dist/0xgenctl_${env:TAG}_windows_amd64.msi"
           msiexec /i $msi /qn
-          & 'C:\Program Files\Glyph\0xgenctl.exe' --version
+          & 'C:\Program Files\0xgen\0xgenctl.exe' --version
 
       - name: Uninstall MSI
         if: steps.release.outputs.tag != ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
             osslsigncode sign \
               -pkcs12 "$cert" \
               "${pass_args[@]}" \
-              -n "Glyph CLI" \
+              -n "0xgen CLI" \
               -i "https://github.com/RowanDark/0xgen" \
               -t "http://timestamp.digicert.com" \
               -in "$workdir/0xgenctl.exe" \

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -19,17 +19,17 @@ jobs:
         uses: anchore/syft-action@v0.9.0
         with:
           path: .
-          output: sbom/glyph-repo.spdx.json
+          output: sbom/0xgen-repo.spdx.json
 
       - name: Generate plugin SBOMs
         uses: anchore/syft-action@v0.9.0
         with:
           path: plugins
-          output: sbom/glyph-plugins.spdx.json
+          output: sbom/0xgen-plugins.spdx.json
 
       - name: Upload SBOM artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: 0xgen-glyph-sboms
+          name: 0xgen-sboms
           path: sbom/
           if-no-files-found: error

--- a/.github/workflows/windows-install.yml
+++ b/.github/workflows/windows-install.yml
@@ -49,22 +49,22 @@ jobs:
         run: |
           $msi = (Resolve-Path 'dist/0xgenctl_v0.0.0-ci_windows_amd64.msi').Path
           Start-Process msiexec.exe -ArgumentList "/i `"$msi`" /qn /norestart" -Wait
-          $glyph = Join-Path $env:ProgramFiles 'Glyph\0xgenctl.exe'
-          if (-not (Test-Path $glyph -PathType Leaf)) {
+          $installedCli = Join-Path $env:ProgramFiles '0xgen\0xgenctl.exe'
+          if (-not (Test-Path $installedCli -PathType Leaf)) {
             throw "0xgenctl.exe was not installed"
           }
-          & $glyph --version
+          & $installedCli --version
           $artifact = (Resolve-Path 'plugins/samples/passive-header-scan/main.go').Path
           $hash = (Get-FileHash $artifact -Algorithm SHA256).Hash
-          & $glyph plugin verify $artifact --hash $hash
+          & $installedCli plugin verify $artifact --hash $hash
 
       - name: Uninstall MSI
         shell: pwsh
         run: |
           $msi = (Resolve-Path 'dist/0xgenctl_v0.0.0-ci_windows_amd64.msi').Path
           Start-Process msiexec.exe -ArgumentList "/x `"$msi`" /qn /norestart" -Wait
-          $glyphDir = Join-Path $env:ProgramFiles 'Glyph'
-          if (Test-Path $glyphDir) {
+          $installDir = Join-Path $env:ProgramFiles '0xgen'
+          if (Test-Path $installDir) {
             throw "Install directory still present after uninstall"
           }
 
@@ -73,13 +73,13 @@ jobs:
         run: |
           $extract = Join-Path $env:RUNNER_TEMP '0xgenctl-portable'
           Expand-Archive -Path dist/0xgenctl_ci_windows_portable.zip -DestinationPath $extract -Force
-          $glyph = Join-Path $extract '0xgenctl.exe'
-          & $glyph --version
+          $portableCli = Join-Path $extract '0xgenctl.exe'
+          & $portableCli --version
 
       - name: Verify plugin subsystem
         shell: pwsh
         run: |
-          $glyph = Join-Path $env:RUNNER_TEMP '0xgenctl-portable' '0xgenctl.exe'
+          $portableCli = Join-Path $env:RUNNER_TEMP '0xgenctl-portable' '0xgenctl.exe'
           $artifact = Resolve-Path 'plugins/samples/passive-header-scan/main.go'
           $hash = (Get-FileHash $artifact -Algorithm SHA256).Hash
-          & $glyph plugin verify $artifact --hash $hash
+          & $portableCli plugin verify $artifact --hash $hash


### PR DESCRIPTION
## Summary
- replace the remaining Glyph identifiers in CI, release, and packaging workflows with the 0xgen name
- update Windows install paths, SBOM artifact names, and container volume mounts to match the new branding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbd02cde94832a9526229e08c23712