### PR TITLE
Add team mode presets to desktop shell

### DIFF
--- a/apps/desktop-shell/src/components/mode-switcher.tsx
+++ b/apps/desktop-shell/src/components/mode-switcher.tsx
@@ -1,0 +1,56 @@
+import { useId } from 'react';
+
+import { cn } from '../lib/utils';
+import { useMode } from '../providers/mode-provider';
+
+export function ModeSwitcher() {
+  const { mode, setMode, options, config } = useMode();
+  const labelId = useId();
+  const descriptionId = useId();
+
+  return (
+    <div className="flex min-w-[14rem] flex-col gap-1 text-left">
+      <span
+        id={labelId}
+        className="text-[0.65rem] font-semibold uppercase tracking-wide text-muted-foreground"
+      >
+        Team mode
+      </span>
+      <div
+        role="radiogroup"
+        aria-labelledby={labelId}
+        aria-describedby={descriptionId}
+        className="flex items-center gap-1 rounded-lg border border-border/60 bg-background/60 p-1 shadow-sm"
+      >
+        {options.map((option) => {
+          const Icon = option.icon;
+          const isActive = option.value === mode;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={isActive}
+              className={cn(
+                'flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                isActive
+                  ? option.switcherActiveClass
+                  : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+              )}
+              onClick={() => setMode(option.value)}
+            >
+              <Icon
+                aria-hidden
+                className={cn('h-4 w-4', isActive ? option.switcherIconClass : 'text-muted-foreground')}
+              />
+              {option.shortLabel}
+            </button>
+          );
+        })}
+      </div>
+      <p id={descriptionId} className="text-[0.7rem] text-muted-foreground">
+        {config.description}
+      </p>
+    </div>
+  );
+}

--- a/apps/desktop-shell/src/main.tsx
+++ b/apps/desktop-shell/src/main.tsx
@@ -7,6 +7,7 @@ import { router } from './router';
 import { AppErrorBoundary } from './providers/error-boundary';
 import { Toaster } from './providers/toaster';
 import { ThemeProvider, bootstrapTheme } from './providers/theme-provider';
+import { ModeProvider } from './providers/mode-provider';
 import { ArtifactProvider } from './providers/artifact-provider';
 import { CommandCenterProvider } from './providers/command-center';
 import { FeedbackProvider } from './providers/feedback-provider';
@@ -25,22 +26,24 @@ if (!rootElement) {
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <ThemeProvider>
-      <CrashReporterProvider>
-        <AppErrorBoundary>
-          <ArtifactProvider>
-            <MetricsProvider>
-              <CommandCenterProvider>
-                <AboutProvider>
-                  <FeedbackProvider>
-                    <Toaster />
-                    <RouterProvider router={router} />
-                  </FeedbackProvider>
-                </AboutProvider>
-              </CommandCenterProvider>
-            </MetricsProvider>
-          </ArtifactProvider>
-        </AppErrorBoundary>
-      </CrashReporterProvider>
+      <ModeProvider>
+        <CrashReporterProvider>
+          <AppErrorBoundary>
+            <ArtifactProvider>
+              <MetricsProvider>
+                <CommandCenterProvider>
+                  <AboutProvider>
+                    <FeedbackProvider>
+                      <Toaster />
+                      <RouterProvider router={router} />
+                    </FeedbackProvider>
+                  </AboutProvider>
+                </CommandCenterProvider>
+              </MetricsProvider>
+            </ArtifactProvider>
+          </AppErrorBoundary>
+        </CrashReporterProvider>
+      </ModeProvider>
     </ThemeProvider>
   </React.StrictMode>,
 );

--- a/apps/desktop-shell/src/providers/mode-provider.tsx
+++ b/apps/desktop-shell/src/providers/mode-provider.tsx
@@ -1,0 +1,355 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+import { type ThemeName, useTheme } from './theme-provider';
+
+export type ModeName = 'red' | 'blue' | 'purple';
+
+export type ModeAction = {
+  id: string;
+  label: string;
+  to: string;
+  icon: LucideIcon;
+  variant?: 'default' | 'secondary' | 'outline';
+  className?: string;
+};
+
+export type ModeModule = {
+  id: string;
+  name: string;
+  focus: string;
+  description: string;
+  to: string;
+  icon: LucideIcon;
+  badgeClass: string;
+  iconClass: string;
+};
+
+export type ModeConfiguration = {
+  value: ModeName;
+  label: string;
+  shortLabel: string;
+  description: string;
+  theme: ThemeName;
+  icon: LucideIcon;
+  accentGradient: string;
+  switcherActiveClass: string;
+  switcherIconClass: string;
+  actions: ModeAction[];
+  modules: ModeModule[];
+};
+
+type ModeContextValue = {
+  mode: ModeName;
+  setMode: (mode: ModeName) => void;
+  options: readonly ModeConfiguration[];
+  config: ModeConfiguration;
+};
+
+const MODE_STORAGE_KEY = '0xgen.mode.presets';
+const DEFAULT_MODE: ModeName = 'purple';
+
+function isModeName(value: unknown): value is ModeName {
+  return value === 'red' || value === 'blue' || value === 'purple';
+}
+
+const ModeContext = createContext<ModeContextValue | undefined>(undefined);
+
+function getStoredMode(): ModeName {
+  if (typeof window === 'undefined') {
+    return DEFAULT_MODE;
+  }
+  try {
+    const stored = window.localStorage.getItem(MODE_STORAGE_KEY);
+    if (isModeName(stored)) {
+      return stored;
+    }
+  } catch (error) {
+    console.warn('Unable to read stored mode preference', error);
+  }
+  return DEFAULT_MODE;
+}
+
+export function ModeProvider({ children }: { children: ReactNode }) {
+  const [mode, setModeState] = useState<ModeName>(() => getStoredMode());
+  const { setTheme } = useTheme();
+
+  useEffect(() => {
+    const config = MODE_CONFIG_MAP[mode];
+    setTheme(config.theme);
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(MODE_STORAGE_KEY, mode);
+      } catch (error) {
+        console.warn('Unable to persist mode preference', error);
+      }
+    }
+  }, [mode, setTheme]);
+
+  const handleSetMode = useCallback((nextMode: ModeName) => {
+    setModeState((current) => {
+      if (current === nextMode) {
+        return current;
+      }
+      return nextMode;
+    });
+  }, []);
+
+  const value = useMemo<ModeContextValue>(
+    () => ({
+      mode,
+      setMode: handleSetMode,
+      options: MODE_OPTIONS,
+      config: MODE_CONFIG_MAP[mode]
+    }),
+    [handleSetMode, mode]
+  );
+
+  return <ModeContext.Provider value={value}>{children}</ModeContext.Provider>;
+}
+
+export function useMode() {
+  const context = useContext(ModeContext);
+  if (!context) {
+    throw new Error('useMode must be used within a ModeProvider');
+  }
+  return context;
+}
+
+// --- Mode configuration map -------------------------------------------------
+
+import {
+  Activity,
+  Bell,
+  Flame,
+  FlaskConical,
+  GitMerge,
+  Grid,
+  Play,
+  Radar,
+  Share2,
+  ShieldCheck,
+  Sparkles,
+  Swords,
+  Workflow
+} from 'lucide-react';
+
+const MODE_OPTIONS = [
+  {
+    value: 'red',
+    label: 'Red team mode',
+    shortLabel: 'Red',
+    description: 'Offensive operations with aggressive tooling front and center.',
+    theme: 'red',
+    icon: Flame,
+    accentGradient: 'from-rose-500/90 via-red-500/85 to-orange-500/85',
+    switcherActiveClass:
+      'bg-gradient-to-r from-rose-500/90 via-red-500/90 to-orange-500/90 text-white shadow-lg ring-1 ring-rose-400/50',
+    switcherIconClass: 'text-white',
+    actions: [
+      {
+        id: 'launch-run',
+        label: 'Launch offensive run',
+        to: '/runs/composer',
+        icon: Play,
+        className:
+          'bg-gradient-to-r from-rose-500 via-red-500 to-orange-500 text-white shadow-lg ring-1 ring-rose-400/50 hover:from-rose-500/90 hover:via-red-500/90 hover:to-orange-500/90'
+      },
+      {
+        id: 'inspect-flows',
+        label: 'Inspect live traffic',
+        to: '/flows',
+        icon: Activity,
+        variant: 'outline'
+      },
+      {
+        id: 'adjust-scope',
+        label: 'Adjust engagement scope',
+        to: '/scope',
+        icon: Radar,
+        variant: 'outline'
+      }
+    ],
+    modules: [
+      {
+        id: 'campaign-planner',
+        name: 'Campaign planner',
+        focus: 'Offense',
+        description: 'Chain payloads, coordinate operators, and track execution windows.',
+        to: '/flows',
+        icon: Swords,
+        badgeClass: 'bg-rose-500/15 text-rose-200 ring-1 ring-inset ring-rose-500/40',
+        iconClass: 'bg-rose-500/20 text-rose-100 shadow-inner ring-1 ring-inset ring-rose-500/50'
+      },
+      {
+        id: 'payload-workshop',
+        name: 'Payload workshop',
+        focus: 'Payloads',
+        description: 'Build, version, and stage payloads with integrated validation.',
+        to: '/runs/composer',
+        icon: FlaskConical,
+        badgeClass: 'bg-orange-500/15 text-orange-200 ring-1 ring-inset ring-orange-500/40',
+        iconClass: 'bg-orange-500/20 text-orange-100 shadow-inner ring-1 ring-inset ring-orange-500/50'
+      },
+      {
+        id: 'exfil-ops',
+        name: 'Exfil ops center',
+        focus: 'C2',
+        description: 'Monitor beacons and exfiltration channels in real time.',
+        to: '/runs',
+        icon: Radar,
+        badgeClass: 'bg-amber-500/15 text-amber-100 ring-1 ring-inset ring-amber-500/40',
+        iconClass: 'bg-amber-500/20 text-amber-50 shadow-inner ring-1 ring-inset ring-amber-500/50'
+      }
+    ]
+  },
+  {
+    value: 'blue',
+    label: 'Blue team mode',
+    shortLabel: 'Blue',
+    description: 'Detection engineering and alert response presets ready to go.',
+    theme: 'blue',
+    icon: ShieldCheck,
+    accentGradient: 'from-sky-500/90 via-blue-500/85 to-indigo-500/85',
+    switcherActiveClass:
+      'bg-gradient-to-r from-sky-500/90 via-blue-500/90 to-indigo-500/90 text-white shadow-lg ring-1 ring-sky-400/50',
+    switcherIconClass: 'text-white',
+    actions: [
+      {
+        id: 'open-detections',
+        label: 'Review detections',
+        to: '/cases',
+        icon: ShieldCheck,
+        className:
+          'bg-gradient-to-r from-sky-500 via-blue-500 to-indigo-500 text-white shadow-lg ring-1 ring-sky-400/50 hover:from-sky-500/90 hover:via-blue-500/90 hover:to-indigo-500/90'
+      },
+      {
+        id: 'monitor-queue',
+        label: 'Monitor telemetry queue',
+        to: '/flows',
+        icon: Activity,
+        variant: 'outline'
+      },
+      {
+        id: 'launch-playbook',
+        label: 'Launch response playbook',
+        to: '/runs/composer',
+        icon: Workflow,
+        variant: 'outline'
+      }
+    ],
+    modules: [
+      {
+        id: 'alert-triage',
+        name: 'Alert triage desk',
+        focus: 'Detections',
+        description: 'Prioritise findings, assign analysts, and track containment steps.',
+        to: '/cases',
+        icon: Bell,
+        badgeClass: 'bg-sky-500/15 text-sky-100 ring-1 ring-inset ring-sky-500/40',
+        iconClass: 'bg-sky-500/20 text-sky-50 shadow-inner ring-1 ring-inset ring-sky-500/50'
+      },
+      {
+        id: 'queue-guardian',
+        name: 'Queue guardian',
+        focus: 'Telemetry',
+        description: 'Inspect queue depth, drops, and enrichment coverage in one place.',
+        to: '/flows',
+        icon: Activity,
+        badgeClass: 'bg-cyan-500/15 text-cyan-100 ring-1 ring-inset ring-cyan-500/40',
+        iconClass: 'bg-cyan-500/20 text-cyan-50 shadow-inner ring-1 ring-inset ring-cyan-500/50'
+      },
+      {
+        id: 'response-playbooks',
+        name: 'Response playbooks',
+        focus: 'Response',
+        description: 'Launch automation to contain incidents and verify recovery.',
+        to: '/runs/composer',
+        icon: Workflow,
+        badgeClass: 'bg-blue-500/15 text-blue-100 ring-1 ring-inset ring-blue-500/40',
+        iconClass: 'bg-blue-500/20 text-blue-50 shadow-inner ring-1 ring-inset ring-blue-500/50'
+      }
+    ]
+  },
+  {
+    value: 'purple',
+    label: 'Purple team mode',
+    shortLabel: 'Purple',
+    description: 'Correlate offensive and defensive insights for joint operations.',
+    theme: 'purple',
+    icon: Sparkles,
+    accentGradient: 'from-fuchsia-500/90 via-purple-500/85 to-indigo-500/85',
+    switcherActiveClass:
+      'bg-gradient-to-r from-fuchsia-500/90 via-purple-500/90 to-indigo-500/90 text-white shadow-lg ring-1 ring-fuchsia-400/50',
+    switcherIconClass: 'text-white',
+    actions: [
+      {
+        id: 'start-correlation',
+        label: 'Start correlation workspace',
+        to: '/compare',
+        icon: GitMerge,
+        className:
+          'bg-gradient-to-r from-fuchsia-500 via-purple-500 to-indigo-500 text-white shadow-lg ring-1 ring-purple-400/50 hover:from-fuchsia-500/90 hover:via-purple-500/90 hover:to-indigo-500/90'
+      },
+      {
+        id: 'review-campaigns',
+        label: 'Review recent campaigns',
+        to: '/runs',
+        icon: Grid,
+        variant: 'outline'
+      },
+      {
+        id: 'sync-intel',
+        label: 'Sync intel coverage',
+        to: '/scope',
+        icon: Share2,
+        variant: 'outline'
+      }
+    ],
+    modules: [
+      {
+        id: 'fusion-correlator',
+        name: 'Fusion correlator',
+        focus: 'Correlation',
+        description: 'Blend adversary telemetry with detection results to surface gaps.',
+        to: '/compare',
+        icon: GitMerge,
+        badgeClass: 'bg-fuchsia-500/15 text-fuchsia-100 ring-1 ring-inset ring-fuchsia-500/40',
+        iconClass: 'bg-fuchsia-500/20 text-fuchsia-50 shadow-inner ring-1 ring-inset ring-fuchsia-500/50'
+      },
+      {
+        id: 'campaign-matrix',
+        name: 'Campaign coverage matrix',
+        focus: 'Matrix',
+        description: 'Map offensive steps to defensive coverage across recent activity.',
+        to: '/runs',
+        icon: Grid,
+        badgeClass: 'bg-purple-500/15 text-purple-100 ring-1 ring-inset ring-purple-500/40',
+        iconClass: 'bg-purple-500/20 text-purple-50 shadow-inner ring-1 ring-inset ring-purple-500/50'
+      },
+      {
+        id: 'intel-bridge',
+        name: 'Intelligence bridge',
+        focus: 'Intel',
+        description: 'Share discoveries and coverage requests between teams instantly.',
+        to: '/scope',
+        icon: Share2,
+        badgeClass: 'bg-indigo-500/15 text-indigo-100 ring-1 ring-inset ring-indigo-500/40',
+        iconClass: 'bg-indigo-500/20 text-indigo-50 shadow-inner ring-1 ring-inset ring-indigo-500/50'
+      }
+    ]
+  }
+] as const satisfies readonly ModeConfiguration[];
+
+const MODE_CONFIG_MAP: Record<ModeName, ModeConfiguration> = MODE_OPTIONS.reduce(
+  (map, option) => {
+    map[option.value] = option;
+    return map;
+  },
+  {
+    red: MODE_OPTIONS[0],
+    blue: MODE_OPTIONS[1],
+    purple: MODE_OPTIONS[2]
+  } as Record<ModeName, ModeConfiguration>
+);
+

--- a/apps/desktop-shell/src/routes/__root.tsx
+++ b/apps/desktop-shell/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner';
 import { Button } from '../components/ui/button';
 import { cn } from '../lib/utils';
 import { ThemeSwitcher } from '../components/theme-switcher';
+import { ModeSwitcher } from '../components/mode-switcher';
 import { MetricsPanel } from '../components/metrics-panel';
 import { openArtifact } from '../lib/ipc';
 import { useArtifact } from '../providers/artifact-provider';
@@ -264,7 +265,7 @@ function Header({ onOpenMetrics }: { onOpenMetrics: () => void }) {
         <HealthChip label="DROPS" value={dropDisplay} tone={dropTone} onClick={onOpenMetrics} />
         <HealthChip label="ERRORS" value={errorDisplay} tone={errorTone} onClick={onOpenMetrics} />
       </div>
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         <Button
           type="button"
           variant="ghost"
@@ -296,6 +297,7 @@ function Header({ onOpenMetrics }: { onOpenMetrics: () => void }) {
           <MessageCircle className="h-4 w-4" aria-hidden="true" />
           <span className="sr-only">Open feedback panel</span>
         </Button>
+        <ModeSwitcher />
         <ThemeSwitcher />
         <div className="hidden flex-col text-xs text-muted-foreground sm:flex">
           <span className="font-medium text-foreground">{offlineMode ? 'Offline mode' : 'Live mode'}</span>

--- a/apps/desktop-shell/src/routes/index.tsx
+++ b/apps/desktop-shell/src/routes/index.tsx
@@ -8,17 +8,7 @@ import {
   useState,
   type ReactNode
 } from 'react';
-import {
-  Activity,
-  AlertTriangle,
-  FileText,
-  History,
-  ListOrdered,
-  Play,
-  Target,
-  Timer,
-  type LucideIcon
-} from 'lucide-react';
+import { Activity, AlertTriangle, ListOrdered, Target, Timer, type LucideIcon } from 'lucide-react';
 import { Area, AreaChart, ResponsiveContainer } from 'recharts';
 
 import { Button } from '../components/ui/button';
@@ -30,6 +20,7 @@ import { useArtifact } from '../providers/artifact-provider';
 import { useMetrics } from '../providers/metrics-provider';
 import { useTheme } from '../providers/theme-provider';
 import { baseTransition, hoverTransition } from '../lib/motion';
+import { useMode } from '../providers/mode-provider';
 
 type SparklinePoint = {
   time: number;
@@ -261,6 +252,8 @@ function DashboardRoute() {
     latest: latestMetrics,
     error: metricsError
   } = useMetrics();
+  const { config: modeConfig } = useMode();
+  const ModeIcon = modeConfig.icon;
 
   const integerFormatter = useMemo(() => new Intl.NumberFormat(), []);
   const decimalFormatter = useMemo(() => new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }), []);
@@ -350,35 +343,77 @@ function DashboardRoute() {
           </p>
         </div>
         <div className="grid gap-2 sm:grid-cols-3">
-          <Button
-            className="gap-2"
-            onClick={() => {
-              navigate({ to: '/runs/composer' });
-            }}
-          >
-            <Play className="h-4 w-4" aria-hidden />
-            New run
-          </Button>
-          <Button
-            variant="outline"
-            className="gap-2"
-            onClick={() => {
-              navigate({ to: '/runs' });
-            }}
-          >
-            <History className="h-4 w-4" aria-hidden />
-            Open replay
-          </Button>
-          <Button
-            variant="outline"
-            className="gap-2"
-            onClick={() => {
-              navigate({ to: '/runs' });
-            }}
-          >
-            <FileText className="h-4 w-4" aria-hidden />
-            Open report
-          </Button>
+          {modeConfig.actions.map((action, index) => {
+            const Icon = action.icon;
+            const variant = action.variant ?? (index === 0 ? 'default' : 'outline');
+            return (
+              <Button
+                key={action.id}
+                variant={variant}
+                className={cn('gap-2', action.className)}
+                onClick={() => {
+                  navigate({ to: action.to });
+                }}
+              >
+                <Icon className="h-4 w-4" aria-hidden />
+                {action.label}
+              </Button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-2xl border border-border/70 bg-card/95 shadow-soft backdrop-blur-sm">
+        <div
+          className={cn(
+            'border-b border-border/70 px-8 py-6 text-white',
+            'bg-gradient-to-r',
+            modeConfig.accentGradient
+          )}
+        >
+          <div className="flex items-start gap-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white/20 text-white/90 backdrop-blur">
+              <ModeIcon className="h-5 w-5" aria-hidden />
+            </div>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Highlighted modules</p>
+              <h2 className="text-lg font-semibold tracking-tight">{modeConfig.label}</h2>
+              <p className="mt-1 text-sm text-white/80">{modeConfig.description}</p>
+            </div>
+          </div>
+        </div>
+        <div className="grid gap-4 px-8 py-6 md:grid-cols-3">
+          {modeConfig.modules.map((module) => {
+            const Icon = module.icon;
+            return (
+              <button
+                key={module.id}
+                type="button"
+                onClick={() => {
+                  navigate({ to: module.to });
+                }}
+                className="group flex h-full flex-col gap-4 rounded-xl border border-border/70 bg-background/60 p-5 text-left transition hover:-translate-y-1 hover:border-primary/60 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
+                <span
+                  className={cn(
+                    'inline-flex w-fit items-center rounded-full px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide',
+                    module.badgeClass
+                  )}
+                >
+                  {module.focus}
+                </span>
+                <div className="flex items-start gap-4">
+                  <div className={cn('flex h-12 w-12 items-center justify-center rounded-xl', module.iconClass)}>
+                    <Icon className="h-5 w-5" aria-hidden />
+                  </div>
+                  <div>
+                    <h3 className="text-base font-semibold text-foreground">{module.name}</h3>
+                    <p className="mt-1 text-sm text-muted-foreground">{module.description}</p>
+                  </div>
+                </div>
+              </button>
+            );
+          })}
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- add a mode provider with red, blue, and purple presets that store preferences and align the active theme
- expose a mode switcher in the shell header so operators can swap presets quickly
- update the dashboard to render mode-specific quick actions and highlighted module cards

## Testing
- pnpm --filter 0xgen-desktop-shell build

------
https://chatgpt.com/codex/tasks/task_e_6908dd92a948832a952835fc0ecff72e