### PR TITLE
chore: drop Windows shim from packaging

### DIFF
--- a/packaging/windows/0xgenctl.wxs
+++ b/packaging/windows/0xgenctl.wxs
@@ -46,7 +46,6 @@
     <ComponentGroup Id="ZeroXgenComponents">
       <Component Id="ZeroXgenExecutable" Guid="{2DFEEA0E-4FD0-4F71-83F2-5C2F11C278F7}" Directory="INSTALLFOLDER" Win64="yes">
         <File Id="ZeroXgenExecutableFile" Source="$(var.PayloadDir)/0xgenctl.exe" KeyPath="yes" />
-        <File Id="ZeroXgenAliasFile" Source="$(var.PayloadDir)/0xgenctl.cmd" />
         <File Id="ZeroXgenLicenseFile" Source="$(var.PayloadDir)/LICENSE.txt" />
         <File Id="ZeroXgenReadmeFile" Source="$(var.PayloadDir)/README.txt" />
         <Environment Id="ZeroXgenPath"

--- a/scoop/bucket/0xgenctl.json
+++ b/scoop/bucket/0xgenctl.json
@@ -14,8 +14,7 @@
     }
   },
   "bin": [
-    "0xgenctl.exe",
-    ["0xgenctl.cmd", "0xgenctl"]
+    "0xgenctl.exe"
   ],
   "checkver": {
     "github": "https://github.com/RowanDark/0xgen"

--- a/scripts/0xgenctl.cmd
+++ b/scripts/0xgenctl.cmd
@@ -1,2 +1,0 @@
-@echo off
-"%~dp00xgenctl.exe" %*

--- a/scripts/build_windows_installer.ps1
+++ b/scripts/build_windows_installer.ps1
@@ -50,7 +50,6 @@ $tempDir = New-Item -ItemType Directory -Path (Join-Path -Path ([IO.Path]::GetTe
 try {
     $repoRoot = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath '..')).Path
     Copy-Item -Path $payloadExecutable -Destination (Join-Path -Path $tempDir -ChildPath '0xgenctl.exe')
-    Copy-Item -Path (Join-Path -Path $repoRoot -ChildPath 'scripts/0xgenctl.cmd') -Destination (Join-Path -Path $tempDir -ChildPath '0xgenctl.cmd')
     Copy-Item -Path (Join-Path -Path $repoRoot -ChildPath 'README.md') -Destination (Join-Path -Path $tempDir -ChildPath 'README.txt')
     Copy-Item -Path (Join-Path -Path $repoRoot -ChildPath 'LICENSE') -Destination (Join-Path -Path $tempDir -ChildPath 'LICENSE.txt')
 

--- a/scripts/build_windows_installer.sh
+++ b/scripts/build_windows_installer.sh
@@ -65,7 +65,6 @@ trap 'rm -rf "$stage"' EXIT
 mkdir -p "$output_dir"
 
 cp "$payload_dir/0xgenctl.exe" "$stage/0xgenctl.exe"
-cp "$ROOT_DIR/scripts/0xgenctl.cmd" "$stage/0xgenctl.cmd"
 cp "$ROOT_DIR/README.md" "$stage/README.txt"
 cp "$ROOT_DIR/LICENSE" "$stage/LICENSE.txt"
 


### PR DESCRIPTION
## Summary
- stop bundling the deprecated 0xgenctl.cmd shim in the Windows MSI definition and scoop manifest
- update the installer build scripts to only include the native executable payload

## Testing
- go test ./... *(fails: CLI/e2e fixtures require additional assets)*

------
https://chatgpt.com/codex/tasks/task_e_68fbd9508920832a893ba7ae4c5b10e4