### PR TITLE
Add case snapshot history and comparison UI

### DIFF
--- a/apps/desktop-shell/src-tauri/Cargo.toml
+++ b/apps/desktop-shell/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ once_cell = "1.19"
 parking_lot = "0.12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
+sha2 = "0.10"
 
 [features]
 default = ["custom-protocol"]

--- a/apps/desktop-shell/src/lib/case-diff.ts
+++ b/apps/desktop-shell/src/lib/case-diff.ts
@@ -1,0 +1,412 @@
+import type { CaseRecord, CaseSnapshot, CaseSnapshotSummary } from './ipc';
+
+export type CaseSeverity = 'critical' | 'high' | 'medium' | 'low' | 'informational';
+
+export type KeyChange = {
+  key: string;
+  before?: string;
+  after?: string;
+  change: 'added' | 'removed' | 'changed';
+};
+
+export type EvidenceDiff = {
+  key: string;
+  plugin: string;
+  type: string;
+  change: 'added' | 'removed' | 'changed' | 'unchanged';
+  before?: CaseRecord['evidence'][number];
+  after?: CaseRecord['evidence'][number];
+  bodyText?: {
+    before: string;
+    after: string;
+    changed: boolean;
+  };
+  bodyMetadata: KeyChange[];
+  headers: KeyChange[];
+  metadata: KeyChange[];
+};
+
+export type CaseChange = {
+  id: string;
+  titleBefore: string;
+  titleAfter: string;
+  severityBefore: string;
+  severityAfter: string;
+  before: CaseRecord;
+  after: CaseRecord;
+  summaryChanged: boolean;
+  confidenceChanged: boolean;
+  riskChanged: boolean;
+  labelsChanged: KeyChange[];
+  evidenceDiff: EvidenceDiff[];
+  changedFields: string[];
+};
+
+export type CaseDiffSummary = {
+  baseline: CaseSnapshotSummary;
+  target: CaseSnapshotSummary;
+  added: CaseRecord[];
+  removed: CaseRecord[];
+  changed: CaseChange[];
+};
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(',')}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .map(([key, val]) => [key, stableStringify(val)] as const)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return `{${entries.map(([key, val]) => `${JSON.stringify(key)}:${val}`).join(',')}}`;
+}
+
+function casesEqual(a: CaseRecord, b: CaseRecord): boolean {
+  return stableStringify(a) === stableStringify(b);
+}
+
+function diffLabels(
+  before: Record<string, string> | undefined,
+  after: Record<string, string> | undefined
+): KeyChange[] {
+  const left = before ?? {};
+  const right = after ?? {};
+  const changes: KeyChange[] = [];
+
+  for (const [key, value] of Object.entries(right)) {
+    if (!(key in left)) {
+      changes.push({ key, after: value, change: 'added' });
+    } else if (left[key] !== value) {
+      changes.push({ key, before: left[key], after: value, change: 'changed' });
+    }
+  }
+
+  for (const [key, value] of Object.entries(left)) {
+    if (!(key in right)) {
+      changes.push({ key, before: value, change: 'removed' });
+    }
+  }
+
+  return changes;
+}
+
+function classifyKeyChange(change: KeyChange) {
+  const lowered = change.key.toLowerCase();
+  if (lowered.includes('header')) {
+    return 'header' as const;
+  }
+  if (lowered.includes('body')) {
+    return 'body' as const;
+  }
+  return 'metadata' as const;
+}
+
+function diffEvidenceItem(
+  before: CaseRecord['evidence'][number] | undefined,
+  after: CaseRecord['evidence'][number] | undefined,
+  key: string
+): EvidenceDiff {
+  if (before && !after) {
+    return {
+      key,
+      plugin: before.plugin,
+      type: before.type,
+      change: 'removed',
+      before,
+      bodyMetadata: [],
+      headers: [],
+      metadata: []
+    };
+  }
+  if (after && !before) {
+    return {
+      key,
+      plugin: after.plugin,
+      type: after.type,
+      change: 'added',
+      after,
+      bodyMetadata: [],
+      headers: [],
+      metadata: []
+    };
+  }
+  if (!before || !after) {
+    throw new Error('diffEvidenceItem called with invalid arguments');
+  }
+
+  const metadataChanges = diffLabels(before.metadata, after.metadata);
+  const bodyMetadata: KeyChange[] = [];
+  const headers: KeyChange[] = [];
+  const metadata: KeyChange[] = [];
+
+  for (const change of metadataChanges) {
+    const category = classifyKeyChange(change);
+    if (category === 'header') {
+      headers.push(change);
+    } else if (category === 'body') {
+      bodyMetadata.push(change);
+    } else {
+      metadata.push(change);
+    }
+  }
+
+  const bodyBefore = before.evidence ?? '';
+  const bodyAfter = after.evidence ?? '';
+  const bodyChanged = bodyBefore !== bodyAfter;
+
+  return {
+    key,
+    plugin: after.plugin,
+    type: after.type,
+    change: metadataChanges.length > 0 || bodyChanged || before.message !== after.message ? 'changed' : 'unchanged',
+    before,
+    after,
+    bodyText: bodyChanged
+      ? {
+          before: bodyBefore,
+          after: bodyAfter,
+          changed: true
+        }
+      : undefined,
+    bodyMetadata,
+    headers,
+    metadata
+  };
+}
+
+function matchEvidence(list: CaseRecord['evidence']): Map<string, CaseRecord['evidence'][number]> {
+  const counts = new Map<string, number>();
+  const map = new Map<string, CaseRecord['evidence'][number]>();
+  list.forEach((item) => {
+    const baseKey = `${item.plugin}|${item.type}`;
+    const index = (counts.get(baseKey) ?? 0) + 1;
+    counts.set(baseKey, index);
+    map.set(`${baseKey}#${index}`, item);
+  });
+  return map;
+}
+
+function computeEvidenceDiff(
+  before: CaseRecord['evidence'] | undefined,
+  after: CaseRecord['evidence'] | undefined
+): EvidenceDiff[] {
+  const leftMap = matchEvidence(before ?? []);
+  const leftCounts = new Map<string, number>();
+  (before ?? []).forEach((item) => {
+    const key = `${item.plugin}|${item.type}`;
+    leftCounts.set(key, (leftCounts.get(key) ?? 0) + 1);
+  });
+
+  const rightCounts = new Map<string, number>();
+  const changes: EvidenceDiff[] = [];
+  (after ?? []).forEach((item) => {
+    const baseKey = `${item.plugin}|${item.type}`;
+    const index = (rightCounts.get(baseKey) ?? 0) + 1;
+    rightCounts.set(baseKey, index);
+    const composite = `${baseKey}#${index}`;
+    const previous = leftMap.get(composite);
+    changes.push(diffEvidenceItem(previous, item, composite));
+    if (previous) {
+      leftMap.delete(composite);
+    }
+  });
+
+  for (const [key, remaining] of leftMap.entries()) {
+    changes.push(diffEvidenceItem(remaining, undefined, key));
+  }
+
+  return changes.filter((entry) => entry.change !== 'unchanged');
+}
+
+function mapSeverity(value: string | undefined): CaseSeverity {
+  const normalized = value?.trim().toLowerCase();
+  switch (normalized) {
+    case 'critical':
+    case 'crit':
+      return 'critical';
+    case 'high':
+      return 'high';
+    case 'medium':
+    case 'med':
+      return 'medium';
+    case 'low':
+      return 'low';
+    default:
+      return 'informational';
+  }
+}
+
+export function severityToSarifLevel(severity: CaseSeverity): 'error' | 'warning' | 'note' {
+  switch (severity) {
+    case 'critical':
+    case 'high':
+      return 'error';
+    case 'medium':
+      return 'warning';
+    default:
+      return 'note';
+  }
+}
+
+export function computeCaseDiff(baseline: CaseSnapshot, target: CaseSnapshot): CaseDiffSummary {
+  const baselineMap = new Map(baseline.cases.map((item) => [item.id, item] as const));
+  const targetMap = new Map(target.cases.map((item) => [item.id, item] as const));
+
+  const added: CaseRecord[] = [];
+  const removed: CaseRecord[] = [];
+  const changed: CaseChange[] = [];
+
+  for (const [id, before] of baselineMap.entries()) {
+    const current = targetMap.get(id);
+    if (!current) {
+      removed.push(before);
+      continue;
+    }
+    if (casesEqual(before, current)) {
+      continue;
+    }
+
+    const summaryChanged = before.summary !== current.summary;
+    const confidenceChanged = before.confidence !== current.confidence;
+    const riskChanged =
+      before.risk?.severity !== current.risk?.severity || before.risk?.score !== current.risk?.score;
+    const labelsChanged = diffLabels(before.labels, current.labels);
+    const evidenceDiff = computeEvidenceDiff(before.evidence, current.evidence);
+
+    const changedFields: string[] = [];
+    if (summaryChanged) changedFields.push('summary');
+    if (confidenceChanged) changedFields.push('confidence');
+    if (riskChanged) changedFields.push('risk');
+    if (labelsChanged.length > 0) changedFields.push('labels');
+    if (evidenceDiff.length > 0) changedFields.push('evidence');
+
+    changed.push({
+      id,
+      titleBefore: before.summary,
+      titleAfter: current.summary,
+      severityBefore: before.risk?.severity ?? 'informational',
+      severityAfter: current.risk?.severity ?? 'informational',
+      before,
+      after: current,
+      summaryChanged,
+      confidenceChanged,
+      riskChanged,
+      labelsChanged,
+      evidenceDiff,
+      changedFields
+    });
+  }
+
+  for (const [id, current] of targetMap.entries()) {
+    if (!baselineMap.has(id)) {
+      added.push(current);
+    }
+  }
+
+  const { cases: _baselineCases, ...baselineSummary } = baseline;
+  const { cases: _targetCases, ...targetSummary } = target;
+
+  return {
+    baseline: baselineSummary,
+    target: targetSummary,
+    added,
+    removed,
+    changed
+  };
+}
+
+function simplifyCase(caseRecord: CaseRecord) {
+  return {
+    id: caseRecord.id,
+    summary: caseRecord.summary,
+    severity: caseRecord.risk?.severity ?? 'informational',
+    asset: caseRecord.asset,
+    confidence: caseRecord.confidence,
+    labels: caseRecord.labels,
+    evidence: caseRecord.evidence
+  };
+}
+
+export function buildCaseDiffJson(diff: CaseDiffSummary) {
+  return {
+    baseline: diff.baseline,
+    target: diff.target,
+    summary: {
+      added: diff.added.length,
+      removed: diff.removed.length,
+      changed: diff.changed.length
+    },
+    added: diff.added.map(simplifyCase),
+    removed: diff.removed.map(simplifyCase),
+    changed: diff.changed.map((entry) => ({
+      id: entry.id,
+      changedFields: entry.changedFields,
+      before: simplifyCase(entry.before),
+      after: simplifyCase(entry.after),
+      evidenceDiff: entry.evidenceDiff.map((item) => ({
+        plugin: item.plugin,
+        type: item.type,
+        change: item.change,
+        bodyText: item.bodyText,
+        bodyMetadata: item.bodyMetadata,
+        headers: item.headers,
+        metadata: item.metadata
+      }))
+    }))
+  };
+}
+
+export function buildCaseDiffSarif(diff: CaseDiffSummary) {
+  const results = [
+    ...diff.added.map((entry) => ({
+      ruleId: entry.id,
+      level: severityToSarifLevel(mapSeverity(entry.risk?.severity)),
+      message: { text: `New case detected: ${entry.summary}` },
+      properties: {
+        changeType: 'added',
+        asset: entry.asset?.identifier ?? entry.asset?.details ?? 'unknown'
+      }
+    })),
+    ...diff.removed.map((entry) => ({
+      ruleId: entry.id,
+      level: 'note' as const,
+      message: { text: `Case resolved: ${entry.summary}` },
+      properties: {
+        changeType: 'removed',
+        asset: entry.asset?.identifier ?? entry.asset?.details ?? 'unknown'
+      }
+    })),
+    ...diff.changed.map((entry) => ({
+      ruleId: entry.id,
+      level: severityToSarifLevel(mapSeverity(entry.after.risk?.severity ?? entry.before.risk?.severity)),
+      message: {
+        text:
+          entry.changedFields.length === 0
+            ? 'Case updated'
+            : `Case updated (${entry.changedFields.join(', ')})`
+      },
+      properties: {
+        changeType: 'changed',
+        changedFields: entry.changedFields
+      }
+    }))
+  ];
+
+  return {
+    version: '2.1.0',
+    $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
+    runs: [
+      {
+        tool: {
+          driver: {
+            name: '0xgen Case Diff Viewer',
+            informationUri: 'https://0xgen.sh'
+          }
+        },
+        results
+      }
+    ]
+  } as const;
+}

--- a/apps/desktop-shell/src/routeTree.gen.ts
+++ b/apps/desktop-shell/src/routeTree.gen.ts
@@ -11,9 +11,10 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ScopeRouteImport } from './routes/scope'
 import { Route as RunsRouteImport } from './routes/runs'
-import { Route as FlowsRouteImport } from './routes/flows'
-import { Route as CasesRouteImport } from './routes/cases'
 import { Route as PluginsRouteImport } from './routes/plugins'
+import { Route as FlowsRouteImport } from './routes/flows'
+import { Route as CompareRouteImport } from './routes/compare'
+import { Route as CasesRouteImport } from './routes/cases'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as RunsComposerRouteImport } from './routes/runs.composer'
 import { Route as RunsRunIdRouteImport } from './routes/runs.$runId'
@@ -28,19 +29,24 @@ const RunsRoute = RunsRouteImport.update({
   path: '/runs',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PluginsRoute = PluginsRouteImport.update({
+  id: '/plugins',
+  path: '/plugins',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const FlowsRoute = FlowsRouteImport.update({
   id: '/flows',
   path: '/flows',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CompareRoute = CompareRouteImport.update({
+  id: '/compare',
+  path: '/compare',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CasesRoute = CasesRouteImport.update({
   id: '/cases',
   path: '/cases',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const PluginsRoute = PluginsRouteImport.update({
-  id: '/plugins',
-  path: '/plugins',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -62,6 +68,7 @@ const RunsRunIdRoute = RunsRunIdRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/cases': typeof CasesRoute
+  '/compare': typeof CompareRoute
   '/flows': typeof FlowsRoute
   '/plugins': typeof PluginsRoute
   '/runs': typeof RunsRouteWithChildren
@@ -72,6 +79,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/cases': typeof CasesRoute
+  '/compare': typeof CompareRoute
   '/flows': typeof FlowsRoute
   '/plugins': typeof PluginsRoute
   '/runs': typeof RunsRouteWithChildren
@@ -83,6 +91,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/cases': typeof CasesRoute
+  '/compare': typeof CompareRoute
   '/flows': typeof FlowsRoute
   '/plugins': typeof PluginsRoute
   '/runs': typeof RunsRouteWithChildren
@@ -95,6 +104,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/cases'
+    | '/compare'
     | '/flows'
     | '/plugins'
     | '/runs'
@@ -105,6 +115,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/cases'
+    | '/compare'
     | '/flows'
     | '/plugins'
     | '/runs'
@@ -115,6 +126,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/cases'
+    | '/compare'
     | '/flows'
     | '/plugins'
     | '/runs'
@@ -126,6 +138,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   CasesRoute: typeof CasesRoute
+  CompareRoute: typeof CompareRoute
   FlowsRoute: typeof FlowsRoute
   PluginsRoute: typeof PluginsRoute
   RunsRoute: typeof RunsRouteWithChildren
@@ -148,6 +161,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof RunsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/plugins': {
+      id: '/plugins'
+      path: '/plugins'
+      fullPath: '/plugins'
+      preLoaderRoute: typeof PluginsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/flows': {
       id: '/flows'
       path: '/flows'
@@ -155,18 +175,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof FlowsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/compare': {
+      id: '/compare'
+      path: '/compare'
+      fullPath: '/compare'
+      preLoaderRoute: typeof CompareRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/cases': {
       id: '/cases'
       path: '/cases'
       fullPath: '/cases'
       preLoaderRoute: typeof CasesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/plugins': {
-      id: '/plugins'
-      path: '/plugins'
-      fullPath: '/plugins'
-      preLoaderRoute: typeof PluginsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -208,7 +228,9 @@ const RunsRouteWithChildren = RunsRoute._addFileChildren(RunsRouteChildren)
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CasesRoute: CasesRoute,
+  CompareRoute: CompareRoute,
   FlowsRoute: FlowsRoute,
+  PluginsRoute: PluginsRoute,
   RunsRoute: RunsRouteWithChildren,
   ScopeRoute: ScopeRoute,
 }

--- a/apps/desktop-shell/src/routes/__root.tsx
+++ b/apps/desktop-shell/src/routes/__root.tsx
@@ -21,6 +21,7 @@ const navigation = [
   { to: '/', label: 'Dashboard' },
   { to: '/flows', label: 'Flows' },
   { to: '/runs', label: 'Runs' },
+  { to: '/compare', label: 'Compare Runs' },
   { to: '/cases', label: 'Cases' },
   { to: '/scope', label: 'Scope' },
   { to: '/plugins', label: 'Marketplace' }

--- a/apps/desktop-shell/src/routes/compare.tsx
+++ b/apps/desktop-shell/src/routes/compare.tsx
@@ -1,0 +1,593 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useCallback, useEffect, useMemo, useState, useTransition } from 'react';
+import { Download, RefreshCw, Trash2, Camera, AlertTriangle, CheckCircle2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '../components/ui/button';
+import { cn } from '../lib/utils';
+import {
+  captureCaseSnapshot,
+  deleteCaseSnapshot,
+  listCaseSnapshots,
+  loadCaseSnapshot,
+  type CaseRecord,
+  type CaseSnapshot,
+  type CaseSnapshotSummary
+} from '../lib/ipc';
+import {
+  buildCaseDiffJson,
+  buildCaseDiffSarif,
+  computeCaseDiff,
+  type CaseChange,
+  type CaseDiffSummary,
+  type EvidenceDiff,
+  type KeyChange
+} from '../lib/case-diff';
+
+function formatDate(value: string) {
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return value;
+  }
+}
+
+function formatConfidenceValue(value: number | undefined) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '0%';
+  }
+  if (value > 1) {
+    const bounded = Math.max(0, Math.min(100, value));
+    return `${bounded.toFixed(0)}%`;
+  }
+  const percentage = Math.max(0, Math.min(1, value)) * 100;
+  return `${percentage.toFixed(0)}%`;
+}
+
+function downloadFile(filename: string, mime: string, data: string) {
+  const blob = new Blob([data], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+function SnapshotList({
+  snapshots,
+  selectedBaseline,
+  selectedTarget,
+  onBaselineChange,
+  onTargetChange,
+  onDelete
+}: {
+  snapshots: CaseSnapshotSummary[];
+  selectedBaseline: string;
+  selectedTarget: string;
+  onBaselineChange: (id: string) => void;
+  onTargetChange: (id: string) => void;
+  onDelete: (id: string) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="font-medium text-muted-foreground">Baseline snapshot</span>
+          <select
+            value={selectedBaseline}
+            onChange={(event) => onBaselineChange(event.target.value)}
+            className="rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          >
+            <option value="">Select baseline…</option>
+            {snapshots.map((snapshot) => (
+              <option key={`baseline-${snapshot.id}`} value={snapshot.id}>
+                {formatDate(snapshot.capturedAt)} • {snapshot.caseCount} cases
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="font-medium text-muted-foreground">Target snapshot</span>
+          <select
+            value={selectedTarget}
+            onChange={(event) => onTargetChange(event.target.value)}
+            className="rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          >
+            <option value="">Select target…</option>
+            {snapshots.map((snapshot) => (
+              <option key={`target-${snapshot.id}`} value={snapshot.id}>
+                {formatDate(snapshot.capturedAt)} • {snapshot.caseCount} cases
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="rounded-lg border border-border">
+        <div className="border-b border-border px-4 py-3 text-sm font-semibold uppercase text-muted-foreground">
+          Stored snapshots
+        </div>
+        <ul className="divide-y divide-border">
+          {snapshots.map((snapshot) => (
+            <li key={snapshot.id} className="flex items-start justify-between gap-4 px-4 py-3 text-sm">
+              <div className="space-y-1">
+                <p className="font-semibold text-foreground">{snapshot.label}</p>
+                <p className="text-muted-foreground">
+                  Captured {formatDate(snapshot.capturedAt)} • {snapshot.caseCount}{' '}
+                  {snapshot.caseCount === 1 ? 'case' : 'cases'}
+                </p>
+                <p className="text-xs text-muted-foreground">Hash {snapshot.hash}</p>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-muted-foreground hover:text-destructive"
+                onClick={() => onDelete(snapshot.id)}
+                title="Delete snapshot"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </li>
+          ))}
+          {snapshots.length === 0 && (
+            <li className="px-4 py-6 text-sm text-muted-foreground">No snapshots captured yet.</li>
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function SummaryStat({ label, value, tone }: { label: string; value: number; tone: 'neutral' | 'positive' | 'negative' }) {
+  const toneClasses =
+    tone === 'positive'
+      ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-500'
+      : tone === 'negative'
+        ? 'border-red-500/40 bg-red-500/10 text-red-500'
+        : 'border-border bg-muted/50 text-muted-foreground';
+  return (
+    <div className={cn('rounded-lg border px-4 py-3 text-center', toneClasses)}>
+      <p className="text-xs font-semibold uppercase tracking-wide">{label}</p>
+      <p className="mt-1 text-2xl font-semibold">{value}</p>
+    </div>
+  );
+}
+
+function KeyChangeList({ title, items }: { title: string; items: KeyChange[] }) {
+  if (items.length === 0) {
+    return null;
+  }
+  return (
+    <div className="space-y-2">
+      <p className="text-xs font-semibold uppercase text-muted-foreground">{title}</p>
+      <div className="overflow-hidden rounded-md border border-border">
+        <table className="w-full table-auto text-xs">
+          <thead className="bg-muted/60 text-left font-semibold text-muted-foreground">
+            <tr>
+              <th className="px-3 py-2">Key</th>
+              <th className="px-3 py-2">Previous</th>
+              <th className="px-3 py-2">Current</th>
+              <th className="px-3 py-2">Change</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {items.map((item) => (
+              <tr key={`${title}-${item.key}`}>
+                <td className="px-3 py-2 font-medium">{item.key}</td>
+                <td className="px-3 py-2 text-muted-foreground">{item.before ?? '∅'}</td>
+                <td className="px-3 py-2 text-foreground">{item.after ?? '∅'}</td>
+                <td className="px-3 py-2 capitalize text-muted-foreground">{item.change}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function EvidenceDiffCard({ diff }: { diff: EvidenceDiff }) {
+  const changeTone =
+    diff.change === 'added'
+      ? 'text-emerald-500'
+      : diff.change === 'removed'
+        ? 'text-red-500'
+        : diff.change === 'changed'
+          ? 'text-amber-500'
+          : 'text-muted-foreground';
+  return (
+    <div className="space-y-3 rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-semibold text-foreground">
+            {diff.plugin} <span className="text-muted-foreground">({diff.type})</span>
+          </p>
+          <p className={cn('text-xs font-semibold uppercase', changeTone)}>{diff.change}</p>
+        </div>
+      </div>
+      {diff.bodyText && (
+        <div>
+          <p className="text-xs font-semibold uppercase text-muted-foreground">Body</p>
+          <div className="grid gap-3 lg:grid-cols-2">
+            <pre className="max-h-56 overflow-auto rounded bg-muted/60 p-3 text-xs text-muted-foreground">
+              {diff.bodyText.before || '∅'}
+            </pre>
+            <pre className="max-h-56 overflow-auto rounded bg-muted/60 p-3 text-xs text-foreground">
+              {diff.bodyText.after || '∅'}
+            </pre>
+          </div>
+        </div>
+      )}
+      <KeyChangeList title="Body metadata" items={diff.bodyMetadata} />
+      <KeyChangeList title="Headers" items={diff.headers} />
+      <KeyChangeList title="Metadata" items={diff.metadata} />
+    </div>
+  );
+}
+
+function CaseSummaryPanel({ title, caseRecord }: { title: string; caseRecord: CaseRecord }) {
+  return (
+    <div className="space-y-3 rounded-lg border border-border bg-card p-4">
+      <div>
+        <p className="text-xs font-semibold uppercase text-muted-foreground">{title}</p>
+        <h3 className="text-lg font-semibold text-foreground">{caseRecord.summary}</h3>
+      </div>
+      <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+        <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-1">
+          <AlertTriangle className="h-3.5 w-3.5" />
+          Severity {caseRecord.risk?.severity ?? 'informational'}
+        </span>
+        <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-1">
+          <CheckCircle2 className="h-3.5 w-3.5" />
+          Confidence {formatConfidenceValue(caseRecord.confidence)}
+        </span>
+      </div>
+      <div className="space-y-1 text-sm text-muted-foreground">
+        <p>
+          <span className="font-semibold text-foreground">Asset:</span> {caseRecord.asset.kind} · {caseRecord.asset.identifier}
+        </p>
+        {caseRecord.labels && Object.keys(caseRecord.labels).length > 0 && (
+          <p>
+            <span className="font-semibold text-foreground">Labels:</span>{' '}
+            {Object.entries(caseRecord.labels)
+              .map(([key, value]) => (value ? `${key}:${value}` : key))
+              .join(', ')}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CaseChangeDetail({ change }: { change: CaseChange }) {
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={change.id}
+        initial={{ opacity: 0, x: -16 }}
+        animate={{ opacity: 1, x: 0 }}
+        exit={{ opacity: 0, x: 16 }}
+        transition={{ duration: 0.2 }}
+        className="space-y-6"
+      >
+        <div className="grid gap-4 lg:grid-cols-2">
+          <CaseSummaryPanel title="Baseline" caseRecord={change.before} />
+          <CaseSummaryPanel title="Target" caseRecord={change.after} />
+        </div>
+        <div className="space-y-4">
+          {change.evidenceDiff.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Evidence unchanged between snapshots.</p>
+          ) : (
+            change.evidenceDiff.map((diff) => <EvidenceDiffCard key={diff.key} diff={diff} />)
+          )}
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}
+
+function CompareRunsRoute() {
+  const [snapshots, setSnapshots] = useState<CaseSnapshotSummary[]>([]);
+  const [baseline, setBaseline] = useState<CaseSnapshot | null>(null);
+  const [target, setTarget] = useState<CaseSnapshot | null>(null);
+  const [selectedBaselineId, setSelectedBaselineId] = useState('');
+  const [selectedTargetId, setSelectedTargetId] = useState('');
+  const [activeChangeId, setActiveChangeId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadingSnapshots, setLoadingSnapshots] = useState(false);
+  const [isCapturing, startCapture] = useTransition();
+
+  const refreshSnapshots = useCallback(() => {
+    setLoading(true);
+    listCaseSnapshots()
+      .then((list) => {
+        setSnapshots(list);
+        setLoading(false);
+      })
+      .catch((error) => {
+        console.error('Failed to list case snapshots', error);
+        toast.error('Unable to load stored snapshots');
+        setLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    refreshSnapshots();
+  }, [refreshSnapshots]);
+
+  useEffect(() => {
+    if (!selectedBaselineId) {
+      setBaseline(null);
+      return;
+    }
+    setLoadingSnapshots(true);
+    loadCaseSnapshot(selectedBaselineId)
+      .then(setBaseline)
+      .catch((error) => {
+        console.error('Failed to load baseline snapshot', error);
+        toast.error('Unable to load baseline snapshot');
+        setBaseline(null);
+      })
+      .finally(() => setLoadingSnapshots(false));
+  }, [selectedBaselineId]);
+
+  useEffect(() => {
+    if (!selectedTargetId) {
+      setTarget(null);
+      return;
+    }
+    setLoadingSnapshots(true);
+    loadCaseSnapshot(selectedTargetId)
+      .then(setTarget)
+      .catch((error) => {
+        console.error('Failed to load target snapshot', error);
+        toast.error('Unable to load target snapshot');
+        setTarget(null);
+      })
+      .finally(() => setLoadingSnapshots(false));
+  }, [selectedTargetId]);
+
+  const diff = useMemo<CaseDiffSummary | null>(() => {
+    if (!baseline || !target) {
+      return null;
+    }
+    try {
+      return computeCaseDiff(baseline, target);
+    } catch (error) {
+      console.error('Failed to compute case diff', error);
+      toast.error('Unable to compute diff');
+      return null;
+    }
+  }, [baseline, target]);
+
+  useEffect(() => {
+    if (!diff) {
+      setActiveChangeId(null);
+      return;
+    }
+    if (diff.changed.length > 0) {
+      setActiveChangeId(diff.changed[0].id);
+    } else {
+      setActiveChangeId(null);
+    }
+  }, [diff?.baseline.id, diff?.target.id, diff?.changed.length]);
+
+  const activeChange = useMemo(() => diff?.changed.find((item) => item.id === activeChangeId) ?? null, [diff, activeChangeId]);
+
+  const handleCapture = useCallback(() => {
+    startCapture(() => {
+      captureCaseSnapshot()
+        .then((snapshot) => {
+          toast.success(`Captured snapshot with ${snapshot.caseCount} cases`);
+          refreshSnapshots();
+        })
+        .catch((error) => {
+          console.error('Failed to capture snapshot', error);
+          toast.error('Unable to capture snapshot (load an artifact first)');
+        });
+    });
+  }, [refreshSnapshots]);
+
+  const handleDelete = useCallback(
+    (id: string) => {
+      deleteCaseSnapshot(id)
+        .then(() => {
+          toast.success('Snapshot deleted');
+          if (selectedBaselineId === id) {
+            setSelectedBaselineId('');
+          }
+          if (selectedTargetId === id) {
+            setSelectedTargetId('');
+          }
+          refreshSnapshots();
+        })
+        .catch((error) => {
+          console.error('Failed to delete snapshot', error);
+          toast.error('Unable to delete snapshot');
+        });
+    },
+    [refreshSnapshots, selectedBaselineId, selectedTargetId]
+  );
+
+  const handleExport = useCallback(
+    (format: 'json' | 'sarif') => {
+      if (!diff) {
+        return;
+      }
+      try {
+        if (format === 'json') {
+          const payload = buildCaseDiffJson(diff);
+          downloadFile('case-diff.json', 'application/json', JSON.stringify(payload, null, 2));
+          toast.success('Exported diff as JSON');
+        } else {
+          const payload = buildCaseDiffSarif(diff);
+          downloadFile('case-diff.sarif', 'application/json', JSON.stringify(payload, null, 2));
+          toast.success('Exported diff as SARIF');
+        }
+      } catch (error) {
+        console.error('Failed to export diff', error);
+        toast.error('Unable to export diff');
+      }
+    },
+    [diff]
+  );
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">Compare Runs</h1>
+          <p className="text-muted-foreground">
+            Capture case snapshots and highlight what changed between investigation runs.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" className="gap-2" onClick={refreshSnapshots} disabled={loading}>
+            <RefreshCw className={cn('h-4 w-4', loading && 'animate-spin')} />
+            Refresh
+          </Button>
+          <Button className="gap-2" onClick={handleCapture} disabled={isCapturing}>
+            <Camera className={cn('h-4 w-4', isCapturing && 'animate-spin')} />
+            Capture snapshot
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+        <SnapshotList
+          snapshots={snapshots}
+          selectedBaseline={selectedBaselineId}
+          selectedTarget={selectedTargetId}
+          onBaselineChange={setSelectedBaselineId}
+          onTargetChange={setSelectedTargetId}
+          onDelete={handleDelete}
+        />
+
+        <div className="flex flex-col gap-4 rounded-lg border border-border bg-card p-5">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-foreground">Diff overview</h2>
+              <p className="text-sm text-muted-foreground">
+                Select two snapshots to compute differences across cases.
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="secondary"
+                className="gap-2"
+                disabled={!diff || loadingSnapshots}
+                onClick={() => handleExport('json')}
+              >
+                <Download className="h-4 w-4" /> JSON
+              </Button>
+              <Button
+                variant="secondary"
+                className="gap-2"
+                disabled={!diff || loadingSnapshots}
+                onClick={() => handleExport('sarif')}
+              >
+                <Download className="h-4 w-4" /> SARIF
+              </Button>
+            </div>
+          </div>
+
+          {!diff && (
+            <div className="rounded-md border border-dashed border-border bg-background p-6 text-center text-sm text-muted-foreground">
+              Select a baseline and target snapshot to view the diff.
+            </div>
+          )}
+
+          {diff && (
+            <div className="space-y-6">
+              <div className="grid gap-3 sm:grid-cols-3">
+                <SummaryStat label="New cases" value={diff.added.length} tone="positive" />
+                <SummaryStat label="Resolved" value={diff.removed.length} tone="negative" />
+                <SummaryStat label="Updated" value={diff.changed.length} tone="neutral" />
+              </div>
+
+              <div className="space-y-4">
+                <div>
+                  <h3 className="text-sm font-semibold uppercase text-muted-foreground">New cases</h3>
+                  {diff.added.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">No new cases introduced.</p>
+                  ) : (
+                    <ul className="space-y-2 text-sm">
+                      {diff.added.map((item) => (
+                        <li key={`added-${item.id}`} className="rounded-md border border-emerald-500/40 bg-emerald-500/10 p-3">
+                          <p className="font-semibold text-emerald-600">{item.summary}</p>
+                          <p className="text-xs text-emerald-600/80">Severity {item.risk?.severity ?? 'informational'}</p>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+                <div>
+                  <h3 className="text-sm font-semibold uppercase text-muted-foreground">Resolved cases</h3>
+                  {diff.removed.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">No cases resolved.</p>
+                  ) : (
+                    <ul className="space-y-2 text-sm">
+                      {diff.removed.map((item) => (
+                        <li key={`removed-${item.id}`} className="rounded-md border border-red-500/40 bg-red-500/10 p-3">
+                          <p className="font-semibold text-red-600">{item.summary}</p>
+                          <p className="text-xs text-red-600/80">Severity {item.risk?.severity ?? 'informational'}</p>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-semibold uppercase text-muted-foreground">Updated cases</h3>
+                  <span className="text-xs text-muted-foreground">
+                    {diff.changed.length === 0 ? 'None' : `${diff.changed.length} case(s) updated`}
+                  </span>
+                </div>
+                {diff.changed.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No existing cases changed.</p>
+                ) : (
+                  <div className="grid gap-4 lg:grid-cols-[220px_1fr]">
+                    <div className="space-y-2">
+                      {diff.changed.map((change) => (
+                        <button
+                          key={change.id}
+                          type="button"
+                          onClick={() => setActiveChangeId(change.id)}
+                          className={cn(
+                            'w-full rounded-md border px-3 py-2 text-left text-sm transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+                            activeChangeId === change.id ? 'border-primary bg-primary/10 text-primary' : 'border-border'
+                          )}
+                        >
+                          <p className="font-semibold">{change.after.summary}</p>
+                          <p className="text-xs text-muted-foreground">{change.changedFields.join(', ') || 'Minor updates'}</p>
+                        </button>
+                      ))}
+                    </div>
+                    <div className="min-h-[320px] rounded-lg border border-border bg-background p-4">
+                      {activeChange ? (
+                        <CaseChangeDetail change={activeChange} />
+                      ) : (
+                        <p className="text-sm text-muted-foreground">Select a case to inspect detailed changes.</p>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const Route = createFileRoute('/compare')({
+  component: CompareRunsRoute
+});
+
+export default CompareRunsRoute;


### PR DESCRIPTION
## Summary
- add a snapshot store in the Tauri backend that hashes case lists, persists them, and exposes capture/list/load/delete commands
- extend the desktop IPC layer with snapshot schemas plus diff helpers, and generate stable hashes for comparison exports
- implement a new Compare Runs route with a split-pane Framer Motion diff viewer and JSON/SARIF export actions, and surface it in navigation

## Testing
- pnpm --dir apps/desktop-shell run build

------
https://chatgpt.com/codex/tasks/task_e_68fe627cd3ec832ab5c61f7608b68583