### PR TITLE
Add CLI verification for signed reports

### DIFF
--- a/cmd/0xgenctl/main.go
+++ b/cmd/0xgenctl/main.go
@@ -41,6 +41,8 @@ func main() {
 	switch args[0] {
 	case "report":
 		os.Exit(runReport(args[1:]))
+	case "verify-report":
+		os.Exit(runVerifyReport(args[1:]))
 	case "demo":
 		os.Exit(runDemo(args[1:]))
 	case "findings":
@@ -51,42 +53,42 @@ func main() {
 		os.Exit(runOSINTWell(args[1:]))
 	case "rank":
 		os.Exit(runRank(args[1:]))
-        case "config":
-                os.Exit(runConfig(args[1:]))
-        case "api-token":
-                if len(args) < 2 {
-                        fmt.Fprintln(os.Stderr, "api-token subcommand required")
-                        os.Exit(2)
-                }
-                switch args[1] {
-                case "new":
-                        os.Exit(runAPITokenNew(args[2:]))
-                default:
-                        fmt.Fprintf(os.Stderr, "unknown api-token subcommand: %s\n", args[1])
-                        os.Exit(2)
-                }
-        case "scope":
-                os.Exit(runScope(args[1:]))
-        case "plugin":
-                if len(args) < 2 {
-                        fmt.Fprintln(os.Stderr, "plugin subcommand required")
-                        os.Exit(2)
-                }
-                switch args[1] {
-                case "run":
-                        os.Exit(runPluginRun(args[2:]))
-                case "verify":
-                        os.Exit(runPluginVerify(args[2:]))
-                case "registry":
-                        os.Exit(runPluginRegistry(args[2:]))
-                case "install":
-                        os.Exit(runPluginInstall(args[2:]))
-                case "remove":
-                        os.Exit(runPluginRemove(args[2:]))
-                default:
-                        fmt.Fprintf(os.Stderr, "unknown plugin subcommand: %s\n", args[1])
-                        os.Exit(2)
-                }
+	case "config":
+		os.Exit(runConfig(args[1:]))
+	case "api-token":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "api-token subcommand required")
+			os.Exit(2)
+		}
+		switch args[1] {
+		case "new":
+			os.Exit(runAPITokenNew(args[2:]))
+		default:
+			fmt.Fprintf(os.Stderr, "unknown api-token subcommand: %s\n", args[1])
+			os.Exit(2)
+		}
+	case "scope":
+		os.Exit(runScope(args[1:]))
+	case "plugin":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "plugin subcommand required")
+			os.Exit(2)
+		}
+		switch args[1] {
+		case "run":
+			os.Exit(runPluginRun(args[2:]))
+		case "verify":
+			os.Exit(runPluginVerify(args[2:]))
+		case "registry":
+			os.Exit(runPluginRegistry(args[2:]))
+		case "install":
+			os.Exit(runPluginInstall(args[2:]))
+		case "remove":
+			os.Exit(runPluginRemove(args[2:]))
+		default:
+			fmt.Fprintf(os.Stderr, "unknown plugin subcommand: %s\n", args[1])
+			os.Exit(2)
+		}
 	case "raider":
 		os.Exit(runRaider(args[1:]))
 	case "history":

--- a/cmd/0xgenctl/verify_report.go
+++ b/cmd/0xgenctl/verify_report.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/RowanDark/0xgen/internal/reporter"
+)
+
+func runVerifyReport(args []string) int {
+	fs := flag.NewFlagSet("verify-report", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	signature := fs.String("signature", "", "path to detached signature (defaults to <report>.sig)")
+	key := fs.String("key", "", "path to cosign public key")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	remaining := fs.Args()
+	if len(remaining) == 0 {
+		fmt.Fprintln(os.Stderr, "report path is required")
+		return 2
+	}
+
+	artifactPath := strings.TrimSpace(remaining[0])
+	if artifactPath == "" {
+		fmt.Fprintln(os.Stderr, "report path is required")
+		return 2
+	}
+
+	signaturePath := strings.TrimSpace(*signature)
+	if signaturePath == "" {
+		signaturePath = artifactPath + ".sig"
+	}
+	if !filepath.IsAbs(signaturePath) {
+		signaturePath = filepath.Clean(signaturePath)
+	}
+
+	keyPath := strings.TrimSpace(*key)
+	if keyPath == "" {
+		fmt.Fprintln(os.Stderr, "--key is required")
+		return 2
+	}
+
+	if err := reporter.VerifyArtifact(artifactPath, signaturePath, keyPath); err != nil {
+		fmt.Fprintf(os.Stderr, "verify report: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintln(os.Stdout, "Signature verified.")
+	return 0
+}

--- a/cmd/0xgenctl/verify_report_test.go
+++ b/cmd/0xgenctl/verify_report_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/RowanDark/0xgen/internal/reporter"
+)
+
+func TestRunVerifyReportSuccess(t *testing.T) {
+	restore := silenceOutput(t)
+	defer restore()
+
+	dir := t.TempDir()
+	artifact := filepath.Join(dir, "report.json")
+	if err := os.WriteFile(artifact, []byte(`{"schema_version":"1.0"}`), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pkcs8, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	privPath := filepath.Join(dir, "cosign.key")
+	if err := os.WriteFile(privPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	if _, err := reporter.SignArtifact(artifact, privPath); err != nil {
+		t.Fatalf("sign artifact: %v", err)
+	}
+
+	pubBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal public key: %v", err)
+	}
+	pubPath := filepath.Join(dir, "cosign.pub")
+	if err := os.WriteFile(pubPath, pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes}), 0o644); err != nil {
+		t.Fatalf("write public key: %v", err)
+	}
+
+	if code := runVerifyReport([]string{"--key", pubPath, artifact}); code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+}
+
+func TestRunVerifyReportMissingKey(t *testing.T) {
+	restore := silenceOutput(t)
+	defer restore()
+
+	if code := runVerifyReport([]string{"report.json"}); code != 2 {
+		t.Fatalf("expected exit code 2, got %d", code)
+	}
+}
+
+func TestRunVerifyReportDetectsTampering(t *testing.T) {
+	restore := silenceOutput(t)
+	defer restore()
+
+	dir := t.TempDir()
+	artifact := filepath.Join(dir, "report.json")
+	if err := os.WriteFile(artifact, []byte(`{"schema_version":"1.0"}`), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pkcs8, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	privPath := filepath.Join(dir, "cosign.key")
+	if err := os.WriteFile(privPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	if _, err := reporter.SignArtifact(artifact, privPath); err != nil {
+		t.Fatalf("sign artifact: %v", err)
+	}
+
+	if err := os.WriteFile(artifact, []byte(`{"schema_version":"2.0"}`), 0o644); err != nil {
+		t.Fatalf("tamper artifact: %v", err)
+	}
+
+	pubBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal public key: %v", err)
+	}
+	pubPath := filepath.Join(dir, "cosign.pub")
+	if err := os.WriteFile(pubPath, pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes}), 0o644); err != nil {
+		t.Fatalf("write public key: %v", err)
+	}
+
+	if code := runVerifyReport([]string{"--key", pubPath, artifact}); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+}

--- a/internal/reporter/sign_test.go
+++ b/internal/reporter/sign_test.go
@@ -62,3 +62,87 @@ func TestSignArtifactProducesValidSignature(t *testing.T) {
 		t.Fatalf("signature verification failed")
 	}
 }
+
+func TestVerifyArtifactValidSignature(t *testing.T) {
+	dir := t.TempDir()
+	artifactPath := filepath.Join(dir, "bundle.json")
+	if err := os.WriteFile(artifactPath, []byte(`{"schema_version":"1.0"}`), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	pkcs8, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	privPath := filepath.Join(dir, "sign.key")
+	if err := os.WriteFile(privPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	sigPath, err := SignArtifact(artifactPath, privPath)
+	if err != nil {
+		t.Fatalf("sign artifact: %v", err)
+	}
+
+	pubBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal public key: %v", err)
+	}
+	pubPath := filepath.Join(dir, "sign.pub")
+	if err := os.WriteFile(pubPath, pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes}), 0o644); err != nil {
+		t.Fatalf("write public key: %v", err)
+	}
+
+	if err := VerifyArtifact(artifactPath, sigPath, pubPath); err != nil {
+		t.Fatalf("verify artifact: %v", err)
+	}
+}
+
+func TestVerifyArtifactRejectsTampering(t *testing.T) {
+	dir := t.TempDir()
+	artifactPath := filepath.Join(dir, "bundle.json")
+	if err := os.WriteFile(artifactPath, []byte(`{"schema_version":"1.0"}`), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	pkcs8, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	privPath := filepath.Join(dir, "sign.key")
+	if err := os.WriteFile(privPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	sigPath, err := SignArtifact(artifactPath, privPath)
+	if err != nil {
+		t.Fatalf("sign artifact: %v", err)
+	}
+
+	if err := os.WriteFile(artifactPath, []byte(`{"schema_version":"2.0"}`), 0o644); err != nil {
+		t.Fatalf("tamper artifact: %v", err)
+	}
+
+	pubBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal public key: %v", err)
+	}
+	pubPath := filepath.Join(dir, "sign.pub")
+	if err := os.WriteFile(pubPath, pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes}), 0o644); err != nil {
+		t.Fatalf("write public key: %v", err)
+	}
+
+	if err := VerifyArtifact(artifactPath, sigPath, pubPath); err == nil {
+		t.Fatalf("expected verification failure for tampered artifact")
+	}
+}


### PR DESCRIPTION
## Summary
- allow HTML reports to be signed alongside JSON output
- add `verify-report` command for validating report signatures
- implement reusable signature verification helpers and unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fef0f1fe8c832aa9eb2966ec8c5b1b