### PR TITLE
Fix LastInsertId error being ignored silently

### DIFF
--- a/internal/rewrite/storage_test.go
+++ b/internal/rewrite/storage_test.go
@@ -235,7 +235,10 @@ func TestGetRule_CorruptedJSON(t *testing.T) {
 		t.Fatalf("Failed to insert test rule: %v", err)
 	}
 
-	id, _ := result.LastInsertId()
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("Failed to get last insert id: %v", err)
+	}
 
 	// GetRule should return error for corrupted JSON
 	_, err = storage.GetRule(ctx, int(id))


### PR DESCRIPTION
Problem:
- LastInsertId() error was being ignored in TestGetRule_CorruptedJSON
- Using blank identifier `_` caused silent failures if ID retrieval failed
- Test could not proceed properly without valid ID

Solution:
- Check error from LastInsertId() call
- Add proper error handling with t.Fatalf()
- Ensures test setup fails fast if ID cannot be retrieved

Impact:
- Prevents silent failures in test setup
- All 6 LastInsertId() calls in codebase now properly check errors
- Improved test reliability and error visibility

Files verified:
✅ internal/blitz/storage.go:218 (already properly checking) ✅ plugins/entropy/storage.go:147 (already properly checking) ✅ plugins/entropy/storage.go:183 (already properly checking) ✅ internal/rewrite/storage.go:176 (already properly checking) ✅ internal/rewrite/testcase.go:138 (already properly checking) ✅ internal/rewrite/storage_test.go:238 (fixed in this commit)

Fixes #103

## Security impact
<!-- Describe auth, crypto, injection, secrets, data flows, and how you mitigated risk. If there is no security impact, explain why. -->

## Security checklist
- [ ] I reviewed the [security policy](../SECURITY.md) and [threat model](../THREAT_MODEL.md) for impacts.
- [ ] (Plugins only) I followed the [plugin security guide](../PLUGIN_GUIDE.md) and documented any deviations.

## Tests
<!-- List automated checks and manual validation performed (e.g. `go test ./...`). -->

## Rollback plan
<!-- Outline how to revert safely if needed, including follow-up cleanup. -->
